### PR TITLE
merge: set the checkout strategy to SAFE_CREATE

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -609,6 +609,7 @@ Repository_merge(Repository *self, PyObject *py_oid)
     if (err < 0)
         return Error_set(err);
 
+    checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE_CREATE;
     err = git_merge(self->repo,
                     (const git_merge_head **)&oid_merge_head, 1,
                     &merge_opts, &checkout_opts);


### PR DESCRIPTION
The expectation is set with Repository.checkout()'s default strategy and
the documentation text that we will write the merged content of the
files to the workdir. We however fail to override the default checkout
strategy when calling git_merge() which results in a DRY_RUN strategy
and no files being changed.

Set the checkout strategy to SAFE_CREATE to match expectations and text.
