### PR TITLE
Add support for using short hex string prefixes

### DIFF
--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -71,10 +71,15 @@ class CommitTest(utils.BareRepoTestCase):
         committer = ('John Doe', 'jdoe@example.com', 12346, 0)
         author = ('J. David Ibáñez', 'jdavid@example.com', 12345, 0)
         tree = '967fce8df97cc71722d3c2a5930ef3e6f1d27b12'
+        tree_prefix = tree[:5]
+        too_short_prefix = tree[:3]
 
-        parents = [COMMIT_SHA]
-        sha = repo.create_commit(None, author, committer, message, tree,
-                                 parents)
+        parents = [COMMIT_SHA[:5]]
+        self.assertRaises(ValueError, repo.create_commit, None, author,
+                          committer, message, too_short_prefix, parents)
+        
+        sha = repo.create_commit(None, author, committer, message,
+                                 tree_prefix, parents)
         commit = repo[sha]
 
         self.assertEqual(GIT_OBJ_COMMIT, commit.type)

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -58,6 +58,10 @@ class RepositoryTest(utils.BareRepoTestCase):
 
         a2 = self.repo.read('7f129fd57e31e935c6d60a0c794efe4e6927664b')
         self.assertEqual((GIT_OBJ_BLOB, 'a contents 2\n'), a2)
+        
+        a_hex_prefix = A_HEX_SHA[:4]
+        a3 = self.repo.read(a_hex_prefix)
+        self.assertEqual((GIT_OBJ_BLOB, 'a contents\n'), a3)
 
     def test_write(self):
         data = b"hello world"
@@ -82,6 +86,12 @@ class RepositoryTest(utils.BareRepoTestCase):
         self.assertEqual(A_HEX_SHA, a.hex)
         self.assertEqual(GIT_OBJ_BLOB, a.type)
 
+    def test_lookup_blob_prefix(self):
+        a = self.repo[A_HEX_SHA[:5]]
+        self.assertEqual(b'a contents\n', a.read_raw())
+        self.assertEqual(A_HEX_SHA, a.hex)
+        self.assertEqual(GIT_OBJ_BLOB, a.type)
+
     def test_lookup_commit(self):
         commit_sha = '5fe808e8953c12735680c257f56600cb0de44b10'
         commit = self.repo[commit_sha]
@@ -90,6 +100,18 @@ class RepositoryTest(utils.BareRepoTestCase):
         self.assertEqual(('Second test data commit.\n\n'
                           'This commit has some additional text.\n'),
                          commit.message)
+
+    def test_lookup_commit_prefix(self):
+        commit_sha = '5fe808e8953c12735680c257f56600cb0de44b10'
+        commit_sha_prefix = commit_sha[:7]
+        too_short_prefix = commit_sha[:3]
+        commit = self.repo[commit_sha_prefix]
+        self.assertEqual(commit_sha, commit.hex)
+        self.assertEqual(GIT_OBJ_COMMIT, commit.type)
+        self.assertEqual(('Second test data commit.\n\n'
+                    'This commit has some additional text.\n'),
+                   commit.message)
+        self.assertRaises(ValueError, self.repo.__getitem__, too_short_prefix)
 
     def test_get_path(self):
         directory = realpath(self.repo.path)

--- a/test/test_tag.py
+++ b/test/test_tag.py
@@ -62,8 +62,13 @@ class TagTest(utils.BareRepoTestCase):
         message = 'Tag a blob.\n'
         tagger = ('John Doe', 'jdoe@example.com', 12347, 0)
 
-        sha = self.repo.create_tag(name, target, pygit2.GIT_OBJ_BLOB, tagger,
-                                   message)
+        target_prefix = target[:5]
+        too_short_prefix = target[:3]
+        self.assertRaises(ValueError, self.repo.create_tag, name, 
+                          too_short_prefix, pygit2.GIT_OBJ_BLOB, tagger,
+                          message)
+        sha = self.repo.create_tag(name, target_prefix, pygit2.GIT_OBJ_BLOB,
+                                   tagger, message)
         tag = self.repo[sha]
 
         self.assertEqual('3ee44658fd11660e828dfc96b9b5c5f38d5b49bb', tag.hex)


### PR DESCRIPTION
Following on from pull request #50, I've implemented support for using short hex prefixes in Repository_getitem, Repository_read(_raw), Repository_create_commit (for referring to the tree and parents), and Repository_create_tag (for referring to the tag target) to use short hex strings to lookup objects.
