### PR TITLE
clone: wrap clone_into()

### DIFF
--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -129,4 +129,27 @@ def clone_repository(
 
     return Repository(path)
 
+def clone_into(repo, remote, branch=None):
+    """Clone into an empty repository from the specified remote
+
+    :param Repository repo: The empty repository into which to clone
+
+    :param Remote remote: The remote from which to clone
+
+    :param str branch: Branch to checkout after the clone. Pass None
+     to use the remotes's default branch.
+
+    This allows you specify arbitrary repository and remote configurations
+    before performing the clone step itself. E.g. you can replicate git-clone's
+    '--mirror' option by setting a refspec of '+refs/*:refs/*', 'core.mirror' to true
+    and calling this function.
+    """
+
+    err = C.git_clone_into(repo._repo, remote._remote, ffi.NULL, to_str(branch))
+
+    if remote._stored_exception:
+        raise remote._stored_exception
+
+    check_error(err)
+
 settings = Settings()

--- a/pygit2/decl.h
+++ b/pygit2/decl.h
@@ -216,6 +216,7 @@ int git_clone(git_repository **out,
 		const char *local_path,
 		const git_clone_options *options);
 
+int git_clone_into(git_repository *repo, git_remote *remote, const git_checkout_opts *co_opts, const char *branch);
 
 typedef enum {
 	GIT_CONFIG_LEVEL_SYSTEM = 1,

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -40,7 +40,7 @@ from os.path import join, realpath
 
 # Import from pygit2
 from pygit2 import GIT_OBJ_ANY, GIT_OBJ_BLOB, GIT_OBJ_COMMIT
-from pygit2 import init_repository, clone_repository, discover_repository
+from pygit2 import init_repository, clone_repository, clone_into, discover_repository
 from pygit2 import Oid, Reference, hashfile
 import pygit2
 from . import utils
@@ -460,6 +460,13 @@ class CloneRepositoryTest(utils.NoRepoTestCase):
             repo_path, self._temp_dir, remote_name="custom_remote")
         self.assertFalse(repo.is_empty)
         self.assertEqual(repo.remotes[0].name, "custom_remote")
+
+    def test_clone_into(self):
+        repo_path = "./test/data/testrepo.git/"
+        repo = init_repository(os.path.join(self._temp_dir, "clone-into"))
+        remote = repo.create_remote("origin", 'file://' + os.path.realpath(repo_path))
+        clone_into(repo, remote)
+        self.assertTrue('refs/remotes/origin/master' in repo.listall_references())
 
     def test_clone_with_credentials(self):
         credentials = pygit2.UserPass("libgit2", "libgit2")


### PR DESCRIPTION
This allows the user to prepare the repository and remote with whichever
custom settings they want before performing the "clone" proper.

---

There's unfortunately a bug in the released libgit2 which doesn't allow us to perform a mirror clone, but it will be fixed in the next release.
