### PR TITLE
docs/working-copy: Replace 'del index[path]' with index.remove(path)

### DIFF
--- a/docs/working-copy.rst
+++ b/docs/working-copy.rst
@@ -19,7 +19,7 @@ Iterate over all entries of the index::
 Index write::
 
     >>> index.add('path/to/file')          # git add
-    >>> del index['path/to/file']          # git rm
+    >>> index.remove('path/to/file')       # git rm
     >>> index.write()                      # don't forget to save the changes
 
 Custom entries::


### PR DESCRIPTION
Catch up with b12a5960 (Remove "del index[xxx]" from the API,
2013-05-02).
