### PR TITLE
Introduce RemoteCollection

### DIFF
--- a/docs/remotes.rst
+++ b/docs/remotes.rst
@@ -2,10 +2,14 @@
 Remotes
 **********************************************************************
 
-
 .. autoattribute:: pygit2.Repository.remotes
 .. automethod:: pygit2.Repository.create_remote
 
+The remote collection
+==========================
+
+.. autoclass:: pygit2.remote.RemoteCollection
+   :members:
 
 The Remote type
 ====================

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -167,6 +167,19 @@ class RepositoryTest(utils.RepoTestCase):
         remote = self.repo.create_remote(name, url)
         self.assertTrue(remote.name in [x.name for x in self.repo.remotes])
 
+    def test_remote_collection(self):
+        remote = self.repo.remotes['origin']
+        self.assertEqual(REMOTE_NAME, remote.name)
+        self.assertEqual(REMOTE_URL, remote.url)
+
+        with self.assertRaises(KeyError):
+            self.repo.remotes['upstream']
+
+        name = 'upstream'
+        url = 'git://github.com/libgit2/pygit2.git'
+        remote = self.repo.remotes.create(name, url)
+        self.assertTrue(remote.name in [x.name for x in self.repo.remotes])
+
 
     def test_remote_save(self):
         remote = self.repo.remotes[0]


### PR DESCRIPTION
This lets us look up remotes by name, which is not possible by just
returning the list of remotes.

Move remote creation to Repostiory.remotes.create() and keep the old
Repository.create_remote() for compatibility, delegating to this new
way.

Existing code should keep working, but this moves us towards what we'd
need for a better interface in 0.22 which makes remote renaming and
deleting work with a name rather than an instance and would make sense
to exist as part of an Remote.remotes object.
