### PR TITLE
travis: do a shallow clone of libgit2 and don't build the tests

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -2,11 +2,11 @@
 
 cd ~
 
-git clone -b master https://github.com/libgit2/libgit2.git
+git clone --depth=1 -b master https://github.com/libgit2/libgit2.git
 cd libgit2/
 
 mkdir build && cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=../_install
+cmake .. -DCMAKE_INSTALL_PREFIX=../_install -DBUILD_CLAR=OFF
 cmake --build . --target install
 
 ls -la ..


### PR DESCRIPTION
This just adds time to the tests. We're not testing the library, but
the bindings, so do a shallow clone and stop cmake from building clar.

Totally unscientific measurements from travis builds: the shallow clone removes ~10 minutes off of the test build time (though that obviously depends on how fast we can ask github for four full clones of libgit2, which is bound to be very variable), and not building clar removes ~1 minute (which is not much compared to the clone, but it's 1/4-1/3 of the remaining build time.
