### PR TITLE
Libgit2 version

### DIFF
--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -29,5 +29,4 @@ from .version import __version__
 from _pygit2 import *
 import pygit2.utils
 
-__libgit2_version__ = '%d.%d.%s' % (
-    LIBGIT2_VERSION_MAJOR, LIBGIT2_VERSION_MINOR, LIBGIT2_VERSION_REV)
+__libgit2_version__ = LIBGIT2_VERSION

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -179,8 +179,6 @@ PyMethodDef module_methods[] = {
 PyObject*
 moduleinit(PyObject* m)
 {
-    int libgit2_major, libgit2_minor, libgit2_rev;
-
     if (m == NULL)
         return NULL;
 
@@ -404,10 +402,10 @@ moduleinit(PyObject* m)
     PyModule_AddIntConstant(m, "GIT_FILEMODE_COMMIT", GIT_FILEMODE_COMMIT);
 
     /* libgit2 version info */
-    git_libgit2_version(&libgit2_major, &libgit2_minor, &libgit2_rev);
-    PyModule_AddIntConstant(m, "LIBGIT2_VERSION_MAJOR", libgit2_major);
-    PyModule_AddIntConstant(m, "LIBGIT2_VERSION_MINOR", libgit2_minor);
-    PyModule_AddIntConstant(m, "LIBGIT2_VERSION_REV", libgit2_rev);
+    PyModule_AddIntConstant(m, "LIBGIT2_VER_MAJOR", LIBGIT2_VER_MAJOR);
+    PyModule_AddIntConstant(m, "LIBGIT2_VER_MINOR", LIBGIT2_VER_MINOR);
+    PyModule_AddIntConstant(m, "LIBGIT2_VER_REVISION", LIBGIT2_VER_REVISION);
+    PyModule_AddStringConstant(m, "LIBGIT2_VERSION", LIBGIT2_VERSION);
 
     return m;
 }


### PR DESCRIPTION
Hello,

It would be nice to get access to the version information of the libgit2 library in use.

As that information won't change, I think it makes sense to add this information as constants instead of providing access to the git_libgit2_version() function.

In fact I started by looking in the libgit2 documentation and found only git_libgit2_version() there, but while writing this pull request, I realized that git_libgit2_version() simply returns the values of the LIBGIT2_VER_\* defines which are public, so I think it makes sense to use the latter directly. I updated the branch accordingly (64ae9e1). 

Speaking of version information, pygit2/version.py says '0.17.3' even though the current master is not compatible in places with the released 0.17.3. Wouldn't it be better to upgrade that number plus a dev suffix right after a release? (so 0.17.4dev for now).
