### PR TITLE
Blob: implement the memory buffer interface

### DIFF
--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -74,6 +74,13 @@ class BlobTest(utils.RepoTestCase):
         self.assertEqual(BLOB_NEW_CONTENT, blob.data)
         self.assertEqual(len(BLOB_NEW_CONTENT), blob.size)
         self.assertEqual(BLOB_NEW_CONTENT, blob.read_raw())
+        blob_buffer = memoryview(blob)
+        self.assertEqual(len(BLOB_NEW_CONTENT), len(blob_buffer))
+        self.assertEqual(BLOB_NEW_CONTENT, blob_buffer)
+        def set_content():
+            blob_buffer[:2] = b'hi'
+
+        self.assertRaises(TypeError, set_content)
 
     def test_create_blob_fromworkdir(self):
 


### PR DESCRIPTION
This allows us to expose access to the blob's data without the need to
copy it into new buffer.

Should we take `Blob.data` and make it return a `memoryview` of the data instead of creating two ways o accessing it? I'm not too familiar with any differences in how you might want to use a PyBytes vs a memoryview.
