### PR TITLE
added git_blob_create_fromdisk()

### DIFF
--- a/src/pygit2/repository.c
+++ b/src/pygit2/repository.c
@@ -458,11 +458,15 @@ Repository_create_blob_fromfile(Repository *self, PyObject *args)
     git_oid oid;
     const char* path;
     int err;
+    int is_absolute_path = 0;
 
-    if (!PyArg_ParseTuple(args, "s", &path))
+    if (!PyArg_ParseTuple(args, "s|i", &path, &is_absolute_path))
       return NULL;
 
-    err = git_blob_create_fromfile(&oid, self->repo, path);
+    if(is_absolute_path > 0)
+        err = git_blob_create_fromdisk(&oid, self->repo, path);
+    else
+        err = git_blob_create_fromfile(&oid, self->repo, path);
 
     if (err < 0)
       return Error_set(err);

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -77,7 +77,7 @@ class BlobTest(utils.RepoTestCase):
         self.assertEqual(BLOB_NEW_CONTENT, blob.read_raw())
 
     def test_create_blob_fromfile(self):
-
+        # relative path
         blob_oid = self.repo.create_blob_fromfile("bye.txt")
         blob = self.repo[blob_oid]
 
@@ -93,6 +93,16 @@ class BlobTest(utils.RepoTestCase):
         self.assertEqual(BLOB_FILE_CONTENT, blob.data)
         self.assertEqual(len(BLOB_FILE_CONTENT), blob.size)
         self.assertEqual(BLOB_FILE_CONTENT, blob.read_raw())
+
+        # absolute path
+        path = os.path.join(self.repo.workdir, "bye.txt")
+        blob_oid = self.repo.create_blob_fromfile(path, True)
+        blob = self.repo[blob_oid]
+
+        self.assertTrue(isinstance(blob, pygit2.Blob))
+        self.assertEqual(pygit2.GIT_OBJ_BLOB, blob.type)
+        self.assertEqual(blob_oid, blob.oid)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Blobs can now be created by an absolute path. For that the second parameter of
create_blob_fromfile() has to be True.

> import pygit2
> repo = pygit2.Repository('.')
> repo.create_blob_fromfile('/absolute/path/to/file.txt', True)
