### PR TITLE
Fixed reference tests on linux

### DIFF
--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -47,15 +47,15 @@ class ReferencesTest(utils.RepoTestCase):
         repo = self.repo
 
         # Without argument
-        self.assertEqual(repo.listall_references(),
-                         ('refs/heads/i18n', 'refs/heads/master'))
+        self.assertEqual(sorted(repo.listall_references()),
+                         ['refs/heads/i18n', 'refs/heads/master'])
 
         # We add a symbolic reference
         reference = repo.create_symbolic_reference('refs/tags/version1',
                                                    'refs/heads/master')
-        self.assertEqual(repo.listall_references(),
-                         ('refs/heads/i18n', 'refs/heads/master',
-                          'refs/tags/version1'))
+        self.assertEqual(sorted(repo.listall_references()),
+                         ['refs/heads/i18n', 'refs/heads/master',
+                          'refs/tags/version1'])
 
         # Now we list only the symbolic references
         self.assertEqual(repo.listall_references(GIT_REF_SYMBOLIC),


### PR DESCRIPTION
Fixed reference tests, they were dependent on the order of the file-system, which in fact is undetermined. Sorting them to assure order.

I tested it on python 2.6 only. Its interesting to note that tuples will never compare equal to lists, even though they have the same content.
