### PR TITLE
Add TreeBuilder

### DIFF
--- a/test/test_treebuilder.py
+++ b/test/test_treebuilder.py
@@ -50,9 +50,15 @@ class TreeBuilderTest(utils.BareRepoTestCase):
         result = bld.write()
         self.assertEqual(tree.oid, result)
 
+    def test_noop_treebuilder_from_tree(self):
+        tree = self.repo[TREE_SHA]
+        bld = self.repo.TreeBuilder(tree)
+        result = bld.write()
+        self.assertEqual(tree.oid, result)
+
     def test_rebuild_treebuilder(self):
         tree = self.repo[TREE_SHA]
-        bld = self.repo.TreeBuilder(TREE_SHA)
+        bld = self.repo.TreeBuilder()
         for e in tree:
             bld.insert(e)
 


### PR DESCRIPTION
Add some simple TreeBuilder support to allow pythonistas to create arbitrary trees.

I'm not sure whether it might make sense to have the TreeBuilder grow out of a repo (or get a repo in the constructor), and use that if there is no argument to `TreeBuilder.write()`
