### PR TITLE
Commit: retrieve tree and parents' ids directly

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -199,6 +199,28 @@ Commit_parents__get__(Commit *self)
     return list;
 }
 
+PyDoc_STRVAR(Commit_parent_ids__doc__, "The list of parent commits' ids.");
+
+PyObject *
+Commit_parent_ids__get__(Commit *self)
+{
+    unsigned int i, parent_count;
+    const git_oid *id;
+    PyObject *list;
+
+    parent_count = git_commit_parentcount(self->commit);
+    list = PyList_New(parent_count);
+    if (!list)
+        return NULL;
+
+    for (i=0; i < parent_count; i++) {
+        id = git_commit_parent_id(self->commit, i);
+        PyList_SET_ITEM(list, i, git_oid_to_python(id));
+    }
+
+    return list;
+}
+
 PyGetSetDef Commit_getseters[] = {
     GETTER(Commit, message_encoding),
     GETTER(Commit, message),
@@ -210,6 +232,7 @@ PyGetSetDef Commit_getseters[] = {
     GETTER(Commit, tree),
     GETTER(Commit, tree_id),
     GETTER(Commit, parents),
+    GETTER(Commit, parent_ids),
     {NULL}
 };
 

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -95,6 +95,7 @@ class CommitTest(utils.BareRepoTestCase):
         self.assertEqual(Oid(hex=tree), commit.tree_id)
         self.assertEqual(1, len(commit.parents))
         self.assertEqual(COMMIT_SHA, commit.parents[0].hex)
+        self.assertEqual(Oid(hex=COMMIT_SHA), commit.parent_ids[0])
 
     def test_new_commit_encoding(self):
         repo = self.repo
@@ -122,6 +123,7 @@ class CommitTest(utils.BareRepoTestCase):
         self.assertEqual(Oid(hex=tree), commit.tree_id)
         self.assertEqual(1, len(commit.parents))
         self.assertEqual(COMMIT_SHA, commit.parents[0].hex)
+        self.assertEqual(Oid(hex=COMMIT_SHA), commit.parent_ids[0])
 
     def test_modify_commit(self):
         message = 'New commit.\n\nMessage.\n'


### PR DESCRIPTION
Allow direct access to the tree and parents' ids directly instead of having to load the objects just to get to this data.

This fixes #73.

---

I'm not completely sure about the 'parents' naming, `parents_ids` seemed to have too many plurals in it.
