### PR TITLE
Add libgit2 version check to C code

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -32,6 +32,10 @@
 #include <Python.h>
 #include <git2.h>
 
+#if !(LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR == 20)
+#error You need a compatible libgit2 version (v0.20.x)
+#endif
+
 /*
  * Python objects
  *


### PR DESCRIPTION
This should cause pygit2 to fail a bit more gracefully when the wrong version of libgit2 is installed. I missed this when I was installing, and it should also be a good way to address #363.

I put the check in types.h because it seemed like the most central place to put this.
