### PR TITLE
Add Repository.ahead_behind()

### DIFF
--- a/docs/repository.rst
+++ b/docs/repository.rst
@@ -69,4 +69,8 @@ Below there are some general attributes and methods:
 .. automethod:: pygit2.Repository.write
 .. automethod:: pygit2.Repository.reset
 .. automethod:: pygit2.Repository.state_cleanup
+<<<<<<< HEAD
 .. automethod:: pygit2.Repository.write_archive
+=======
+.. automethod:: pygit2.Repository.ahead_behind
+>>>>>>> Add Repsitory.ahead_behind()

--- a/pygit2/decl.h
+++ b/pygit2/decl.h
@@ -535,6 +535,7 @@ int git_repository_init_ext(
 
 int git_repository_set_head(git_repository *repo, const char *refname, const git_signature *signature, const char *log_message);
 int git_repository_set_head_detached(git_repository *repo, const git_oid *commitish, const git_signature *signature, const char *log_message);
+int git_graph_ahead_behind(size_t *ahead, size_t *behind, git_repository *repo, const git_oid *local, const git_oid *upstream);
 
 /*
  * git_index

--- a/src/repository.c
+++ b/src/repository.c
@@ -1433,6 +1433,24 @@ Repository_reset(Repository *self, PyObject* args)
     Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(Repository_expand_id__doc__,
+    "expand_id(hex) -> Oid\n"
+    "\n"
+    "Expand a string into a full Oid according to the objects in this repsitory.\n");
+
+PyObject *
+Repository_expand_id(Repository *self, PyObject *py_hex)
+{
+    git_oid oid;
+    int err;
+
+    err = py_oid_to_git_oid_expand(self->repo, py_hex, &oid);
+    if (err < 0)
+        return NULL;
+
+    return git_oid_to_python(&oid);
+}
+
 PyMethodDef Repository_methods[] = {
     METHOD(Repository, create_blob, METH_VARARGS),
     METHOD(Repository, create_blob_fromworkdir, METH_VARARGS),
@@ -1461,6 +1479,7 @@ PyMethodDef Repository_methods[] = {
     METHOD(Repository, listall_branches, METH_VARARGS),
     METHOD(Repository, create_branch, METH_VARARGS),
     METHOD(Repository, reset, METH_VARARGS),
+    METHOD(Repository, expand_id, METH_O),
     METHOD(Repository, _from_c, METH_VARARGS),
     METHOD(Repository, _disown, METH_NOARGS),
     {NULL}

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -156,6 +156,11 @@ class RepositoryTest(utils.BareRepoTestCase):
             commit.message)
         self.assertRaises(ValueError, self.repo.__getitem__, too_short_prefix)
 
+    def test_expand_id(self):
+        commit_sha = '5fe808e8953c12735680c257f56600cb0de44b10'
+        expanded = self.repo.expand_id(commit_sha[:7])
+        self.assertEqual(commit_sha, expanded.hex)
+
     @unittest.skipIf(__pypy__ is not None, "skip refcounts checks in pypy")
     def test_lookup_commit_refcount(self):
         start = sys.getrefcount(self.repo)

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -300,6 +300,17 @@ class RepositoryTest_II(utils.RepoTestCase):
         self.assertEqual(commit.hex,
                          'acecd5ea2924a4b900e7e149496e1f4b57976e51')
 
+    def test_ahead_behind(self):
+        ahead, behind = self.repo.ahead_behind('5ebeeebb320790caf276b9fc8b24546d63316533',
+                                               '4ec4389a8068641da2d6578db0419484972284c8')
+        self.assertEqual(1, ahead)
+        self.assertEqual(2, behind)
+
+        ahead, behind = self.repo.ahead_behind('4ec4389a8068641da2d6578db0419484972284c8',
+                                               '5ebeeebb320790caf276b9fc8b24546d63316533')
+        self.assertEqual(2, ahead)
+        self.assertEqual(1, behind)
+
     def test_reset_hard(self):
         ref = "5ebeeebb320790caf276b9fc8b24546d63316533"
         with open(os.path.join(self.repo.workdir, "hello.txt")) as f:


### PR DESCRIPTION
This lets us ask how many diverging commits each side of two histories have.

Unfortunately the libgit2 function is currently buggy, so we might want to avoid merging until we can create some tests which are actually accurate.