### PR TITLE
reference: add a shorthand property

### DIFF
--- a/src/reference.c
+++ b/src/reference.c
@@ -276,6 +276,14 @@ Reference_name__get__(Reference *self)
     return to_path(git_reference_name(self->reference));
 }
 
+PyDoc_STRVAR(Reference_shorthand__doc__, "The shorthand \"human-readable\" name of the reference.");
+
+PyObject *
+Reference_shorthand__get__(Reference *self)
+{
+    CHECK_REFERENCE(self);
+    return to_path(git_reference_shorthand(self->reference));
+}
 
 PyDoc_STRVAR(Reference_type__doc__,
     "Type, either GIT_REF_OID or GIT_REF_SYMBOLIC.");
@@ -432,6 +440,7 @@ PyMethodDef Reference_methods[] = {
 
 PyGetSetDef Reference_getseters[] = {
     GETTER(Reference, name),
+    GETTER(Reference, shorthand),
     GETSET(Reference, target),
     GETTER(Reference, type),
     {NULL}

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -103,6 +103,11 @@ class ReferencesTest(utils.RepoTestCase):
         reference.target = 'refs/heads/i18n'
         self.assertEqual(reference.target, 'refs/heads/i18n')
 
+    def test_get_shorthand(self):
+        reference = self.repo.lookup_reference('refs/heads/master')
+        self.assertEqual(reference.shorthand, 'master')
+        reference = self.repo.create_reference('refs/remotes/origin/master', LAST_COMMIT)
+        self.assertEqual(reference.shorthand, 'origin/master')
 
     def test_delete(self):
         repo = self.repo


### PR DESCRIPTION
Add Reference.shorthand to make it simpler to present a human-readable
name for a particular reference.
