### PR TITLE
git_index_read_tree now accepts a stats structure

### DIFF
--- a/src/pygit2/index.c
+++ b/src/pygit2/index.c
@@ -331,7 +331,7 @@ Index_read_tree(Index *self, PyObject *value)
     if (err < 0)
         return Error_set(err);
 
-    err = git_index_read_tree(self->index, tree);
+    err = git_index_read_tree(self->index, tree, NULL);
     if (err < 0)
         return Error_set(err);
 


### PR DESCRIPTION
Indexer stats may be NULL but the method still needs three arguments
