### PR TITLE
Refspec getter/setters

### DIFF
--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -130,6 +130,10 @@ class RepositoryTest(utils.RepoTestCase):
             '+refs/test/*:refs/test/remotes/*'
         ])
 
+        self.assertRaises(TypeError, setattr, remote, 'push_refspecs', '+refs/*:refs/*')
+        self.assertRaises(TypeError, setattr, remote, 'fetch_refspecs', '+refs/*:refs/*')
+        self.assertRaises(TypeError, setattr, remote, 'fetch_refspecs', ['+refs/*:refs/*', 5])
+
         self.assertEqual('+refs/*:refs/remotes/*',
                          remote.get_push_refspecs()[0])
         self.assertEqual('+refs/test/*:refs/test/remotes/*',


### PR DESCRIPTION
This is much more pythonic than getter/setter function pairs. I've left the functions for backward compatibility, but they should be removed before the minor release. The functions use the attributes' code, so I've left the tests mostly alone, and it should convert over painlessly when we remove the functions.

I've also made sure we fail gracefully on unexpected input.
