### PR TITLE
Get rid of allocfmt()

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -31,6 +31,7 @@
 #include "error.h"
 #include "types.h"
 #include "utils.h"
+#include "oid.h"
 #include "diff.h"
 
 extern PyObject *GitError;
@@ -81,8 +82,8 @@ wrap_patch(git_patch *patch)
         py_patch->status = git_diff_status_char(delta->status);
         py_patch->similarity = delta->similarity;
         py_patch->flags = delta->flags;
-        py_patch->old_id = git_oid_allocfmt(&delta->old_file.id);
-        py_patch->new_id = git_oid_allocfmt(&delta->new_file.id);
+        py_patch->old_id = git_oid_to_python(&delta->old_file.id);
+        py_patch->new_id = git_oid_to_python(&delta->new_file.id);
 
         git_patch_line_stats(NULL, &additions, &deletions, patch);
         py_patch->additions = additions;
@@ -150,8 +151,8 @@ static void
 Patch_dealloc(Patch *self)
 {
     Py_CLEAR(self->hunks);
-    free(self->old_id);
-    free(self->new_id);
+    Py_CLEAR(self->old_id);
+    Py_CLEAR(self->new_id);
     /* We do not have to free old_file_path and new_file_path, they will
      * be freed by git_diff_list_free in Diff_dealloc */
     PyObject_Del(self);
@@ -160,8 +161,8 @@ Patch_dealloc(Patch *self)
 PyMemberDef Patch_members[] = {
     MEMBER(Patch, old_file_path, T_STRING, "old file path"),
     MEMBER(Patch, new_file_path, T_STRING, "new file path"),
-    MEMBER(Patch, old_id, T_STRING, "old oid"),
-    MEMBER(Patch, new_id, T_STRING, "new oid"),
+    MEMBER(Patch, old_id, T_OBJECT, "old oid"),
+    MEMBER(Patch, new_id, T_OBJECT, "new oid"),
     MEMBER(Patch, status, T_CHAR, "status"),
     MEMBER(Patch, similarity, T_INT, "similarity"),
     MEMBER(Patch, hunks, T_OBJECT, "hunks"),

--- a/src/note.c
+++ b/src/note.c
@@ -44,8 +44,8 @@ Note_remove(Note *self, PyObject* args)
 {
     char *ref = "refs/notes/commits";
     int err = GIT_ERROR;
-    git_oid annotated_id;
     Signature *py_author, *py_committer;
+    Oid *id;
 
     if (!PyArg_ParseTuple(args, "O!O!|s",
                           &SignatureType, &py_author,
@@ -53,12 +53,9 @@ Note_remove(Note *self, PyObject* args)
                           &ref))
         return NULL;
 
-    err = git_oid_fromstr(&annotated_id, self->annotated_id);
-    if (err < 0)
-        return Error_set(err);
-
+    id = (Oid *) self->annotated_id;
     err = git_note_remove(self->repo->repo, ref, py_author->signature,
-        py_committer->signature, &annotated_id);
+        py_committer->signature, &id->oid);
     if (err < 0)
         return Error_set(err);
 
@@ -90,7 +87,7 @@ static void
 Note_dealloc(Note *self)
 {
     Py_CLEAR(self->repo);
-    free(self->annotated_id);
+    Py_CLEAR(self->annotated_id);
     git_note_free(self->note);
     PyObject_Del(self);
 }
@@ -102,7 +99,7 @@ PyMethodDef Note_methods[] = {
 };
 
 PyMemberDef Note_members[] = {
-    MEMBER(Note, annotated_id, T_STRING, "id of the annotated object."),
+    MEMBER(Note, annotated_id, T_OBJECT, "id of the annotated object."),
     {NULL}
 };
 
@@ -229,7 +226,7 @@ wrap_note(Repository* repo, git_oid* annotated_id, const char* ref)
 
     py_note->repo = repo;
     Py_INCREF(repo);
-    py_note->annotated_id = git_oid_allocfmt(annotated_id);
+    py_note->annotated_id = git_oid_to_python(annotated_id);
 
     return (PyObject*) py_note;
 }

--- a/src/reference.c
+++ b/src/reference.c
@@ -60,8 +60,8 @@ RefLogIter_iternext(RefLogIter *self)
         entry = git_reflog_entry_byindex(self->reflog, self->i);
         py_entry = PyObject_New(RefLogEntry, &RefLogEntryType);
 
-        py_entry->oid_old = git_oid_allocfmt(git_reflog_entry_id_old(entry));
-        py_entry->oid_new = git_oid_allocfmt(git_reflog_entry_id_new(entry));
+        py_entry->oid_old = git_oid_to_python(git_reflog_entry_id_old(entry));
+        py_entry->oid_new = git_oid_to_python(git_reflog_entry_id_new(entry));
         py_entry->message = strdup(git_reflog_entry_message(entry));
         err = git_signature_dup(&py_entry->signature,
                                 git_reflog_entry_committer(entry));
@@ -431,8 +431,8 @@ RefLogEntry_init(RefLogEntry *self, PyObject *args, PyObject *kwds)
 static void
 RefLogEntry_dealloc(RefLogEntry *self)
 {
-    free(self->oid_old);
-    free(self->oid_new);
+    Py_CLEAR(self->oid_old);
+    Py_CLEAR(self->oid_new);
     free(self->message);
     git_signature_free(self->signature);
     PyObject_Del(self);

--- a/src/types.h
+++ b/src/types.h
@@ -79,7 +79,7 @@ typedef struct {
     PyObject_HEAD
     Repository *repo;
     git_note *note;
-    char* annotated_id;
+    PyObject* annotated_id;
 } Note;
 
 typedef struct {
@@ -105,8 +105,8 @@ typedef struct {
     PyObject* hunks;
     const char * old_file_path;
     const char * new_file_path;
-    char* old_id;
-    char* new_id;
+    PyObject* old_id;
+    PyObject* new_id;
     char status;
     unsigned similarity;
     unsigned additions;
@@ -164,8 +164,8 @@ typedef Reference Branch;
 typedef struct {
     PyObject_HEAD
     git_signature *signature;
-    char *oid_old;
-    char *oid_new;
+    PyObject *oid_old;
+    PyObject *oid_new;
     char *message;
 } RefLogEntry;
 

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -261,9 +261,9 @@ class DiffTest(utils.BareRepoTestCase):
         commit_a = self.repo[COMMIT_SHA1_1]
         commit_b = self.repo[COMMIT_SHA1_2]
         patch = commit_a.tree.diff_to_tree(commit_b.tree)[0]
-        self.assertEqual(patch.old_id,
+        self.assertEqual(patch.old_id.hex,
                          '7f129fd57e31e935c6d60a0c794efe4e6927664b')
-        self.assertEqual(patch.new_id,
+        self.assertEqual(patch.new_id.hex,
                          'af431f20fc541ed6d5afede3e2dc7160f6f01f16')
 
     def test_hunk_content(self):

--- a/test/test_note.py
+++ b/test/test_note.py
@@ -70,7 +70,7 @@ class NotesTest(utils.BareRepoTestCase):
 
     def test_iterate_notes(self):
         for i, note in enumerate(self.repo.notes()):
-            entry = (note.id.hex, note.message, note.annotated_id)
+            entry = (note.id.hex, note.message, note.annotated_id.hex)
             self.assertEqual(NOTES[i], entry)
 
     def test_iterate_non_existing_ref(self):


### PR DESCRIPTION
It is not possible to know how we can free the results of this
allocation, so we shouldn't be using this function.

We have a convention of returning Oid objects in pygit2, so let's keep
to that in these places.

---

The tests showed some issues if we just leave it to use `str` or `repr` to compare, though it likely won't affect anybody who is using this to print them out. So this may be a breaking change in certain situations.
