### PR TITLE
Add support for libgit2 feature detection

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1,0 +1,8 @@
+**********************************************************************
+Feature detection
+**********************************************************************
+
+.. py:data:: pygit2.features
+
+   This variable contains a combination of `GIT_FEATURE_*` flags,
+   indicating which features a particular build of libgit2 supports.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,7 @@ Usage guide:
    remotes
    blame
    settings
+   features
 
 
 Indices and tables

--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -221,3 +221,8 @@ def clone_into(repo, remote, branch=None):
     check_error(err)
 
 settings = Settings()
+
+features = C.git_libgit2_features()
+GIT_FEATURE_THREADS = C.GIT_FEATURE_THREADS
+GIT_FEATURE_HTTPS = C.GIT_FEATURE_HTTPS
+GIT_FEATURE_SSH = C.GIT_FEATURE_SSH

--- a/pygit2/decl.h
+++ b/pygit2/decl.h
@@ -74,6 +74,12 @@ typedef struct git_signature {
 	git_time when;
 } git_signature;
 
+#define GIT_FEATURE_THREADS ...
+#define GIT_FEATURE_HTTPS ...
+#define GIT_FEATURE_SSH ...
+
+int git_libgit2_features(void);
+
 const git_error * giterr_last(void);
 
 void git_strarray_free(git_strarray *array);


### PR DESCRIPTION
This lets us ask the library whether it supports threading, https and
ssh.

---

I wasn't sure whether to leave it with the int as-is or convert the result to a list of strings, so you can do

    if 'ssh' in pygit2.features:

instead of

    if pygit2.features & pygit2.GIT_FEATURE_SSH:

The former seems more in line with what a pure-python library would do, but we do expose the underlying flags in most places.