### PR TITLE
Libgit2 v0.17.0 API

### DIFF
--- a/src/pygit2/commit.c
+++ b/src/pygit2/commit.c
@@ -135,7 +135,7 @@ Commit_get_parents(Commit *commit)
         return NULL;
 
     for (i=0; i < parent_count; i++) {
-        parent_oid = git_commit_parent_id(commit->commit, i);
+        parent_oid = git_commit_parent_oid(commit->commit, i);
         if (parent_oid == NULL) {
             Py_DECREF(list);
             Error_set(GIT_ENOTFOUND);

--- a/src/pygit2/config.c
+++ b/src/pygit2/config.c
@@ -204,7 +204,7 @@ Config_setitem(Config *self, PyObject *py_key, PyObject *py_value)
         return -1;
 
     if (!py_value) {
-        err = git_config_delete_entry(self->config, c_key);
+        err = git_config_delete(self->config, c_key);
     } else if (PyBool_Check(py_value)) {
         err = git_config_set_bool(self->config, c_key,
                 (int)PyObject_IsTrue(py_value));

--- a/src/pygit2/reference.c
+++ b/src/pygit2/reference.c
@@ -63,13 +63,13 @@ PyObject* RefLogIter_iternext(PyObject *self)
                         &RefLogEntryType, NULL, NULL
                     );
 
-        git_oid_fmt(oid_old, git_reflog_entry_id_old(entry));
-        git_oid_fmt(oid_new, git_reflog_entry_id_new(entry));
+        git_oid_fmt(oid_old, git_reflog_entry_oidold(entry));
+        git_oid_fmt(oid_new, git_reflog_entry_oidnew(entry));
 
         py_entry->oid_new = PyUnicode_FromStringAndSize(oid_new, 40);
         py_entry->oid_old = PyUnicode_FromStringAndSize(oid_old, 40);
 
-        py_entry->msg = strdup(git_reflog_entry_message(entry));
+        py_entry->msg = strdup(git_reflog_entry_msg(entry));
 
         signature = git_signature_dup(
               git_reflog_entry_committer(entry)
@@ -223,7 +223,7 @@ Reference_get_target(Reference *self)
     if (GIT_REF_OID == git_reference_type(self->reference)) {
         return git_oid_to_py_str(git_reference_target(self->reference));
     } else {
-        c_name = git_reference_symbolic_target(self->reference);
+        c_name = git_reference_target(self->reference);
         if (c_name == NULL) {
             PyErr_SetString(PyExc_ValueError, "no target available");
             return NULL;
@@ -248,7 +248,7 @@ Reference_set_target(Reference *self, PyObject *py_name)
         return -1;
 
     /* Set the new target */
-    err = git_reference_symbolic_set_target(self->reference, c_name);
+    err = git_reference_set_target(self->reference, c_name);
     free(c_name);
     if (err < 0) {
         Error_set(err);

--- a/src/pygit2/repository.c
+++ b/src/pygit2/repository.c
@@ -527,7 +527,7 @@ Repository_create_blob_fromfile(Repository *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s", &path))
       return NULL;
 
-    err = git_blob_create_fromworkdir(&oid, self->repo, path);
+    err = git_blob_create_fromfile(&oid, self->repo, path);
 
     if (err < 0)
       return Error_set(err);
@@ -740,7 +740,7 @@ Repository_create_reference(Repository *self,  PyObject *args, PyObject* keywds)
             return Error_set(err);
         }
 
-        err = git_reference_create(&c_reference, self->repo, c_name, &oid, force);
+        err = git_reference_create_oid(&c_reference, self->repo, c_name, &oid, force);
     } else {
         #if PY_MAJOR_VERSION == 2
         c_target = PyString_AsString(py_obj);
@@ -750,7 +750,7 @@ Repository_create_reference(Repository *self,  PyObject *args, PyObject* keywds)
         if(c_target == NULL)
             return NULL;
 
-        err = git_reference_symbolic_create(&c_reference, self->repo, c_name,
+        err = git_reference_create_symbolic(&c_reference, self->repo, c_name,
                                             c_target, force);
     }
 

--- a/src/pygit2/tag.c
+++ b/src/pygit2/tag.c
@@ -39,7 +39,7 @@ Tag_get_target(Tag *self)
 {
     const git_oid *oid;
 
-    oid = git_tag_target_id(self->tag);
+    oid = git_tag_target_oid(self->tag);
     return git_oid_to_python(oid->id);
 }
 


### PR DESCRIPTION
Changed references to those in libgit2 v0.17.0.
This allows for running tests after building pygit2.
