### PR TITLE
index: Add missing 'tree' entry to diff_to_tree docstring argspec

### DIFF
--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -241,7 +241,7 @@ class Index(object):
         return Diff.from_c(bytes(ffi.buffer(cdiff)[:]), self._repo)
 
     def diff_to_tree(self, tree, flags=0, context_lines=3, interhunk_lines=0):
-        """diff_to_tree(flags=0, context_lines=3, interhunk_lines=0) -> Diff
+        """diff_to_tree(tree, flags=0, context_lines=3, interhunk_lines=0) -> Diff
 
         Diff the index against a tree
 


### PR DESCRIPTION
It's been missing since the original argspec was added with 5ed9eb4
(Add documentation for conflicts and fixup Index, 2014-07-10).

Maybe it's better to auto-generate these for the docs?  For example:

```
>>> import inspect
>>> import pygit2
>>> argspec = inspect.getargspec(pygit2.index.Index.diff_to_tree)
>>> inspect.formatargspec(args=argspec.args[1:], varargs=argspec.varargs,
...     varkw=argspec.keywords, defaults=argspec.defaults)
'(tree, flags=0, context_lines=3, interhunk_lines=0)'
```

Where the `[1:]` is just to drop the `self` entry.  I imagine there's
way to get Sphinx's automethod to do this sort of thing automatically,
but I don't know what that way is.
