### PR TITLE
config test: the loop should return 0

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -38,7 +38,7 @@ config_filename = "test_config"
 
 def foreach_test_wrapper(key, name, lst):
     lst[key] = name
-    return 1
+    return 0
 
 class ConfigTest(utils.RepoTestCase):
 


### PR DESCRIPTION
Returning anything else makes the loop stop, which stops us from
getting to 'core.bare' which the test is looking for.
