### PR TITLE
Add Commit.subject

### DIFF
--- a/pygit2.c
+++ b/pygit2.c
@@ -1186,6 +1186,24 @@ Commit_get_message(Commit *commit)
 }
 
 static PyObject *
+Commit_get_subject(Commit *commit)
+{
+    const char *message, *encoding, *subj_end;
+    size_t len;
+
+    message = git_commit_message(commit->commit);
+    encoding = git_commit_message_encoding(commit->commit);
+    subj_end = strstr(message, "\n\n");
+
+    if (subj_end == NULL)
+	len = strlen(message);
+    else
+	len = subj_end - message;
+
+    return to_unicode_n(message, len, encoding, "strict");
+}
+
+static PyObject *
 Commit_get_commit_time(Commit *commit)
 {
     return PyLong_FromLong(git_commit_time(commit->commit));
@@ -1280,6 +1298,7 @@ static PyGetSetDef Commit_getseters[] = {
     {"message_encoding", (getter)Commit_get_message_encoding, NULL,
      "message encoding", NULL},
     {"message", (getter)Commit_get_message, NULL, "message", NULL},
+    {"subject", (getter)Commit_get_subject, NULL, "subject", NULL},
     {"commit_time", (getter)Commit_get_commit_time, NULL, "commit time",
      NULL},
     {"commit_time_offset", (getter)Commit_get_commit_time_offset, NULL,

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -53,6 +53,7 @@ class CommitTest(utils.BareRepoTestCase):
         self.assertEqual(('Second test data commit.\n\n'
                           'This commit has some additional text.\n'),
                          commit.message)
+        self.assertEqual(('Second test data commit.'), commit.subject)
         commit_time = 1288481576
         self.assertEqual(commit_time, commit.commit_time)
         self.assertEqualSignature(
@@ -134,6 +135,19 @@ class CommitTest(utils.BareRepoTestCase):
         self.assertRaises(AttributeError, setattr, commit, 'tree', None)
         self.assertRaises(AttributeError, setattr, commit, 'parents', None)
 
+    def test_subject_one_para(self):
+        message = 'New commit.'
+        committer = Signature('John Doe', 'jdoe@example.com', 12346, 0)
+        author = Signature('Jane Doe', 'jdoe2@example.com', 12345, 0)
+        tree = '967fce8df97cc71722d3c2a5930ef3e6f1d27b12'
+        tree_prefix = tree[:5]
+
+        parents = [COMMIT_SHA]
+        sha = self.repo.create_commit(None, author, committer, message,
+                                 tree, parents)
+        commit = self.repo[sha]
+        self.assertEqual(message, commit.message)
+        self.assertEqual(message, commit.subject)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allow easy retrieval of a commit's subject.

This would look better if we could mix python and C in the bindings, as it would become something like (ignoring the actual syntax)

```
commit.subject => commit.message[0:commit.message.find("\n\n")]
```

which works IIRC the code I've on the other computer. No idea if that's possible.
