### PR TITLE
travis: download a tag instead of master

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -2,7 +2,7 @@
 
 cd ~
 
-git clone --depth=1 -b master https://github.com/libgit2/libgit2.git
+git clone --depth=1 -b v0.21.0 https://github.com/libgit2/libgit2.git
 cd libgit2/
 
 mkdir build && cd build


### PR DESCRIPTION
libgit2's development now happens on the master branch, which means we
can't use it to refer to the latest release. Download v0.21.0 explicitly
instead.
