### PR TITLE
Repository: allow retrieving the default signature

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -39,6 +39,7 @@
 #include "branch.h"
 #include "blame.h"
 #include "mergeresult.h"
+#include "signature.h"
 #include <git2/odb_backend.h>
 
 extern PyObject *GitError;
@@ -1324,6 +1325,19 @@ Repository_remotes__get__(Repository *self)
     return (PyObject*) py_list;
 }
 
+PyDoc_STRVAR(Repository_default_signature__doc__, "Return the signature according to the repository's configuration");
+
+PyObject *
+Repository_default_signature__get__(Repository *self)
+{
+    git_signature *sig;
+    int err;
+
+    if ((err = git_signature_default(&sig, self->repo)) < 0)
+        return Error_set(err);
+
+    return build_signature((Object*) self, sig, "utf-8");
+}
 
 PyDoc_STRVAR(Repository_checkout_head__doc__,
     "checkout_head(strategy)\n"
@@ -1633,6 +1647,7 @@ PyGetSetDef Repository_getseters[] = {
     GETTER(Repository, config),
     GETTER(Repository, workdir),
     GETTER(Repository, remotes),
+    GETTER(Repository, default_signature),
     {NULL}
 };
 

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -371,6 +371,16 @@ class RepositoryTest_III(utils.RepoTestCaseForMerging):
         self.repo.index.add('inindex.txt')
         self.assertRaises(pygit2.GitError, self.repo.merge, branch_oid)
 
+class RepositorySignatureTest(utils.RepoTestCase):
+
+    def test_default_signature(self):
+        config = self.repo.config
+        config['user.name'] = 'Random J Hacker'
+        config['user.email'] ='rjh@example.com'
+
+        sig = self.repo.default_signature
+        self.assertEqual('Random J Hacker', sig.name)
+        self.assertEqual('rjh@example.com', sig.email)
 
 class NewRepositoryTest(utils.NoRepoTestCase):
 


### PR DESCRIPTION
Make it easier to grab the default signature for a repository by adding
a getter at the Repository level.
