### PR TITLE
repository: allow again creating a blob from a file on disk

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -578,13 +578,13 @@ Repository_create_blob(Repository *self, PyObject *args)
 }
 
 
-PyDoc_STRVAR(Repository_create_blob_fromfile__doc__,
-  "create_blob_fromfile(path) -> bytes\n"
+PyDoc_STRVAR(Repository_create_blob_fromworkdir__doc__,
+  "create_blob_fromworkdir(path) -> bytes\n"
   "\n"
-  "Create a new blob from file.");
+  "Create a new blob from a file within the working directory.");
 
 PyObject *
-Repository_create_blob_fromfile(Repository *self, PyObject *args)
+Repository_create_blob_fromworkdir(Repository *self, PyObject *args)
 {
     git_oid oid;
     const char* path;
@@ -594,6 +594,29 @@ Repository_create_blob_fromfile(Repository *self, PyObject *args)
         return NULL;
 
     err = git_blob_create_fromworkdir(&oid, self->repo, path);
+    if (err < 0)
+        return Error_set(err);
+
+    return git_oid_to_python(oid.id);
+}
+
+
+PyDoc_STRVAR(Repository_create_blob_fromdisk__doc__,
+  "create_blob_fromdisk(path) -> bytes\n"
+  "\n"
+  "Create a new blob from file.");
+
+PyObject *
+Repository_create_blob_fromdisk(Repository *self, PyObject *args)
+{
+    git_oid oid;
+    const char* path;
+    int err;
+
+    if (!PyArg_ParseTuple(args, "s", &path))
+        return NULL;
+
+    err = git_blob_create_fromdisk(&oid, self->repo, path);
     if (err < 0)
         return Error_set(err);
 
@@ -1181,7 +1204,8 @@ Repository_lookup_note(Repository *self, PyObject* args)
 
 PyMethodDef Repository_methods[] = {
     METHOD(Repository, create_blob, METH_VARARGS),
-    METHOD(Repository, create_blob_fromfile, METH_VARARGS),
+    METHOD(Repository, create_blob_fromworkdir, METH_VARARGS),
+    METHOD(Repository, create_blob_fromdisk, METH_VARARGS),
     METHOD(Repository, create_commit, METH_VARARGS),
     METHOD(Repository, create_tag, METH_VARARGS),
     METHOD(Repository, TreeBuilder, METH_VARARGS),

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -29,6 +29,7 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import os
 import unittest
 
 import pygit2
@@ -74,9 +75,9 @@ class BlobTest(utils.RepoTestCase):
         self.assertEqual(len(BLOB_NEW_CONTENT), blob.size)
         self.assertEqual(BLOB_NEW_CONTENT, blob.read_raw())
 
-    def test_create_blob_fromfile(self):
+    def test_create_blob_fromworkdir(self):
 
-        blob_oid = self.repo.create_blob_fromfile("bye.txt")
+        blob_oid = self.repo.create_blob_fromworkdir("bye.txt")
         blob = self.repo[blob_oid]
 
         self.assertTrue(isinstance(blob, pygit2.Blob))
@@ -91,6 +92,20 @@ class BlobTest(utils.RepoTestCase):
         self.assertEqual(BLOB_FILE_CONTENT, blob.data)
         self.assertEqual(len(BLOB_FILE_CONTENT), blob.size)
         self.assertEqual(BLOB_FILE_CONTENT, blob.read_raw())
+
+    def test_create_blob_outside_workdir(self):
+
+        path = os.path.join(os.path.dirname(__file__), 'data', self.repo_dir + '.tar')
+        self.assertRaises(KeyError, self.repo.create_blob_fromworkdir, path)
+
+    def test_create_blob_fromdisk(self):
+
+        path = os.path.join(os.path.dirname(__file__), 'data', self.repo_dir + '.tar')
+        blob_oid = self.repo.create_blob_fromdisk(path)
+        blob = self.repo[blob_oid]
+
+        self.assertTrue(isinstance(blob, pygit2.Blob))
+        self.assertEqual(pygit2.GIT_OBJ_BLOB, blob.type)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi,

There is a behaviour change in libgit2 where "git_blob_create_fromfile" was split into "git_blob_create_fromdisk" and "git_blob_create_fromworkdir".

PyGit2 is calling "git_blob_create_fromworkdir" and thus preventing from creating a (loose) blob from any file. This is particularly useful with bare repos where there is no workdir.

The proposed patch detects if the path is inside or outside the repo to call the appropriate function. Yes, it's rather a convention than a heuristic.

An alternative is to rename "create_blob_fromfile" to "create_blob_fromworkdir" to match libgit2's API, and add another "create_blob_fromdisk". But you'll probably wait for 0.19 or even 1.0 to break the API.

There is no test, it's just an RFC.
