### PR TITLE
Iterate over the config keys

### DIFF
--- a/pygit2/config.py
+++ b/pygit2/config.py
@@ -62,9 +62,8 @@ class ConfigIterator(object):
     def __next__(self):
         entry = self._next_entry()
         name = ffi.string(entry.name).decode('utf-8')
-        value = ffi.string(entry.value).decode('utf-8')
 
-        return name, value
+        return name
 
 
 class ConfigMultivarIterator(ConfigIterator):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -173,8 +173,8 @@ class ConfigTest(utils.RepoTestCase):
         config = self.repo.config
         lst = {}
 
-        for name, value in config:
-            lst[name] = value
+        for name in config:
+            lst[name] = config[name]
 
         self.assertTrue('core.bare' in lst)
         self.assertTrue(lst['core.bare'])


### PR DESCRIPTION
The first commit is something the change in the test brought up.

The config behaves like a dictionary with peculiar equality rules, so make it behave like a python dict when we iterate over it.
