### PR TITLE
test: clean up

### DIFF
--- a/test/test_index.py
+++ b/test/test_index.py
@@ -34,6 +34,7 @@ import unittest
 import tempfile
 
 import pygit2
+from pygit2 import Repository
 from . import utils
 
 
@@ -154,12 +155,10 @@ class IndexTest(utils.RepoTestCase):
         self.assertEqual(pygit2.GIT_FILEMODE_BLOB_EXECUTABLE, entry.mode)
 
     def test_write_tree_to(self):
-        path = tempfile.mkdtemp()
-        pygit2.init_repository(path)
-        nrepo = pygit2.Repository(path)
-
-        id = self.repo.index.write_tree(nrepo)
-        self.assertNotEqual(None, nrepo[id])
+        with utils.TemporaryRepository(('tar', 'emptyrepo')) as path:
+            nrepo = Repository(path)
+            id = self.repo.index.write_tree(nrepo)
+            self.assertNotEqual(None, nrepo[id])
 
 class IndexEntryTest(utils.RepoTestCase):
 

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -165,6 +165,7 @@ class RepositoryTest(utils.BareRepoTestCase):
         with open(tempfile_path, 'w') as fh:
             fh.write(data)
         hashed_sha1 = hashfile(tempfile_path)
+        os.unlink(tempfile_path)
         written_sha1 = self.repo.create_blob(data)
         self.assertEqual(hashed_sha1, written_sha1)
 


### PR DESCRIPTION
Remove the temporary files and directories we create as part of running
the test suite.
