### PR TITLE
Implement repository.reset, with tests

### DIFF
--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -302,6 +302,13 @@ moduleinit(PyObject* m)
     ADD_CONSTANT_INT(m, GIT_SORT_REVERSE)
 
     /*
+     * Reset
+     */
+    ADD_CONSTANT_INT(m, GIT_RESET_SOFT)
+    ADD_CONSTANT_INT(m, GIT_RESET_MIXED)
+    ADD_CONSTANT_INT(m, GIT_RESET_HARD)
+
+    /*
      * References
      */
     INIT_TYPE(ReferenceType, NULL, PyType_GenericNew)


### PR DESCRIPTION
This patch makes the function git_reset from libgit available to python repository class:
repository.reset(oid, reset_type)
Includes three tests to test the different types of git reset modes (hard, soft, mixed)
