### PR TITLE
windows: detailed build instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,28 @@ When those are installed, you can install pygit2::
     $ python setup.py install
     $ python setup.py test
 
+Building on Windows
+-------------------
+
+pygit2 expects to find the libgit2 installed files in the directory specified
+in the ``LIBGIT2`` environment variable.
+
+In addition, make sure that libgit2 is build in "__cdecl" mode.
+The following recipe shows you how to do it, assuming you're working
+from a bash shell::
+
+    $ export LIBGIT2=C:/Dev/libgit2
+    $ git clone git://github.com/libgit2/libgit2.git
+    $ cd libgit2
+    $ mkdir build
+    $ cd build
+    $ cmake .. -DSTDCALL=OFF -DCMAKE_INSTALL_PREFIX=$LIBGIT2 -G "Visual Studio 9 2008"
+    $ cmake --build . --config release --target install
+    $ ctest -v
+
+At this point, you're ready to execute the generic pygit2 installation
+steps described above.
+
 
 The repository
 =================


### PR DESCRIPTION
The default build of libgit2 with `__stdcall` calling
convention is inadequate. We need to use a more standard
`__cdecl` build, which can be obtained by specifying
`-DSTDCALL=OFF` while configuring libgit2.

Also mention the LIBGIT2 environment variable (2b4e5504).

---

The default build of libgit2 with `__stdcall` calling convention is inadequate because:
1. in libgit2, the `__stdcall` calling convention is enforced by the use of the `/Gz` compilation flag; but the use of this calling convention is not made visible in the headers, so when building the pygit2 extension the normal `__cdecl` calling convention will be assumed; linking the `_pygit2.pyd` library will then fail with errors such as:

```
pygit2.obj : error LNK2019: unresolved external symbol _git_repository_free referenced in function _init_repository
...
```
1. if one manages nevertheless to link the extension in that mode (for example, by using libgit2/libgit2#749), the next problem is the presence of crashes when running the unit tests. The first one is `test_new_repo`, but there are more. 

Trying to debugging this crash proved to be pretty hard for me (i.e. no clue), and the crash actually disappears if one tries to use the debug versions of Python (python_d.exe), libgit2 built in `--config debug` mode and the pygit2 extension built in debug mode (i.e. in this situation, `python_d.exe setup.py build_ext --debug test` _doesn't_ trigger a crash!).

OTOH, when building with libgit2 built with the `__cdecl` calling convention, I don't get a crash, only the few known errors (#60/#83).

What I didn't do so far is build the extension with mingw... but I suppose it's the way other people build it, otherwise they would also have run into the problems described above. Would be nice if someone could document that as well (which version of mingw gcc to use, etc.).
