### PR TITLE
commit: rename Commit._message to Commit.raw_message

### DIFF
--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -216,6 +216,7 @@ committer and others.
 .. autoattribute:: pygit2.Commit.committer
 .. autoattribute:: pygit2.Commit.message
 .. autoattribute:: pygit2.Commit.message_encoding
+.. autoattribute:: pygit2.Commit.raw_message
 .. autoattribute:: pygit2.Commit.tree
 .. autoattribute:: pygit2.Commit.parents
 .. autoattribute:: pygit2.Commit.commit_time

--- a/src/commit.c
+++ b/src/commit.c
@@ -64,10 +64,10 @@ Commit_message__get__(Commit *commit)
 }
 
 
-PyDoc_STRVAR(Commit__message__doc__, "Message (bytes).");
+PyDoc_STRVAR(Commit_raw_message__doc__, "Message (bytes).");
 
 PyObject *
-Commit__message__get__(Commit *commit)
+Commit_raw_message__get__(Commit *commit)
 {
     return PyBytes_FromString(git_commit_message(commit->commit));
 }
@@ -195,7 +195,7 @@ Commit_parents__get__(Commit *self)
 PyGetSetDef Commit_getseters[] = {
     GETTER(Commit, message_encoding),
     GETTER(Commit, message),
-    GETTER(Commit, _message),
+    GETTER(Commit, raw_message),
     GETTER(Commit, commit_time),
     GETTER(Commit, commit_time_offset),
     GETTER(Commit, committer),

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -113,7 +113,7 @@ class CommitTest(utils.BareRepoTestCase):
 
         self.assertEqual(GIT_OBJ_COMMIT, commit.type)
         self.assertEqual('iso-8859-1', commit.message_encoding)
-        self.assertEqual(message, commit.message)
+        self.assertEqual(message.encode(encoding), commit.raw_message)
         self.assertEqual(12346, commit.commit_time)
         self.assertEqualSignature(committer, commit.committer)
         self.assertEqualSignature(author, commit.author)


### PR DESCRIPTION
This exposes this as a proper API.

Aside: I noticed that at least in commit.h, none of the public function declarations are actually defined. That should probably be fixed.
