### PR TITLE
Fix handling of symlinks in write_archive().

### DIFF
--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -623,5 +623,7 @@ class Repository(_Repository):
                 info.type = archive.SYMTYPE
                 info.linkname = content
                 info.mode = 0o777 # symlinks get placeholder
-
-            archive.addfile(info, StringIO(content))
+                info.size = 0
+                archive.addfile(info)
+            else:
+                archive.addfile(info, StringIO(content))


### PR DESCRIPTION
`repository.write_archive()` writes the contents of a file for symlinks, which causes tar to skip those bytes when extracting, and fail with an error code.  This patch fixes that issue.