### PR TITLE
Tree: let contains look in subtrees

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -191,14 +191,26 @@ Tree_len(Tree *self)
 int
 Tree_contains(Tree *self, PyObject *py_name)
 {
-    int result = 0;
+	int err;
+    git_tree_entry *entry;
     char *name = py_path_to_c_str(py_name);
     if (name == NULL)
         return -1;
 
-    result = git_tree_entry_byname(self->tree, name) ? 1 : 0;
+    err = git_tree_entry_bypath(&entry, self->tree, name);
     free(name);
-    return result;
+
+    if (err == GIT_ENOTFOUND)
+        return 0;
+
+    if (err < 0) {
+        Error_set(err);
+        return -1;
+    }
+
+    git_tree_entry_free(entry);
+
+    return 1;
 }
 
 TreeEntry *

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -120,6 +120,13 @@ class TreeTest(utils.BareRepoTestCase):
         for tree_entry in tree:
             self.assertEqual(tree_entry, tree[tree_entry.name])
 
+    def test_deep_contains(self):
+        tree = self.repo[TREE_SHA]
+        self.assertTrue('a' in tree)
+        self.assertTrue('c' in tree)
+        self.assertTrue('c/d' in tree)
+        self.assertFalse('c/e' in tree)
+        self.assertFalse('d' in tree)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allow looking in subtrees as a convenience in the 'contains'
function. As slashes are not allowed to be part of the name of an entry,
there is no ambiguity in what they mean.

This fixes #306 

---

This does mean a bit more data copying, but it's probably not enough to warrant treating the subtree and no-subtree cases differently in the code.
