### PR TITLE
TreeEntry: add rich comparison function

### DIFF
--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -118,7 +118,7 @@ class TreeTest(utils.BareRepoTestCase):
         """
         tree = self.repo[TREE_SHA]
         for tree_entry in tree:
-            self.assertEqual(tree_entry.hex, tree[tree_entry.name].hex)
+            self.assertEqual(tree_entry, tree[tree_entry.name])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allow direct comparisons between TreeEntry objects, which also allows us
to use assertEqual in the sanity check test.

This fixes #305.
