### PR TITLE
tag: fix incorrect doc string wording for get_object()

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -51,7 +51,7 @@ Tag_target__get__(Tag *self)
 PyDoc_STRVAR(Tag_get_object__doc__,
   "get_object() -> object\n"
   "\n"
-  "Retrieves the object the current reference is pointing to.");
+  "Retrieves the object the current tag is pointing to.");
 
 PyObject *
 Tag_get_object(Tag *self)


### PR DESCRIPTION
I forgot to update the doc string for `Tag.get_object()` when copying it from `Reference.get_object()`.
