### PR TITLE
Removed invalid Py_XDECREF for Reference instance in Index_dealloc

### DIFF
--- a/pygit2.c
+++ b/pygit2.c
@@ -1651,7 +1651,6 @@ Index_dealloc(Index* self)
 {
     if (self->own_obj)
         git_index_free(self->index);
-    Py_XDECREF(self->repo);
     self->ob_type->tp_free((PyObject*)self);
 }
 


### PR DESCRIPTION
Removed invalid Py_XDECREF for Reference instance in Index_dealloc which was not a new reference  (refs GH-39).
