### PR TITLE
Remove all warnings during compilation.

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -37,7 +37,7 @@ PyDoc_STRVAR(Blob_size__doc__, "Size.");
 PyObject *
 Blob_size__get__(Blob *self)
 {
-    return PyLong_FromLong(git_blob_rawsize(self->blob));
+    return PyLong_FromLongLong(git_blob_rawsize(self->blob));
 }
 
 

--- a/src/commit.c
+++ b/src/commit.c
@@ -77,7 +77,7 @@ PyDoc_STRVAR(Commit_commit_time__doc__, "Commit time.");
 PyObject *
 Commit_commit_time__get__(Commit *commit)
 {
-    return PyLong_FromLong(git_commit_time(commit->commit));
+    return PyLong_FromLongLong(git_commit_time(commit->commit));
 }
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -172,7 +172,7 @@ Config_contains(Config *self, PyObject *py_key) {
 PyObject *
 Config_getitem(Config *self, PyObject *py_key)
 {
-    long value_int;
+    int64_t value_int;
     int err, value_bool;
     const char *value_str;
     char *key;
@@ -187,7 +187,7 @@ Config_getitem(Config *self, PyObject *py_key)
         goto cleanup;
 
     if (git_config_parse_int64(&value_int, value_str) == 0)
-      py_value = PyLong_FromLong(value_int);
+      py_value = PyLong_FromLongLong(value_int);
     else if(git_config_parse_bool(&value_bool, value_str) == 0)
       py_value = PyBool_FromLong(value_bool);
     else

--- a/src/index.c
+++ b/src/index.c
@@ -351,14 +351,14 @@ Index_read_tree(Index *self, PyObject *value)
 {
     git_oid oid;
     git_tree *tree;
-    int err, len;
+    int err;
+    Py_ssize_t len;
 
     len = py_str_to_git_oid(value, &oid);
     if (len < 0)
         return NULL;
 
-    err = git_tree_lookup_prefix(&tree, self->repo->repo, &oid,
-                                 (unsigned int)len);
+    err = git_tree_lookup_prefix(&tree, self->repo->repo, &oid, len);
     if (err < 0)
         return Error_set(err);
 

--- a/src/oid.c
+++ b/src/oid.c
@@ -45,7 +45,7 @@ git_oid_to_python(const git_oid *oid)
     return (PyObject*)py_oid;
 }
 
-int
+Py_ssize_t
 _oid_from_hex(PyObject *py_oid, git_oid *oid)
 {
     PyObject *py_hex;
@@ -97,7 +97,7 @@ _oid_from_hex(PyObject *py_oid, git_oid *oid)
     return -1;
 }
 
-int
+Py_ssize_t
 py_str_to_git_oid(PyObject *py_oid, git_oid *oid)
 {
     /* Oid */
@@ -110,11 +110,11 @@ py_str_to_git_oid(PyObject *py_oid, git_oid *oid)
     return _oid_from_hex(py_oid, oid);
 }
 
-int
+Py_ssize_t
 py_str_to_git_oid_expand(git_repository *repo, PyObject *py_str, git_oid *oid)
 {
     int err;
-    int len;
+    Py_ssize_t len;
     git_odb *odb;
     git_odb_object *obj;
 
@@ -197,8 +197,8 @@ Oid_init(Oid *self, PyObject *args, PyObject *kw)
     }
 
     /* Case 2: hex */
-    err = _oid_from_hex(hex, &self->oid);
-    if (err < 0)
+    len = _oid_from_hex(hex, &self->oid);
+    if (len < 0)
         return -1;
 
     return 0;

--- a/src/oid.h
+++ b/src/oid.h
@@ -32,9 +32,9 @@
 #include <Python.h>
 #include <git2.h>
 
-int py_str_to_git_oid(PyObject *py_str, git_oid *oid);
-int py_str_to_git_oid_expand(git_repository *repo, PyObject *py_str,
-                             git_oid *oid);
+Py_ssize_t py_str_to_git_oid(PyObject *py_str, git_oid *oid);
+Py_ssize_t py_str_to_git_oid_expand(git_repository *repo, PyObject *py_str,
+                                    git_oid *oid);
 PyObject* git_oid_to_python(const git_oid *oid);
 PyObject* git_oid_to_py_str(const git_oid *oid);
 

--- a/src/reference.c
+++ b/src/reference.c
@@ -226,6 +226,7 @@ Reference_target__set__(Reference *self, PyObject *py_target)
     git_oid oid;
     char *c_name;
     int err;
+    Py_ssize_t len;
     git_reference *new_ref;
     git_repository *repo;
 
@@ -234,9 +235,11 @@ Reference_target__set__(Reference *self, PyObject *py_target)
     /* Case 1: Direct */
     if (GIT_REF_OID == git_reference_type(self->reference)) {
         repo = git_reference_owner(self->reference);
-        err = py_str_to_git_oid_expand(repo, py_target, &oid);
-        if (err < 0)
+        len = py_str_to_git_oid_expand(repo, py_target, &oid);
+        if (len < 0) {
+            err = (int)len;
             goto error;
+        }
 
         err = git_reference_set_target(&new_ref, self->reference, &oid);
         if (err < 0)

--- a/src/signature.c
+++ b/src/signature.c
@@ -148,7 +148,7 @@ PyDoc_STRVAR(Signature_time__doc__, "Unix time.");
 PyObject *
 Signature_time__get__(Signature *self)
 {
-    return PyLong_FromLong(self->signature->when.time);
+    return PyLong_FromLongLong(self->signature->when.time);
 }
 
 

--- a/src/treebuilder.c
+++ b/src/treebuilder.c
@@ -53,7 +53,8 @@ PyObject *
 TreeBuilder_insert(TreeBuilder *self, PyObject *args)
 {
     PyObject *py_oid;
-    int len, err, attr;
+    Py_ssize_t len;
+    int err, attr;
     git_oid oid;
     const char *fname;
 

--- a/src/types.h
+++ b/src/types.h
@@ -174,8 +174,8 @@ typedef struct {
 typedef struct {
     PyObject_HEAD
     git_reflog *reflog;
-    int i;
-    int size;
+    size_t i;
+    size_t size;
 } RefLogIter;
 
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -33,6 +33,12 @@
 #include <git2.h>
 #include "types.h"
 
+#ifdef __GNUC__
+#  define PYGIT2_FN_UNUSED __attribute__((unused))
+#else
+#  define PYGIT2_FN_UNUSED
+#endif
+
 /* Python 2 support */
 #if PY_MAJOR_VERSION == 2
   #define PyLong_FromSize_t PyInt_FromSize_t
@@ -75,6 +81,7 @@
 /* Utilities */
 #define to_unicode(x, encoding, errors) to_unicode_n(x, strlen(x), encoding, errors)
 
+PYGIT2_FN_UNUSED
 Py_LOCAL_INLINE(PyObject*)
 to_unicode_n(const char *value, size_t len, const char *encoding, const char *errors)
 {
@@ -90,6 +97,7 @@ to_unicode_n(const char *value, size_t len, const char *encoding, const char *er
     return PyUnicode_Decode(value, len, encoding, errors);
 }
 
+PYGIT2_FN_UNUSED
 Py_LOCAL_INLINE(PyObject*)
 to_bytes(const char * value)
 {

--- a/src/walker.c
+++ b/src/walker.c
@@ -53,11 +53,12 @@ PyObject *
 Walker_hide(Walker *self, PyObject *py_hex)
 {
     int err;
+    Py_ssize_t len;
     git_oid oid;
 
-    err = py_str_to_git_oid_expand(self->repo->repo, py_hex, &oid);
-    if (err < 0)
-        return Error_set(err);
+    len = py_str_to_git_oid_expand(self->repo->repo, py_hex, &oid);
+    if (len < 0)
+        return Error_set((int)len);
 
     err = git_revwalk_hide(self->walk, &oid);
     if (err < 0)
@@ -76,11 +77,12 @@ PyObject *
 Walker_push(Walker *self, PyObject *py_hex)
 {
     int err;
+    Py_ssize_t len;
     git_oid oid;
 
-    err = py_str_to_git_oid_expand(self->repo->repo, py_hex, &oid);
-    if (err < 0)
-        return Error_set(err);
+    len = py_str_to_git_oid_expand(self->repo->repo, py_hex, &oid);
+    if (len < 0)
+        return Error_set((int)len);
 
     err = git_revwalk_push(self->walk, &oid);
     if (err < 0)


### PR DESCRIPTION
- Many PyLong_FromLong changed into PyLong_FromLongLong.
- A long used as out argument for git_config_parse_int64 changed into a
  int64_t.
- Many len variables changed from int into Py_ssize_t. Removed some
  castings related to those variables.
- Functions py_str_to_git_oid(_expand) return a Py_ssize_t, which is the
  return type of PyBytes_AsStringAndSize. Error values are usually casted to
  int, since the only error returned from those functions is -1.
- Changed RefLogIter i and size fields from int into size_t.
- Marked to_unicode_n and to_bytes inline functions as "unused". Not all
  compilation units which include utils.h use them.

Tested with:
$ clang --version
Apple clang version 4.0 (tags/Apple/clang-421.0.57) (based on LLVM 3.1svn)
Target: x86_64-apple-darwin12.3.0
Thread model: posix
