### PR TITLE
Added: Reference.get_object() method

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -11,7 +11,7 @@ Example::
 
     >>> all_refs = repo.listall_references()
     >>> master_ref = repo.lookup_reference("refs/heads/master")
-    >>> commit = repo[master_ref.target]
+    >>> commit = master_ref.get_object() # or repo[master_ref.target]
 
 
 The Reference type
@@ -25,6 +25,7 @@ The Reference type
 .. automethod:: pygit2.Reference.rename
 .. automethod:: pygit2.Reference.resolve
 .. automethod:: pygit2.Reference.log
+.. automethod:: pygit2.Reference.get_object
 
 
 The HEAD

--- a/src/reference.c
+++ b/src/reference.c
@@ -29,6 +29,7 @@
 #include <Python.h>
 #include <string.h>
 #include <structmember.h>
+#include "object.h"
 #include "error.h"
 #include "types.h"
 #include "utils.h"
@@ -312,6 +313,27 @@ Reference_log(Reference *self)
 }
 
 
+PyDoc_STRVAR(Reference_get_object__doc__,
+  "get_object() -> object\n"
+  "\n"
+  "Retrieves the object the current reference is pointing to.");
+
+PyObject *
+Reference_get_object(Reference *self)
+{
+    int err;
+    git_object* obj;
+
+    CHECK_REFERENCE(self);
+
+    err = git_reference_peel(&obj, self->reference, GIT_OBJ_ANY);
+    if (err < 0)
+        return Error_set(err);
+
+    return wrap_object(obj, self->repo);
+}
+
+
 PyDoc_STRVAR(RefLogEntry_committer__doc__, "Committer.");
 
 PyObject *
@@ -404,6 +426,7 @@ PyMethodDef Reference_methods[] = {
     METHOD(Reference, rename, METH_O),
     METHOD(Reference, resolve, METH_NOARGS),
     METHOD(Reference, log, METH_NOARGS),
+    METHOD(Reference, get_object, METH_NOARGS),
     {NULL}
 };
 

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -209,5 +209,11 @@ class ReferencesTest(utils.RepoTestCase):
 #       self.repo.packall_references()
 
 
+    def test_get_object(self):
+        repo = self.repo
+        ref = repo.lookup_reference('refs/heads/master')
+        self.assertEqual(repo[ref.target].oid, ref.get_object().oid)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
get_object() retrieves the object the current reference is pointing to
