### PR TITLE
walk: make the sorting mode optional

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -626,13 +626,13 @@ Repository_merge(Repository *self, PyObject *py_oid)
 }
 
 PyDoc_STRVAR(Repository_walk__doc__,
-  "walk(oid, sort_mode) -> iterator\n"
+  "walk(oid[, sort_mode]) -> iterator\n"
   "\n"
   "Generator that traverses the history starting from the given commit.\n"
   "The following types of sorting could be used to control traversing\n"
   "direction:\n"
   "\n"
-  "* GIT_SORT_NONE. This is the default sorting for new walkers\n"
+  "* GIT_SORT_NONE. This is the default sorting for new walkers.\n"
   "  Sort the repository contents in no particular ordering\n"
   "* GIT_SORT_TOPOLOGICAL. Sort the repository contents in topological order\n"
   "  (parents before children); this sorting mode can be combined with\n"
@@ -656,13 +656,13 @@ PyObject *
 Repository_walk(Repository *self, PyObject *args)
 {
     PyObject *value;
-    unsigned int sort;
+    unsigned int sort = GIT_SORT_NONE;
     int err;
     git_oid oid;
     git_revwalk *walk;
     Walker *py_walker;
 
-    if (!PyArg_ParseTuple(args, "OI", &value, &sort))
+    if (!PyArg_ParseTuple(args, "O|I", &value, &sort))
         return NULL;
 
     err = git_revwalk_new(&walk, self->repo);

--- a/test/test_revwalk.py
+++ b/test/test_revwalk.py
@@ -31,7 +31,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import unittest
 
-from pygit2 import GIT_SORT_TIME, GIT_SORT_REVERSE
+from pygit2 import GIT_SORT_NONE, GIT_SORT_TIME, GIT_SORT_REVERSE
 from . import utils
 
 
@@ -106,6 +106,14 @@ class WalkerTest(utils.RepoTestCase):
         walker = self.repo.walk(log[0], GIT_SORT_TIME)
         walker.simplify_first_parent()
         self.assertEqual(len(list(walker)), 3)
+
+    def test_default_sorting(self):
+        walker = self.repo.walk(log[0], GIT_SORT_NONE)
+        list1 = list([x.id for x in walker])
+        walker = self.repo.walk(log[0])
+        list2 = list([x.id for x in walker])
+
+        self.assertEqual(list1, list2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Since the libgit2 has a default sorting method, which we also mention as
default in the documentation, there is no particular need to make the
user choose a sorting method when the order does not matter. We use
sorting NONE in that case.
