### PR TITLE
Plug memory leaks

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -623,8 +623,9 @@ IndexEntry_init(IndexEntry *self, PyObject *args, PyObject *kwds)
         return -1;
 
     memset(&self->entry, 0, sizeof(struct git_index_entry));
-    if (c_path)
-        self->entry.path = c_path;
+    self->entry.path = strdup(c_path);
+    if (!self->entry.path)
+        return -1;
 
     if (id)
         git_oid_cpy(&self->entry.oid, &id->oid);
@@ -638,6 +639,7 @@ IndexEntry_init(IndexEntry *self, PyObject *args, PyObject *kwds)
 void
 IndexEntry_dealloc(IndexEntry *self)
 {
+    free(self->entry.path);
     PyObject_Del(self);
 }
 

--- a/src/mergeresult.c
+++ b/src/mergeresult.c
@@ -50,6 +50,14 @@ git_merge_result_to_python(git_merge_result *merge_result)
     return (PyObject*) py_merge_result;
 }
 
+void
+MergeResult_dealloc(MergeResult *self)
+{
+    git_merge_result_free(self->result);
+    PyObject_Del(self);
+}
+
+
 PyDoc_STRVAR(MergeResult_is_uptodate__doc__, "Is up to date");
 
 PyObject *
@@ -99,7 +107,7 @@ PyTypeObject MergeResultType = {
     "_pygit2.MergeResult",                     /* tp_name           */
     sizeof(MergeResult),                       /* tp_basicsize      */
     0,                                         /* tp_itemsize       */
-    0,                                         /* tp_dealloc        */
+    (destructor)MergeResult_dealloc,           /* tp_dealloc        */
     0,                                         /* tp_print          */
     0,                                         /* tp_getattr        */
     0,                                         /* tp_setattr        */

--- a/src/remote.c
+++ b/src/remote.c
@@ -175,6 +175,7 @@ transfer_progress_cb(const git_transfer_progress *stats, void *data)
         return -1;
 
     ret = PyObject_CallFunctionObjArgs(remote->transfer_progress, py_stats, NULL);
+    Py_DECREF(py_stats);
     if (!ret)
         return -1;
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -139,6 +139,7 @@ Repository_as_iter(Repository *self)
     git_odb *odb;
     int err;
     PyObject *accum = PyList_New(0);
+    PyObject *ret;
 
     err = git_repository_odb(&odb, self->repo);
     if (err < 0)
@@ -151,7 +152,10 @@ Repository_as_iter(Repository *self)
     if (err < 0)
         return Error_set(err);
 
-    return PyObject_GetIter(accum);
+    ret = PyObject_GetIter(accum);
+    Py_DECREF(accum);
+
+    return ret;
 }
 
 
@@ -1345,7 +1349,7 @@ Repository_default_signature__get__(Repository *self)
     if ((err = git_signature_default(&sig, self->repo)) < 0)
         return Error_set(err);
 
-    return build_signature((Object*) self, sig, "utf-8");
+    return build_signature(NULL, sig, "utf-8");
 }
 
 PyDoc_STRVAR(Repository_checkout_head__doc__,

--- a/src/types.h
+++ b/src/types.h
@@ -191,7 +191,7 @@ typedef struct {
     PyObject_HEAD
     Object *obj;
     const git_signature *signature;
-    const char *encoding;
+    char *encoding;
 } Signature;
 
 


### PR DESCRIPTION
This patch is mostly about making sure that we free the copies of what
we have, as well as making sure that we can free it.

The IndexEntry forgot to free its path, but it also used a pointer to
python-owned memory, which could be freed at any time.

MergeResult completely lacked a deallocator.

Signature needs to make sure we can free the enocoding, and not to set
an owner when we own the memory (in this case for the default
signature).

The repository needs to get rid of its reference to the object list when
returning.

The transfer progress callback needs to decref the stats object.
