### PR TITLE
Remote: push url

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -278,6 +278,42 @@ Remote_url__set__(Remote *self, PyObject* py_url)
     return -1;
 }
 
+PyDoc_STRVAR(Remote_push_url__doc__, "Push url of the remote");
+
+
+PyObject *
+Remote_push_url__get__(Remote *self)
+{
+	const char *url;
+
+    url = git_remote_pushurl(self->remote);
+    if (!url)
+        Py_RETURN_NONE;
+
+    return to_unicode(url, NULL, NULL);
+}
+
+
+int
+Remote_push_url__set__(Remote *self, PyObject* py_url)
+{
+    int err;
+    char* url = NULL;
+
+    url = py_str_to_c_str(py_url, NULL);
+    if (url != NULL) {
+        err = git_remote_set_pushurl(self->remote, url);
+        free(url);
+
+        if (err == GIT_OK)
+            return 0;
+
+        Error_set(err);
+    }
+
+    return -1;
+}
+
 
 PyDoc_STRVAR(Remote_refspec_count__doc__, "Number of refspecs.");
 
@@ -452,6 +488,7 @@ PyMethodDef Remote_methods[] = {
 PyGetSetDef Remote_getseters[] = {
     GETSET(Remote, name),
     GETSET(Remote, url),
+    GETSET(Remote, push_url),
     GETTER(Remote, refspec_count),
     {NULL}
 };

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -50,6 +50,7 @@ class RepositoryTest(utils.RepoTestCase):
         self.assertEqual(type(remote), pygit2.Remote)
         self.assertEqual(name, remote.name)
         self.assertEqual(url, remote.url)
+        self.assertEqual(None, remote.push_url)
 
         self.assertRaises(ValueError, self.repo.create_remote, *(name, url))
 
@@ -73,6 +74,10 @@ class RepositoryTest(utils.RepoTestCase):
         self.assertEqual(new_url, remote.url)
 
         self.assertRaisesAssign(ValueError, remote, 'url', '')
+
+        remote.push_url = new_url
+        self.assertEqual(new_url, remote.push_url)
+        self.assertRaisesAssign(ValueError, remote, 'push_url', '')
 
 
     def test_refspec(self):


### PR DESCRIPTION
Allow access to the push url. Includes a fix for segfaulting in case there is no url. We shouldn't currently be exposing this in libgit2, but this may change at any moment.
