### PR TITLE
Explain what "latest libgit2" means better

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,8 +6,10 @@ How to Install
 .. contents::
 
 
-First you need to install the latest version of libgit2.  You can find
-platform-specific instructions to build the library in the libgit2 website:
+First you need to install the latest release of libgit2. If you clone
+the repository, make sure to use the ``master`` branch. You can find
+platform-specific instructions to build the library in the libgit2
+website:
 
   http://libgit2.github.com
 
@@ -55,7 +57,7 @@ instructions in the libgit2 ``README.md``):
 
 .. code-block:: sh
 
-  $ git clone git://github.com/libgit2/libgit2.git
+  $ git clone -b master git://github.com/libgit2/libgit2.git
   $ mkdir libgit2/build
   $ cd libgit2/build
   $ cmake ..
@@ -105,7 +107,7 @@ from a bash shell:
 .. code-block:: sh
 
     $ export LIBGIT2=C:/Dev/libgit2
-    $ git clone git://github.com/libgit2/libgit2.git
+    $ git clone -b master git://github.com/libgit2/libgit2.git
     $ cd libgit2
     $ mkdir build
     $ cd build


### PR DESCRIPTION
pygit2 targets the master branch, and "latest" isn't well-defined in
this case, as libgit2's default branch is development.

---

This looks to be the cause of confusion in http://stackoverflow.com/questions/16570217/installing-pygit2-libgit2-in-python-virtualenv-on-a-mac and being explicit about what we target about is good anyway.
