### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -296,14 +296,14 @@ Diff_patch__get__(Diff *self)
     git_patch* patch;
     git_buf buf = {NULL};
     int err = GIT_ERROR;
-    size_t i, len, num;
+    size_t i, num;
     PyObject *py_patch = NULL;
 
     num = git_diff_num_deltas(self->diff);
     if (num == 0)
         Py_RETURN_NONE;
 
-    for (i = 0, len = 1; i < num ; ++i) {
+    for (i = 0; i < num ; ++i) {
         err = git_patch_from_diff(&patch, self->diff, i);
         if (err < 0)
             goto cleanup;

--- a/src/types.h
+++ b/src/types.h
@@ -103,8 +103,8 @@ typedef struct {
 typedef struct {
     PyObject_HEAD
     PyObject* hunks;
-    const char * old_file_path;
-    const char * new_file_path;
+    char * old_file_path;
+    char * new_file_path;
     PyObject* old_id;
     PyObject* new_id;
     char status;


### PR DESCRIPTION
My last patch introduced compiler warnings.  This patch fixes them and one other (`len` was unused).