### PR TITLE
More informative repr for Repository objects

### DIFF
--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -56,6 +56,8 @@ class Repository(_Repository):
     def __contains__(self, key):
         return self.git_object_lookup_prefix(key) is not None
 
+    def __repr__(self):
+        return "pygit2.Repository(%r)" % self.path
 
     #
     # References


### PR DESCRIPTION
Before, with the default Python repr:

```
<pygit2.repository.Repository at 0x7f3858b1cc00>
```

After, with a repr that shows how to construct this object (which is recommended where practical):

```
pygit2.Repository('/home/takluyver/Code/pygit2/.git/')
```
