### PR TITLE
Config: switch from foreach iterator

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -10,9 +10,17 @@ The Config type
 
 .. automethod:: pygit2.Config.get_system_config
 .. automethod:: pygit2.Config.get_global_config
-.. automethod:: pygit2.Config.foreach
 .. automethod:: pygit2.Config.add_file
 .. automethod:: pygit2.Config.get_multivar
 .. automethod:: pygit2.Config.set_multivar
 
 The :class:`Config` Mapping interface.
+
+Iterator
+=========
+
+The :class:`Config` class has an iterator which can be used to loop
+through all the entries in the configuration. Each element is a tuple
+containing the name and the value of each configuration variable. Be
+aware that this may return multiple versions of each entry if they are
+set multiple times in the configuration files.

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -56,6 +56,7 @@ extern PyTypeObject IndexEntryType;
 extern PyTypeObject IndexIterType;
 extern PyTypeObject WalkerType;
 extern PyTypeObject ConfigType;
+extern PyTypeObject ConfigIterType;
 extern PyTypeObject ReferenceType;
 extern PyTypeObject RefLogIterType;
 extern PyTypeObject RefLogEntryType;
@@ -412,7 +413,9 @@ moduleinit(PyObject* m)
 
     /* Config */
     INIT_TYPE(ConfigType, NULL, PyType_GenericNew)
+    INIT_TYPE(ConfigIterType, NULL, PyType_GenericNew)
     ADD_TYPE(m, Config)
+    ADD_TYPE(m, ConfigIter)
 
     /* Remotes */
     INIT_TYPE(RemoteType, NULL, NULL)

--- a/src/types.h
+++ b/src/types.h
@@ -77,6 +77,11 @@ typedef struct {
     git_config* config;
 } Config;
 
+typedef struct {
+    PyObject_HEAD
+    Config *owner;
+    git_config_iterator *iter;
+} ConfigIter;
 
 /* git_note */
 typedef struct {

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -36,13 +36,6 @@ from . import utils
 
 CONFIG_FILENAME = "test_config"
 
-
-def foreach_test_wrapper(key, name, lst):
-    lst[key] = name
-    return 0
-foreach_test_wrapper.__test__ = False
-
-
 class ConfigTest(utils.RepoTestCase):
 
     def tearDown(self):
@@ -175,13 +168,15 @@ class ConfigTest(utils.RepoTestCase):
         for i in l:
             self.assertEqual(i, 'foo-123456')
 
-    def test_foreach(self):
+    def test_iterator(self):
         config = self.repo.config
         lst = {}
-        config.foreach(foreach_test_wrapper, lst)
+
+        for name, value in config:
+            lst[name] = value
+
         self.assertTrue('core.bare' in lst)
         self.assertTrue(lst['core.bare'])
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
An iterator is much more natural in python, so let's use that.

---

I documented what we return in `docs/config.rst`, but I'm not sure if there's a better place/way.

With this, we're removing the last usage of a foreach, so we should be able to close #183.
