### PR TITLE
Make pygit work (for FAForever) in a frozen environment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.h text eol=lf

--- a/pygit2/_utils.py
+++ b/pygit2/_utils.py
@@ -79,7 +79,11 @@ def get_ffi():
     ffi = cffi.FFI()
 
     # Load C definitions
-    dir_path = dirname(abspath(inspect.getfile(inspect.currentframe())))
+    if getattr(sys, 'frozen', False):
+        dir_path = dirname(abspath(sys.executable))
+    else:
+        dir_path = dirname(abspath(__file__))
+
     decl_path = os.path.join(dir_path, 'decl.h')
     with codecs.open(decl_path, 'r', 'utf-8') as header:
         ffi.cdef(header.read())


### PR DESCRIPTION
Two things here:
  - Ensure git stores headers with LF line endings, so it's parseable by CFFI at runtime even on windows.
  - If sys has attribute 'Frozen', we need to look in a different place for the decl.h file. This naively uses the current path of the executable, as I don't know where else to put it.

I'm not sure you'll want this in main, but it posed problems for me when using pygit2 in a frozen executable (Using cx_Freeze), where the python modules are loaded from a .zip file.