### PR TITLE
[Fixbug]: Repository object reference count increase abnormal

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -1317,6 +1317,7 @@ Repository_remotes__get__(Repository *self)
         py_remote = PyObject_New(Remote, &RemoteType);
         py_args = Py_BuildValue("Os", self, remotes.strings[i]);
         Remote_init(py_remote, py_args, NULL);
+        Py_DECREF(py_args);
         PyList_SetItem(py_list, i, (PyObject*) py_remote);
     }
 


### PR DESCRIPTION
For issue #326, Repository object's reference count will be increased abnormally by it's remotes getter function. That is because 'py_args' does not release which hold 1 reference to repository.
This issue stem from my requirement to dealloc repository object for purpose of releasing file descriptor resource occupied by it. When I construct a new repository object, I found that the old one won't be deconstructed since it's reference count can't decrease to zero.
