### PR TITLE
Properly initialize the clone options

### DIFF
--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -82,7 +82,7 @@ def init_repository(path, bare=False,
 
     # Options
     options = ffi.new('git_repository_init_options *')
-    options.version = 1
+    C.git_repository_init_init_options(options, C.GIT_REPOSITORY_INIT_OPTIONS_VERSION)
     options.flags = flags
     options.mode = mode
     options.workdir_path = to_bytes(workdir_path)

--- a/pygit2/decl.h
+++ b/pygit2/decl.h
@@ -462,6 +462,9 @@ typedef struct {
 	const char *origin_url;
 } git_repository_init_options;
 
+#define GIT_REPOSITORY_INIT_OPTIONS_VERSION ...
+int git_repository_init_init_options(git_repository_init_options *opts, int version);
+
 int git_repository_init(
 	git_repository **out,
 	const char *path,


### PR DESCRIPTION
libgit2 provides an initialization function to set sane defaults. Use
that instead of setting the version by hand, as that's not the only
thing it does.

Using C.git_clone_init_options() sets the checkout strategy to SAFE,
which will checkout the files after the clone, instead of the implicit
NONE which we're setting by hand.

This fixes #425,
