### PR TITLE
pygit2 should work with libgit2 built with THREADSAFE=ON

### DIFF
--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -380,6 +380,9 @@ moduleinit(PyObject* m)
     PyModule_AddIntConstant(m, "GIT_CHECKOUT_DISABLE_PATHSPEC_MATC",
                             GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH);
 
+    /* Global initialization of libgit2 */
+    git_threads_init();
+
     return m;
 }
 


### PR DESCRIPTION
I just built libgit2 with `-DTHREADSAFE=ON` (it's _not_ the default), and when trying to test the corresponding build of pygit2, I got:

```
$ python setup.py test
running test
running build
running build_py
copying pygit2/__init__.py -> build/lib.linux-x86_64-2.7/pygit2
copying pygit2/repository.py -> build/lib.linux-x86_64-2.7/pygit2
copying pygit2/utils.py -> build/lib.linux-x86_64-2.7/pygit2
copying pygit2/version.py -> build/lib.linux-x86_64-2.7/pygit2
running build_ext
python: /packages/libgit2/libgit2/src/global.c:151: git__global_state: Assertion `_tls_init' failed.
Aborted
```

It seems that [git_threads_init](http://libgit2.github.com/libgit2/#HEAD/group/threads/git_threads_init) was never called.

After adding it (this patch), I get:

```
python setup.py test
running test
running build
running build_py
copying pygit2/__init__.py -> build/lib.linux-x86_64-2.7/pygit2
copying pygit2/repository.py -> build/lib.linux-x86_64-2.7/pygit2
copying pygit2/utils.py -> build/lib.linux-x86_64-2.7/pygit2
copying pygit2/version.py -> build/lib.linux-x86_64-2.7/pygit2
running build_ext
...........................................................................................................................
----------------------------------------------------------------------
Ran 123 tests in 5.188s

OK
```

Much better ;-)
