### PR TITLE
Fix format string for Blob.diff()

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -106,7 +106,7 @@ Blob_diff_to_buffer(Blob *self, PyObject *args, PyObject *kwds)
     char *keywords[] = {"buffer", "flag", "old_as_path", "buffer_as_path",
                         NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|s#ssI", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|s#Iss", keywords,
                                      &buffer, &buffer_len, &opts.flags,
                                      &old_as_path, &buffer_as_path))
         return NULL;


### PR DESCRIPTION
Format string items out of order relative to docstring and outargs. 

In Python, the problem manifested whereby calls to Blob.diff would only succeed if you did not pass any arguments past the other blob. Otherwise they would raise with a message about expecting an integer.
