### PR TITLE
make build options.c with VS2008 compiler

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -41,10 +41,11 @@ get_search_path(long level)
     size_t len = 64;
     PyObject *py_path;
     int error;
+    char *tmp;
 
     do {
         len *= 2;
-        char *tmp = realloc(buf, len);
+        tmp = realloc(buf, len);
         if (!tmp) {
             free(buf);
             PyErr_NoMemory();


### PR DESCRIPTION
Cannot build options.c in pygit2 v0.20.3 with Visual Studio 2008 compiler. Patch makes build options.c with the compiler.

```
c:\Program Files\Microsoft Visual Studio 9.0\VC\BIN\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG "-IC:\Program Files\libgit2\include" -Iinclude -IC:\python\include -IC:\python\PC /Tcsrc\options.c /Fobuild\temp.win32-2.6\Release\src\options.obj
options.c
src\options.c(47) : error C2143: syntax error : missing ';' before 'type'
...
```
