### PR TITLE
Bdist wininst fixes for Python 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ from distutils import log
 sys.path.insert(0, 'pygit2')
 from version import __version__
 
+u = lambda s: s if sys.version_info[0] > 2 else unicode(s, 'utf-8')
+
 
 # Use environment variable LIBGIT2 to set your own libgit2 configuration.
 libgit2_path = os.getenv("LIBGIT2")
@@ -171,7 +173,7 @@ setup(name='pygit2',
       url='http://github.com/libgit2/pygit2',
       classifiers=classifiers,
       license='GPLv2',
-      maintainer=u'J. David Ibáñez',
+      maintainer=u('J. David Ibáñez'),
       maintainer_email='jdavid.ibp@gmail.com',
       long_description=long_description,
       packages = ['pygit2'],


### PR DESCRIPTION
Trying to build an installer for verifying if the new version set in #179 did show up, I was greeted by an Unicode error:

```
...
  File "c:\Dev\Python273\lib\distutils\command\bdist_wininst.py", line 259, in create_exe
    cfgdata = self.get_inidata()
  File "c:\Dev\Python273\lib\distutils\command\bdist_wininst.py", line 227, in get_inidata
    (string.capitalize(name), escape(data)))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 28: ordinal not in range(128)
```

While fixing that, I realize I broke setup.py for Py3k...
The final result seems to work fine with 2.6.5, 2.7.3 and 3.2.2. 
