### PR TITLE
Add Blob.size

### DIFF
--- a/include/pygit2/blob.h
+++ b/include/pygit2/blob.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2012 The pygit2 contributors
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * In addition to the permissions in the GNU General Public License,
+ * the authors give you unlimited permission to link the compiled
+ * version of this file into combinations with other programs,
+ * and to distribute those combinations without any restriction
+ * coming from the use of this file.  (The General Public License
+ * restrictions do apply in other respects; for example, they cover
+ * modification of the file, and distribution when not linked into
+ * a combined executable.)
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDE_pygit2_blob_h
+#define INCLUDE_pygit2_blob_h
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <git2.h>
+#include <pygit2/types.h>
+
+PyObject* Blob_get_size(Blob *self);
+
+#endif

--- a/src/pygit2/blob.c
+++ b/src/pygit2/blob.c
@@ -27,10 +27,20 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include <pygit2/utils.h>
 #include <pygit2/object.h>
+#include <pygit2/blob.h>
+
+PyObject *
+Blob_get_size(Blob *self)
+{
+    return PyInt_FromLong(git_blob_rawsize(self->blob));
+}
+
 
 PyGetSetDef Blob_getseters[] = {
     {"data", (getter)Object_read_raw, NULL, "raw data", NULL},
+    {"size", (getter)Blob_get_size, NULL, "size", NULL},
     {NULL}
 };
 

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -56,6 +56,7 @@ class BlobTest(utils.RepoTestCase):
         self.assertTrue(isinstance(blob, pygit2.Blob))
         self.assertEqual(pygit2.GIT_OBJ_BLOB, blob.type)
         self.assertEqual(BLOB_CONTENT, blob.data)
+        self.assertEqual(len(BLOB_CONTENT), blob.size)
         self.assertEqual(BLOB_CONTENT, blob.read_raw())
 
     def test_create_blob(self):
@@ -72,6 +73,7 @@ class BlobTest(utils.RepoTestCase):
         )
 
         self.assertEqual(BLOB_NEW_CONTENT, blob.data)
+        self.assertEqual(len(BLOB_NEW_CONTENT), blob.size)
         self.assertEqual(BLOB_NEW_CONTENT, blob.read_raw())
 
     def test_create_blob_fromfile(self):
@@ -89,6 +91,7 @@ class BlobTest(utils.RepoTestCase):
         )
 
         self.assertEqual(BLOB_FILE_CONTENT, blob.data)
+        self.assertEqual(len(BLOB_FILE_CONTENT), blob.size)
         self.assertEqual(BLOB_FILE_CONTENT, blob.read_raw())
 
 if __name__ == '__main__':


### PR DESCRIPTION
Expose libgit2's `git_blow_rawsize()` as `Blob.size`.

This functionality exists in rugged
https://github.com/libgit2/rugged/blob/development/ext/rugged/rugged_blob.c#L152
