### PR TITLE
Added note about pygit2/libgit2 versioning

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,6 +25,10 @@ When those are installed, you can install pygit2:
     $ python setup.py install
     $ python setup.py test
 
+.. note:: A minor version of pygit2 must be used with the corresponding minor
+   version of libgit2. For example, pygit2 v0.18.x must be used with libgit2
+   v0.18.0.
+
 Building on \*nix (including OS X)
 ===================================
 


### PR DESCRIPTION
I see that this is documented on the [wiki](https://github.com/libgit2/pygit2/wiki/Release-policy) but I think it's worth mentioning in the install docs as I ran into the issue.
