### PR TITLE
only use error message if giterr_last() is not null

### DIFF
--- a/src/pygit2/error.c
+++ b/src/pygit2/error.c
@@ -113,7 +113,7 @@ PyObject* Error_set_str(int err, const char *str)
     }
 
     error = giterr_last();
-    if (error == NULL) //exptected error - no error msg set
+    if (error == NULL) //expected error - no error msg set
         return PyErr_Format(Error_type(err), "%s", str);
 
     return PyErr_Format(Error_type(err), "%s: %s", str, error->message);


### PR DESCRIPTION
expected errors in libgit2 have not to set `git_error`.  If we do not check for a NULL-Pointer we could get a segmentation fault...
