### PR TITLE
remote: clear self handle only on error

### DIFF
--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -210,8 +210,9 @@ class Remote(object):
         err = C.git_remote_set_callbacks(self._remote, callbacks)
         try:
             check_error(err)
-        finally:
+        except:
             self._self_handle = None
+            raise
 
         if signature:
             ptr = signature._pointer[:]


### PR DESCRIPTION
When setting the callbacks fails, we want to clear self._self_handle so
we don't leak a pointer to ourselves.

The current code used a 'finally' clause which clears it
unconditionally, which means that by the time the fetch starts, we have
no guarantee that the handle will be valid.

Replace that with an except and re-raise to make sure we only clear it
here if there was an error.
