### PR TITLE
Fixed crashes in `Repository.create_remote` caused by missing `Py_INCREF()`

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -1028,6 +1028,7 @@ Repository_create_remote(Repository *self, PyObject *args)
         return Error_set(err);
 
     py_remote = PyObject_New(Remote, &RemoteType);
+    Py_INCREF(self);
     py_remote->repo = self;
     py_remote->remote = remote;
 


### PR DESCRIPTION
I tried pygit2-0.18.0 and got SEGV while calling `Repository.create_remote`.

```
$ PYTHONPATH=build/lib.linux-x86_64-2.6 python2.6
Python 2.6.6 (r266:84292, Feb 22 2013, 00:00:18)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-3)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pygit2
>>> repos = pygit2.init_repository('/tmp/test.git')
>>> for i in xrange(100): repos.create_remote('remote-%d' % i, 'http://localhost/%d' % i)
...
<_pygit2.Remote object at 0x7f4d14f22090>
<_pygit2.Remote object at 0x7f4d14f220b0>
Bus error
```

It seems that the function should call `Py_INCREF` for the instance of `Repository`. After the patch, the SEGV goes away.
