### PR TITLE
Fix sphinx complaints about the docs

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -109,10 +109,8 @@ Example::
     >>> for entry in head.log():
     ...     print(entry.message)
 
-.. autoattribute:: pygit2.RefLogEntry.id_new
-.. autoattribute:: pygit2.RefLogEntry.id_old
-.. autoattribute:: pygit2.RefLogEntry.message
-.. autoattribute:: pygit2.RefLogEntry.committer
+.. autoclass:: pygit2.RefLogEntry
+   :members:
 
 Notes
 ====================

--- a/docs/remotes.rst
+++ b/docs/remotes.rst
@@ -10,48 +10,22 @@ Remotes
 The Remote type
 ====================
 
-.. autoattribute:: pygit2.Remote.name
-.. autoattribute:: pygit2.Remote.url
-.. autoattribute:: pygit2.Remote.push_url
-.. autoattribute:: pygit2.Remote.refspec_count
-.. autoattribute:: pygit2.Remote.push_refspecs
-.. autoattribute:: pygit2.Remote.fetch_refspecs
-.. automethod:: pygit2.Remote.progress
-.. automethod:: pygit2.Remote.transfer_progress
-.. automethod:: pygit2.Remote.update_tips
-.. automethod:: pygit2.Remote.get_refspec
-.. automethod:: pygit2.Remote.fetch
-.. automethod:: pygit2.Remote.push
-.. automethod:: pygit2.Remote.save
-.. automethod:: pygit2.Remote.add_push
-.. automethod:: pygit2.Remote.add_fetch
+.. autoclass:: pygit2.Remote
+   :members:
 
 The TransferProgress type
 ===========================
 
 This class contains the data which is available to us during a fetch.
 
-.. autoattribute:: pygit2.TransferProgress.total_objects
-.. autoattribute:: pygit2.TransferProgress.indexed_objects
-.. autoattribute:: pygit2.TransferProgress.received_objects
-.. autoattribute:: pygit2.TransferProgress.local_objects
-.. autoattribute:: pygit2.TransferProgress.total_deltas
-.. autoattribute:: pygit2.TransferProgress.indexed_deltas
-.. autoattribute:: pygit2.TransferProgress.received_bytes
-
+.. autoclass:: pygit2.remote.TransferProgress
+   :members:
 
 The Refspec type
 ===================
 
-.. autoattribute:: pygit2.Refspec.direction
-.. autoattribute:: pygit2.Refspec.src
-.. autoattribute:: pygit2.Refspec.dst
-.. autoattribute:: pygit2.Refspec.force
-.. autoattribute:: pygit2.Refspec.string
-.. automethod:: pygit2.Refspec.src_matches
-.. automethod:: pygit2.Refspec.dst_matches
-.. automethod:: pygit2.Refspec.transform
-.. automethod:: pygit2.Refspec.rtransform
+.. autoclass:: pygit2.refspec.Refspec
+   :members:
 
 Credentials
 ================


### PR DESCRIPTION
Use the right namespace so Refspec and TransferProgress show up. These
classes are not instantiated by the user, so they were not promoted to
the pygit2 module. Use autoclass so it lists everything for us.

Also use autoclass for the reflog. We had a difference is oid vs id
between the docs and the code.

---

Why don't we use autoclass everywhere instead of listing everything by hand? Sphinx can extract the data from the C modules, so it doesn't seem obvious why we're listing the attributes and methods.
