### PR TITLE
Fixed `undefined symbol: PyLong_AsSize_t` on PyPy

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -61,6 +61,10 @@
   #define to_encoding(x) PyUnicode_DecodeASCII(x, strlen(x), "strict")
 #endif
 
+#ifdef PYPY_VERSION
+  #define PyLong_AsSize_t (size_t)PyLong_AsUnsignedLong
+#endif
+
 #ifndef Py_hash_t
   #define Py_hash_t long
 #endif


### PR DESCRIPTION
Without this fix, I get this error:

```
$ ./pip install --user pygit2
Downloading/unpacking pygit2
  Downloading pygit2-0.20.2.tar.gz (140kB): 140kB downloaded
  Running setup.py egg_info for package pygit2

Installing collected packages: pygit2
  Running setup.py install for pygit2
    building '_pygit2' extension
    cc -O2 -fPIC -Wimplicit -I/usr/local/include -Iinclude -I/opt/pypy3/include -c src/repository.c -o build/temp.linux-x86_64-3.2/src/repository.o
    cc -O2 -fPIC -Wimplicit -I/usr/local/include -Iinclude -I/opt/pypy3/include -c src/error.c -o build/temp.linux-x86_64-3.2/src/error.o
    cc -O2 -fPIC -Wimplicit -I/usr/local/include -Iinclude -I/opt/pypy3/include -c src/tree.c -o build/temp.linux-x86_64-3.2/src/tree.o
    cc -O2 -fPIC -Wimplicit -I/usr/local/include -Iinclude -I/opt/pypy3/include -c src/walker.c -o build/temp.linux-x86_64-3.2/src/walker.o
    cc -O2 -fPIC -Wimplicit -I/usr/local/include -Iinclude -I/opt/pypy3/include -c src/remote.c -o build/temp.linux-x86_64-3.2/src/remote.o
    src/remote.c: In function ‘Remote_get_refspec’:
    src/remote.c:486:5: warning: implicit declaration of function ‘PyLong_AsSize_t’ [-Wimplicit-function-declaration]
         n = PyLong_AsSize_t(value);
```

And:

```
$ pypy3
Python 3.2.3 (d63636b30cc089cd7f3b658766bd6f5cdaa381dd, Aug 08 2013, 17:13:31)
[PyPy 2.1.0-beta1 with GCC 4.8.1 20130725 (prerelease)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
And now for something completely different: ``PyPy is not a real VM: no
segfault handlers to do the rare cases''
>>>> import pygit2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mdevaev/.local/lib/python3.2/site-packages/pygit2/__init__.py", line 32, in <module>
    import _pygit2
ImportError: unable to load extension module '/home/mdevaev/.local/lib/python3.2/site-packages/_pygit2.pypy-21.so': /home/mdevaev/.local/lib/python3.2/site-packages/_pygit2.pypy-21.so: undefined symbol: PyLong_AsSize_t
```
