### PR TITLE
continuous integration with travis

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+cd ~
+
+git clone -b master https://github.com/libgit2/libgit2.git
+cd libgit2/
+
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=../_install
+cmake --build . --target install
+
+ls -la ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.2"
+
+env: LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib
+
+before_install:
+  - sudo apt-get install cmake
+  - "./.travis.sh"
+
+script: 
+  - python setup.py test


### PR DESCRIPTION
It would be nice if we have continuous integration tests for pygit2 as libgit2 has. This pull requests adds the necessary travis build files to automatically check each commit against our test suite.

The result would be something like http://travis-ci.org/#!/cholin/pygit2/builds/1463817
