### PR TITLE
Safer handling of string arrays

### DIFF
--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -32,7 +32,7 @@ from __future__ import absolute_import, unicode_literals
 from _pygit2 import Oid, Tree, Diff
 from .errors import check_error
 from .ffi import ffi, C
-from .utils import is_string, strings_to_strarray, to_bytes, to_str
+from .utils import is_string, to_bytes, to_str, StrArray
 
 
 class Index(object):
@@ -175,9 +175,9 @@ class Index(object):
         If pathspecs are specified, only files matching those pathspecs will
         be added.
         """
-        arr, refs = strings_to_strarray(pathspecs)
-        err = C.git_index_add_all(self._index, arr, 0, ffi.NULL, ffi.NULL)
-        check_error(err, True)
+        with StrArray(pathspecs) as arr:
+            err = C.git_index_add_all(self._index, arr, 0, ffi.NULL, ffi.NULL)
+            check_error(err, True)
 
     def add(self, path_or_entry):
         """add([path|entry])

--- a/pygit2/utils.py
+++ b/pygit2/utils.py
@@ -50,34 +50,34 @@ def strarray_to_strings(arr):
     return l
 
 
-def strings_to_strarray(l):
-    """Convert a list of strings to a git_strarray
+class StrArray(object):
+    """A git_strarray wrapper
 
-    We return first the git_strarray* you can pass to libgit2 and a
-    list of references to the memory, which we must keep around for as
-    long as the git_strarray must live.
+    Use this in order to get a git_strarray* to pass to libgit2 out of a
+    list of strings. This has a context manager, which you should use, e.g.
+
+        with StrArray(list_of_strings) as arr:
+            C.git_function_that_takes_strarray(arr)
     """
 
-    if not isinstance(l, list):
-        raise TypeError("Value must be a list")
+    def __init__(self, l):
+        if not isinstance(l, list):
+            raise TypeError("Value must be a list")
 
-    arr = ffi.new('git_strarray *')
-    strings = ffi.new('char *[]', len(l))
+        arr = ffi.new('git_strarray *')
+        strings = [None] * len(l)
+        for i in range(len(l)):
+            if not is_string(l[i]):
+                raise TypeError("Value must be a string")
 
-    # We need refs in order to keep a reference to the value returned
-    # by the ffi.new(). Otherwise, they will be freed and the memory
-    # re-used, with less than great consequences.
-    refs = [None] * len(l)
+            strings[i] = ffi.new('char []', to_bytes(l[i]))
 
-    for i in range(len(l)):
-        if not is_string(l[i]):
-            raise TypeError("Value must be a string")
+        self._arr = ffi.new('char *[]', strings)
+        self._strings = strings
+        self.array = ffi.new('git_strarray *', [self._arr, len(strings)])
 
-        s = ffi.new('char []', to_bytes(l[i]))
-        refs[i] = s
-        strings[i] = s
+    def __enter__(self):
+        return self.array
 
-    arr.strings = strings
-    arr.count = len(l)
-
-    return arr, refs
+    def __exit__(self, type, value, traceback):
+        pass


### PR DESCRIPTION
We need to keep hold of the strings which we create. We must also hold
on to the array of strings which we assing to our git_strarray.

We were not doing the latter, which meant that our strings may have been
freed too early, leaving us with with memory access errors (though often
not leading to a crash due to the custom allocator in python).

As we need to keep hold of two/three pieces of information, this looks
like a good place to introduce a context manager. This allows us to
keep these pointers alive without burdening the call sites with a return
of multiple objects they have no use for.