### PR TITLE
Fix data type of options in init_repository()

### DIFF
--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -86,11 +86,26 @@ def init_repository(path, bare=False,
     C.git_repository_init_init_options(options, C.GIT_REPOSITORY_INIT_OPTIONS_VERSION)
     options.flags = flags
     options.mode = mode
-    options.workdir_path = to_bytes(workdir_path)
-    options.description = to_bytes(description)
-    options.template_path = to_bytes(template_path)
-    options.initial_head = to_bytes(initial_head)
-    options.origin_url = to_bytes(origin_url)
+
+    if workdir_path:
+        workdir_path_ref = ffi.new('char []', to_bytes(workdir_path))
+        options.workdir_path = workdir_path_ref
+
+    if description:
+        description_ref = ffi.new('char []', to_bytes(description))
+        options.description = description_ref
+
+    if template_path:
+        template_path_ref = ffi.new('char []', to_bytes(template_path))
+        options.template_path = template_path_ref
+
+    if initial_head:
+        initial_head_ref = ffi.new('char []', to_bytes(initial_head))
+        options.initial_head = initial_head_ref
+
+    if origin_url:
+        origin_url_ref = ffi.new('char []', to_bytes(origin_url))
+        options.origin_url = origin_url_ref
 
     # Call
     crepository = ffi.new('git_repository **')


### PR DESCRIPTION
This fixes errors such as the following which occur when using any of the optional string parameters of init_repository():

```
Traceback (most recent call last):
  [...]
    pygit2.init_repository(repo_path, True, template_path=template_path)
  File "/usr/lib/python3.4/site-packages/pygit2/__init__.py", line 89, in init_repository
    options.template_path = to_str(template_path)
TypeError: initializer for ctype 'char *' must be a cdata pointer, not bytes
```