### PR TITLE
fix windows VC9 build

### DIFF
--- a/src/pygit2/diff.c
+++ b/src/pygit2/diff.c
@@ -55,6 +55,9 @@ static int diff_hunk_cb(
 {
     PyObject *hunks;
     Hunk *hunk;
+    int len;
+    char* old_path, *new_path;
+
 
     hunks = PyDict_GetItemString(cb_data, "hunks");
     if (hunks == NULL) {
@@ -70,9 +73,6 @@ static int diff_hunk_cb(
     hunk->old_lines = range->old_lines;
     hunk->new_start = range->new_start;
     hunk->new_lines = range->new_lines;
-
-    int len;
-    char* old_path, *new_path;
 
     if (delta->old_file.path != NULL) {
         len = strlen(delta->old_file.path) + 1;

--- a/src/pygit2/error.c
+++ b/src/pygit2/error.c
@@ -4,6 +4,7 @@ PyObject *GitError;
 
 PyObject * Error_type(int type)
 {
+    const git_error* error;
     // Expected
     switch (type) {
         /** Input does not exist in the scope searched. */
@@ -32,7 +33,7 @@ PyObject * Error_type(int type)
     }
 
     // Critical
-    const git_error* error = giterr_last();
+    error = giterr_last();
     if(error != NULL) {
         switch (error->klass) {
             case GITERR_NOMEMORY:
@@ -66,13 +67,14 @@ PyObject* Error_set(int err)
 
 PyObject* Error_set_str(int err, const char *str)
 {
+    const git_error* error;
     if (err == GIT_ENOTFOUND) {
         /* KeyError expects the arg to be the missing key. */
         PyErr_SetString(PyExc_KeyError, str);
         return NULL;
     }
 
-    const git_error* error = giterr_last();
+    error = giterr_last();
     return PyErr_Format(Error_type(err), "%s: %s", str, error->message);
 }
 


### PR DESCRIPTION
Hello there, 

I'm experimenting with libgit2/pygit2 on Windows, using Visual Studio 9 2008 (i.e. VC9).

The first obstacle was a few compilation errors which could be easily fixed.
This corresponds to the present pull request.

The second thing was a linking error, but it was rather due to the way libgit2 was built, and with the following [libgit2 change](https://github.com/libgit2/libgit2/issues/741#issuecomment-6121472), pygit2 links fine.

The last thing I noticed were a few problems during the tests. One is known (#60), the others are crashes in `test_repository.py` (`test_new_repo` and `test_write`, both involve a `repo.write` operation). I'm currently investigating, if I find something I'll propose another fix.
