### PR TITLE
added Repository.write, 20 byte sha support, some memory leak fixes

### DIFF
--- a/pygit2.c
+++ b/pygit2.c
@@ -162,7 +162,7 @@ Error_set_py_obj(int err, PyObject *py_obj) {
     assert(err < 0);
 
     if (err == GIT_ENOTOID && !PyString_Check(py_obj)) {
-        PyErr_Format(PyExc_TypeError, "Git object id must be str, not %.200s",
+        PyErr_Format(PyExc_TypeError, "Git object id must be 40 byte hexadecimal str, or 20 byte binary str: %.200s",
                      py_obj->ob_type->tp_name);
         return NULL;
     } else if (err == GIT_ENOTFOUND) {
@@ -216,6 +216,18 @@ lookup_object(Repository *repo, const git_oid *oid, git_otype type) {
     return (PyObject*)py_obj;
 }
 
+static git_otype 
+int_to_loose_object_type(int type_id)
+{
+	switch((git_otype)type_id) {
+		case GIT_OBJ_COMMIT: return GIT_OBJ_COMMIT;
+		case GIT_OBJ_TREE: return GIT_OBJ_TREE;
+		case GIT_OBJ_BLOB: return GIT_OBJ_BLOB;
+		case GIT_OBJ_TAG: return GIT_OBJ_TAG;
+		default: return GIT_OBJ_BAD;
+	}
+}
+
 static PyObject *
 wrap_reference(git_reference * c_reference)
 {
@@ -252,6 +264,16 @@ py_str_to_git_oid(PyObject *py_str, git_oid *oid) {
     }
 
     return 1;
+}
+
+static PyObject*
+git_oid_to_py_string(git_oid* oid)
+{
+    char buf[GIT_OID_HEXSZ+1];
+    if (strlen(git_oid_to_string(buf, sizeof(buf), oid)) != GIT_OID_HEXSZ)
+        return NULL;
+    
+    return PyString_FromStringAndSize(buf, GIT_OID_HEXSZ);
 }
 
 static int
@@ -332,6 +354,37 @@ Repository_read(Repository *self, PyObject *py_hex) {
 
     git_odb_object_close(obj);
     return tuple;
+}
+
+static PyObject *
+Repository_write(Repository *self, PyObject *args)
+{
+    int err;
+    git_oid oid;
+    git_odb_stream* stream;
+
+    int type_id;
+    const char* buffer;
+    Py_ssize_t buflen;
+
+    if (!PyArg_ParseTuple(args, "Is#", &type_id, &buffer, &buflen))
+        return NULL;
+
+    git_otype type = int_to_loose_object_type(type_id);
+    if (type == GIT_OBJ_BAD)
+        return Error_set_str(-100, "Invalid object type");
+
+    git_odb* odb = git_repository_database(self->repo);
+
+    if ((err = git_odb_open_wstream(&stream, odb, buflen, type)) == GIT_SUCCESS) {
+        stream->write(stream, buffer, buflen);
+        err = stream->finalize_write(&oid, stream);
+        stream->free(stream);
+    }
+    if (err < 0)
+        return Error_set_str(err, "failed to write data");
+
+    return git_oid_to_py_string(&oid);
 }
 
 static PyObject *
@@ -665,6 +718,10 @@ static PyMethodDef Repository_methods[] = {
      "Generator that traverses the history starting from the given commit."},
     {"read", (PyCFunction)Repository_read, METH_O,
      "Read raw object data from the repository."},
+    {"write", (PyCFunction)Repository_write, METH_VARARGS,
+     "Write raw object data into the repository. First arg is the object type number, \n\
+     the second one a buffer with data.\n\
+     Return the hexadecimal sha of the created object"},
     {"listall_references", (PyCFunction)Repository_listall_references,
       METH_VARARGS,
       "Return a list with all the references that can be found in a "

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -53,6 +53,17 @@ class RepositoryTest(utils.BareRepoTestCase):
 
         a2 = self.repo.read('7f129fd57e31e935c6d60a0c794efe4e6927664b')
         self.assertEqual((pygit2.GIT_OBJ_BLOB, 'a contents 2\n'), a2)
+        
+    def test_write(self):
+        data = "hello world"
+        # invalid object type
+        self.assertRaises(pygit2.GitError, self.repo.write, pygit2.GIT_OBJ_ANY, data)
+
+        hex_sha = self.repo.write(pygit2.GIT_OBJ_BLOB, data)
+        self.assertEqual(len(hex_sha), 40)
+
+        # works as buffer as well
+        self.assertEqual(hex_sha, self.repo.write(pygit2.GIT_OBJ_BLOB, buffer(data)))
 
     def test_contains(self):
         self.assertRaises(TypeError, lambda: 123 in self.repo)


### PR DESCRIPTION
Based on my previous pull request, I did some additional work and implemented a Repository.write method, hoping that the name fits into your scheme.
The method is verified with a simple test.
### 20 byte sha support

Additionally, I added support for 20 byte shas, as I see no reason not to allow them. To my mind, it wouldn't make sense to force GitPython to convert its 20 byte shas to hex, just to have it converted back to raw bytes when a git_oid is created.
### Fixed Leaks

On my way, I found two memory leaks, git_odb_object_close was never called on temporary git_odb_object instances.
