### PR TITLE
Introduce Repository.merge_trees()

### DIFF
--- a/docs/merge.rst
+++ b/docs/merge.rst
@@ -33,3 +33,13 @@ can create a commit with these two parents.
    >>> tree = repo.index.write_tree()
    >>> new_commit = repo.create_commit('HEAD', user, user, tree,
                                        [repo.head.target, other_branch_tip])
+
+Lower-level methods
+===================
+
+These methods allow more direct control over how to perform the
+merging. They do not modify the working directory and return an
+in-memory Index representing the result of the merge.
+
+.. automethod:: pygit2.Repository.merge_commits
+.. automethod:: pygit2.Repository.merge_trees

--- a/pygit2/decl.h
+++ b/pygit2/decl.h
@@ -661,3 +661,4 @@ typedef struct {
 
 int git_merge_init_options(git_merge_options *opts,	unsigned int version);
 int git_merge_commits(git_index **out, git_repository *repo, const git_commit *our_commit, const git_commit *their_commit, const git_merge_options *opts);
+int git_merge_trees(git_index **out, git_repository *repo, const git_tree *ancestor_tree, const git_tree *our_tree, const git_tree *their_tree, const git_merge_options *opts);

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -165,3 +165,29 @@ class MergeCommitsTest(utils.RepoTestCaseForMerging):
         self.assertTrue(merge_index.conflicts is None)
 
         self.assertRaises(ValueError, self.repo.merge_commits, self.repo.head.target, branch_head_hex, favor='foo')
+
+class MergeTreesTest(utils.RepoTestCaseForMerging):
+
+    def test_merge_trees(self):
+        branch_head_hex = '03490f16b15a09913edb3a067a3dc67fbb8d41f1'
+        branch_id = self.repo.get(branch_head_hex).id
+        ancestor_id = self.repo.merge_base(self.repo.head.target, branch_id)
+
+        merge_index = self.repo.merge_trees(ancestor_id, self.repo.head.target, branch_head_hex)
+        self.assertTrue(merge_index.conflicts is None)
+        merge_commits_tree = merge_index.write_tree(self.repo)
+
+        self.repo.merge(branch_id)
+        index = self.repo.index
+        self.assertTrue(index.conflicts is None)
+        merge_tree = index.write_tree()
+
+        self.assertEqual(merge_tree, merge_commits_tree)
+
+    def test_merge_commits_favor(self):
+        branch_head_hex = '1b2bae55ac95a4be3f8983b86cd579226d0eb247'
+        ancestor_id = self.repo.merge_base(self.repo.head.target, branch_head_hex)
+        merge_index = self.repo.merge_trees(ancestor_id, self.repo.head.target, branch_head_hex, favor='ours')
+        self.assertTrue(merge_index.conflicts is None)
+
+        self.assertRaises(ValueError, self.repo.merge_trees, ancestor_id, self.repo.head.target, branch_head_hex, favor='foo')


### PR DESCRIPTION
This allows us more direct control over which trees to consider for merging.