### PR TITLE
Latest Changes V0.21 + 1 of libgit2

### DIFF
--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -118,8 +118,8 @@ def _credentials_cb(cred_out, url, username_from_url, allowed, data):
 
 
 def clone_repository(
-        url, path, bare=False, ignore_cert_errors=False,
-        remote_name="origin", checkout_branch=None, credentials=None):
+        url, path, bare=False, remote_name="origin",
+        checkout_branch=None, credentials=None):
     """Clones a new Git repository from *url* in the given *path*.
 
     Returns a Repository class pointing to the newly cloned repository.
@@ -162,9 +162,7 @@ def clone_repository(
         opts.checkout_branch = checkout_branch_ref
 
     remote_name_ref = ffi.new('char []', to_bytes(remote_name))
-    opts.remote_name = remote_name_ref
 
-    opts.ignore_cert_errors = ignore_cert_errors
     opts.bare = bare
     if credentials:
         opts.remote_callbacks.credentials = _credentials_cb

--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -148,7 +148,8 @@ class Remote(object):
             raise ValueError("New remote name must be a non-empty string")
 
         problems = ffi.new('git_strarray *')
-        err = C.git_remote_rename(problems, self._remote, to_bytes(new_name))
+        err = C.git_remote_rename(problems, self._repo, self.name,
+                                  to_bytes(new_name))
         check_error(err)
 
         ret = strarray_to_strings(problems)
@@ -181,9 +182,10 @@ class Remote(object):
     def delete(self):
         """Remove this remote
 
-        All remote-tracking branches and configuration settings for the remote will be removed.
+        All remote-tracking branches and configuration settings for the remote
+        will be removed.
         """
-        err = C.git_remote_delete(self._remote)
+        err = C.git_remote_delete(self._repo, self.name)
         check_error(err)
 
     def save(self):
@@ -231,7 +233,8 @@ class Remote(object):
         self._stored_exception = None
 
         try:
-            err = C.git_remote_fetch(self._remote, ptr, to_bytes(message))
+            err = C.git_remote_fetch(self._remote, self.fetch_refspecs, ptr,
+                                     to_bytes(message))
             if self._stored_exception:
                 raise self._stored_exception
 

--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -113,7 +113,8 @@ class Repository(_Repository):
             l = [None] * names.count
             cremote = ffi.new('git_remote **')
             for i in range(names.count):
-                err = C.git_remote_load(cremote, self._repo, names.strings[i])
+                err = C.git_remote_lookup(cremote, self._repo,
+                                          names.strings[i])
                 check_error(err)
 
                 l[i] = Remote(self, cremote[0])

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -209,13 +209,14 @@ moduleinit(PyObject* m)
     ADD_CONSTANT_INT(m, GIT_OBJ_TREE)
     ADD_CONSTANT_INT(m, GIT_OBJ_BLOB)
     ADD_CONSTANT_INT(m, GIT_OBJ_TAG)
-    /* Valid modes for index and tree entries. */
+    /* Valid modes for index and tree entries.
     ADD_CONSTANT_INT(m, GIT_FILEMODE_NEW)
     ADD_CONSTANT_INT(m, GIT_FILEMODE_TREE)
     ADD_CONSTANT_INT(m, GIT_FILEMODE_BLOB)
     ADD_CONSTANT_INT(m, GIT_FILEMODE_BLOB_EXECUTABLE)
     ADD_CONSTANT_INT(m, GIT_FILEMODE_LINK)
     ADD_CONSTANT_INT(m, GIT_FILEMODE_COMMIT)
+    */
 
     /*
      * Log


### PR DESCRIPTION
The latest version of pygit2 doesn't build against the latest version of libgit2, this Pull Requests fixes the changes from libgit2 in pygit2. Although does not fix implementation, I'll start on fixing implementation if these changes appear sane to begin with. 
