### PR TITLE
Don't forget to remove the temporary directory in the config tests

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -46,6 +46,7 @@ foreach_test_wrapper.__test__ = False
 class ConfigTest(utils.RepoTestCase):
 
     def tearDown(self):
+        super(ConfigTest, self).tearDown()
         try:
             os.remove(CONFIG_FILENAME)
         except OSError:


### PR DESCRIPTION
When overriding the tear-down function, we must remember to call the
parent's function or we won't clean up the temporary directory for the
test.
