### PR TITLE
Fixbuild

### DIFF
--- a/pygit2.c
+++ b/pygit2.c
@@ -933,23 +933,24 @@ Tree_delitem(Tree *self, PyObject *name, PyObject *value) {
     }
 }
 
-static PyObject *
+static TreeEntry *
 Tree_add_entry(Tree *self, PyObject *args) {
     PyObject *py_sha;
     char *name;
     int attributes, err;
     git_oid oid;
+    git_tree_entry *entry = NULL;
 
     if (!PyArg_ParseTuple(args, "Osi", &py_sha, &name, &attributes))
         return NULL;
 
     err = py_str_to_git_oid(py_sha, &oid);
     if (err < 0)
-        return Error_set_py_obj(err, py_sha);
+        return (TreeEntry*)Error_set_py_obj(err, py_sha);
 
-    if (git_tree_add_entry(self->tree, &oid, name, attributes) < 0)
-        return PyErr_NoMemory();
-    Py_RETURN_NONE;
+    if (git_tree_add_entry(&entry, self->tree, &oid, name, attributes) < 0)
+        return (TreeEntry*)PyErr_NoMemory();
+    return wrap_tree_entry(entry, self);
 }
 
 static PyMethodDef Tree_methods[] = {


### PR DESCRIPTION
Commit b29e8f19300bb95b9f of libgit2 changed the prototype of git_tree_add_entry and since then pygit2 does not build.

This patch makes pygit2 to build again, and changes Tree.add_entry so it returns the created entry.
