### PR TITLE
Branches

### DIFF
--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -164,6 +164,16 @@ class BranchesEmptyRepoTestCase(utils.EmptyRepoTestCase):
         master.upstream = None
         self.assertTrue(master.upstream is None)
 
+    def test_branch_upstream_name(self):
+        self.repo.remotes[0].fetch()
+        remote_master = self.repo.lookup_branch('origin/master',
+                                                pygit2.GIT_BRANCH_REMOTE)
+        master = self.repo.create_branch('master',
+                                         self.repo[remote_master.target.hex])
+
+        master.upstream = remote_master
+        self.assertEqual(master.upstream_name, 'refs/remotes/origin/master')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
WARNING: “Depends” on #220

Branch type and related methods.
- Repository has two new properties: branches and remote_branches. Using
  subscripting you can obtain references to the named branches.
- Repository has a new method create_branch. With a name and a Commit object,
  it creates a branch from the given commit.
- The Branch objects are a subtype of Reference, and should support all of the
  methods of Reference.
- Additionally Branch has new methods (delete, move and is_head), and new
  properties (name, remote_name, upstream and upstream_name).
- Two new exposed constants: GIT_BRANCH_LOCAL and GIT_BRANCH_REMOTE.
- Every reference stores now also a pointer to its owner repository.
- Test for all those new methods.
