### PR TITLE
Adjust to libgit2's immutable refs

### DIFF
--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -292,7 +292,6 @@ moduleinit(PyObject* m)
     PyModule_AddIntConstant(m, "GIT_SORT_REVERSE", GIT_SORT_REVERSE);
     PyModule_AddIntConstant(m, "GIT_REF_OID", GIT_REF_OID);
     PyModule_AddIntConstant(m, "GIT_REF_SYMBOLIC", GIT_REF_SYMBOLIC);
-    PyModule_AddIntConstant(m, "GIT_REF_PACKED", GIT_REF_PACKED);
     PyModule_AddIntConstant(m, "GIT_REF_LISTALL", GIT_REF_LISTALL);
 
     /* Git status flags */

--- a/src/repository.c
+++ b/src/repository.c
@@ -901,25 +901,6 @@ Repository_create_symbolic_reference(Repository *self,  PyObject *args,
     return wrap_reference(c_reference);
 }
 
-
-PyDoc_STRVAR(Repository_packall_references__doc__,
-  "packall_references()\n"
-  "\n"
-  "Pack all the loose references in the repository.");
-
-PyObject *
-Repository_packall_references(Repository *self, PyObject *args)
-{
-    int err;
-
-    err = git_reference_packall(self->repo);
-    if (err < 0)
-        return Error_set(err);
-
-    Py_RETURN_NONE;
-}
-
-
 PyDoc_STRVAR(Repository_status__doc__,
   "status() -> {str: int}\n"
   "\n"
@@ -1145,7 +1126,6 @@ PyMethodDef Repository_methods[] = {
     METHOD(Repository, create_symbolic_reference, METH_VARARGS),
     METHOD(Repository, listall_references, METH_VARARGS),
     METHOD(Repository, lookup_reference, METH_O),
-    METHOD(Repository, packall_references, METH_NOARGS),
     METHOD(Repository, revparse_single, METH_O),
     METHOD(Repository, status, METH_NOARGS),
     METHOD(Repository, status_file, METH_O),

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -82,13 +82,13 @@ class ReferencesTest(utils.RepoTestCase):
     def test_reference_set_sha(self):
         NEW_COMMIT = '5ebeeebb320790caf276b9fc8b24546d63316533'
         reference = self.repo.lookup_reference('refs/heads/master')
-        reference.oid = NEW_COMMIT
+        reference = reference.set_oid(NEW_COMMIT)
         self.assertEqual(reference.hex, NEW_COMMIT)
 
     def test_reference_set_sha_prefix(self):
         NEW_COMMIT = '5ebeeebb320790caf276b9fc8b24546d63316533'
         reference = self.repo.lookup_reference('refs/heads/master')
-        reference.oid = NEW_COMMIT[0:6]
+        reference = reference.set_oid(NEW_COMMIT[0:6])
         self.assertEqual(reference.hex, NEW_COMMIT)
 
 
@@ -105,7 +105,7 @@ class ReferencesTest(utils.RepoTestCase):
     def test_set_target(self):
         reference = self.repo.lookup_reference('HEAD')
         self.assertEqual(reference.target, 'refs/heads/master')
-        reference.target = 'refs/heads/i18n'
+        reference = reference.set_target('refs/heads/i18n')
         self.assertEqual(reference.target, 'refs/heads/i18n')
 
 
@@ -120,38 +120,13 @@ class ReferencesTest(utils.RepoTestCase):
         reference.delete()
         self.assertFalse('refs/tags/version1' in repo.listall_references())
 
-        # Access the deleted reference
-        self.assertRaises(GitError, getattr, reference, 'name')
-        self.assertRaises(GitError, getattr, reference, 'type')
-        self.assertRaises(GitError, getattr, reference, 'oid')
-        self.assertRaises(GitError, setattr, reference, 'oid', LAST_COMMIT)
-        self.assertRaises(GitError, getattr, reference, 'hex')
-        self.assertRaises(GitError, getattr, reference, 'target')
-        self.assertRaises(GitError, setattr, reference, 'target', "a/b/c")
-        self.assertRaises(GitError, reference.delete)
-        self.assertRaises(GitError, reference.resolve)
-        self.assertRaises(GitError, reference.rename, "refs/tags/version2")
-
-
     def test_rename(self):
         # We add a tag as a new reference that points to "origin/master"
         reference = self.repo.create_reference('refs/tags/version1',
                                                LAST_COMMIT)
         self.assertEqual(reference.name, 'refs/tags/version1')
-        reference.rename('refs/tags/version2')
+        reference = reference.rename('refs/tags/version2')
         self.assertEqual(reference.name, 'refs/tags/version2')
-
-
-    def test_reload(self):
-        name = 'refs/tags/version1'
-
-        repo = self.repo
-        ref = repo.create_reference(name, "refs/heads/master", symbolic=True)
-        ref2 = repo.lookup_reference(name)
-        ref.delete()
-        self.assertEqual(ref2.name, name)
-        self.assertRaises(KeyError, ref2.reload)
-        self.assertRaises(GitError, getattr, ref2, 'name')
 
 
     def test_reference_resolve(self):
@@ -208,9 +183,6 @@ class ReferencesTest(utils.RepoTestCase):
         self.assertEqual(reference.type, GIT_REF_SYMBOLIC)
         self.assertEqual(reference.target, 'refs/heads/master')
 
-
-    def test_packall_references(self):
-        self.repo.packall_references()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reference objects are immutable now, which means that any operation
that affects the values returns a new object.

Accessing data from a deleted ref is also permissible now, as libgit2
doesn't free the memory.
