### PR TITLE
Object or the Index are never False

### DIFF
--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -94,6 +94,11 @@ class Index(object):
     def __iter__(self):
         return IndexIterator(self)
 
+    def __bool__(self):
+        return True
+
+    __nonzero__ = __bool__
+
     def read(self, force=True):
         """Update the contents the Index
 

--- a/src/object.c
+++ b/src/object.c
@@ -184,6 +184,12 @@ Object_peel(Object *self, PyObject *py_type)
     return wrap_object(peeled, self->repo);
 }
 
+int
+Object___nonzero__(PyObject *self)
+{
+    return 1;
+}
+
 PyGetSetDef Object_getseters[] = {
     GETTER(Object, oid),
     GETTER(Object, id),
@@ -199,6 +205,36 @@ PyMethodDef Object_methods[] = {
     {NULL}
 };
 
+#if PY_MAJOR_VERSION == 2 || defined(PYPY_VERSION)
+static PyNumberMethods Object_as_number = {
+    0, /* nb_add */
+    0, /* nb_subtract */
+    0, /* nb_multiply */
+    0, /* nb_divide */
+    0, /* nb_remainder */
+    0, /* nb_divmod */
+    0, /* nb_power */
+    0, /* nb_negative */
+    0, /* nb_positive */
+    0, /* nb_absolute */
+    Object___nonzero__, /* nb_nonzero */
+    /* There are a lot more, we we don't need any of them */
+};
+#else
+static PyNumberMethods Object_as_number = {
+    0, /* nb_add */
+    0, /* nb_subtract */
+    0, /* nb_divide */
+    0, /* nb_remainder */
+    0, /* nb_divmod */
+    0, /* nb_power */
+    0, /* nb_negative */
+    0, /* nb_positive */
+    0, /* nb_absolute */
+    Object___nonzero__, /* nb_nonzero */
+    /* There are a lot more, we we don't need any of them */
+};
+#endif
 
 PyDoc_STRVAR(Object__doc__, "Base class for Git objects.");
 
@@ -213,7 +249,7 @@ PyTypeObject ObjectType = {
     0,                                         /* tp_setattr        */
     0,                                         /* tp_compare        */
     0,                                         /* tp_repr           */
-    0,                                         /* tp_as_number      */
+    &Object_as_number,                         /* tp_as_number      */
     0,                                         /* tp_as_sequence    */
     0,                                         /* tp_as_mapping     */
     0,                                         /* tp_hash           */

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -50,6 +50,9 @@ class IndexTest(utils.RepoTestCase):
     def test_index(self):
         self.assertNotEqual(None, self.repo.index)
 
+    def test_nonzero(self):
+        self.assertTrue(Index())
+
     def test_read(self):
         index = self.repo.index
         self.assertEqual(len(index), 2)

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -33,7 +33,7 @@ from os.path import dirname, join
 import unittest
 
 import pygit2
-from pygit2 import GIT_OBJ_TREE, GIT_OBJ_TAG, Tree, Tag
+from pygit2 import GIT_OBJ_TREE, GIT_OBJ_TAG, GIT_OBJ_BLOB, Tree, Tag
 from . import utils
 
 
@@ -77,6 +77,13 @@ class ObjectTest(utils.RepoTestCase):
         commit = self.repo[commit_id]
 
         self.assertRaises(ValueError, commit.peel, Tag)
+
+    def test_nonzero(self):
+        empty_tree_id = self.repo.TreeBuilder().write()
+        self.assertTrue(self.repo[empty_tree_id])
+
+        empty_blob_id = self.repo.write(GIT_OBJ_BLOB, '')
+        self.assertTrue(self.repo[empty_tree_id])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The sequence interface, with `len(X)` returning 0 makes Python consider the object falsy, which is nonsensical. Always consider these to be True.

This fixes #432 