### PR TITLE
diff: Fix for memory leak in git_patch

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -127,6 +127,7 @@ wrap_patch(git_patch *patch)
             }
         }
     }
+    git_patch_free(patch);
 
     return (PyObject*) py_patch;
 }


### PR DESCRIPTION
This pull request will fix a memory leak,
that occurs while iterating through patches.

It's quite major issue, my machine run out of memory in couple of minutes.
Please take a look at this fragment of valgrind log.
==6056== 154,660,050 (15,076,512 direct, 139,583,538 indirect) bytes in 52,349 blocks are definitely lost in loss record 788 of 788
==6056==    at 0x4C2B590: calloc (vg_replace_malloc.c:618)
==6056==    by 0x71159C6: git__calloc (util.h:36)
==6056==    by 0x7115D97: diff_patch_alloc_from_diff (diff_patch.c:104)
==6056==    by 0x711726A: git_patch_from_diff (diff_patch.c:622)
==6056==    by 0x6ED71AF: diff_get_patch_byindex (diff.c:140)
==6056==    by 0x55F1DA: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==6056==    by 0x55F7B9: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==6056==    by 0x55F7B9: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==6056==    by 0x55F7B9: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==6056==    by 0x55F7B9: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==6056==    by 0x55F7B9: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==6056==    by 0x55F7B9: PyEval_EvalFrameEx (in /usr/bin/python2.7)
