### PR TITLE
Update git-show recipe

### DIFF
--- a/docs/recipes/git-show.rst
+++ b/docs/recipes/git-show.rst
@@ -45,7 +45,9 @@ Produce something like a ``git show`` message
 ======================================================================
 
 In order to display time zone information you have to create a subclass
-of tzinfo as described in the `Python datetime documentation`_::
+of tzinfo. In Python 3.2+ you can do this fairly directly. In older
+versions you have to make your own class as described in the `Python
+datetime documentation`_::
 
     from datetime import tzinfo, timedelta
     class FixedOffset(tzinfo):
@@ -67,10 +69,15 @@ of tzinfo as described in the `Python datetime documentation`_::
 
 Then you can make your message:
 
+    >>> # Until Python 2.7.9:
     >>> from __future__ import unicode_literals
     >>> from datetime import datetime
-    >>>
     >>> tzinfo  = FixedOffset(commit.author.offset)
+
+    >>> # From Python 3.2:
+    >>> from datetime import datetime, timezone, timedelta
+    >>> tzinfo  = timezone( timedelta(minutes=commit.author.offset) )
+    >>>
     >>> dt      = datetime.fromtimestamp(float(commit.author.time), tzinfo)
     >>> timestr = dt.strftime('%c %z')
     >>> msg     = '\n'.join(['commit {}'.format(commit.tree_id.hex),

--- a/docs/recipes/git-show.rst
+++ b/docs/recipes/git-show.rst
@@ -44,8 +44,8 @@ Show all files in commit
 Produce something like a ``git show`` message
 ======================================================================
 
-In order to display timezone information you have to create a subclass of
-tzinfo as described in the `Python datetime documentation`_::
+In order to display time zone information you have to create a subclass
+of tzinfo as described in the `Python datetime documentation`_::
 
     from datetime import tzinfo, timedelta
     class FixedOffset(tzinfo):
@@ -58,10 +58,10 @@ tzinfo as described in the `Python datetime documentation`_::
             return self.__offset
 
         def tzname(self, dt):
-            return None
+            return None # we don't know the time zone's name
 
         def dst(self, dt):
-            return timedelta(0) # dealing with DST would be too complicated
+            return timedelta(0) # we don't know about DST
 
 .. _Python datetime documentation: https://docs.python.org/2/library/datetime.html#tzinfo-objects
 

--- a/docs/recipes/git-show.rst
+++ b/docs/recipes/git-show.rst
@@ -31,7 +31,7 @@ Show SHA hash
 Show diff
 ======================================================================
 
-    >>> diff = commit.tree.diff()
+    >>> diff = commit.parents[0].tree.diff_to_tree(commit.tree)
 
 ======================================================================
 Show all files in commit
@@ -39,6 +39,22 @@ Show all files in commit
 
     >>> for e in commit.tree:
     >>>     print(e.name)
+
+======================================================================
+Produce something like a `git show` message
+======================================================================
+
+    >>> from __future__ import unicode_literals
+    >>> from datetime import datetime
+    >>> import pytz
+    >>> tzinfo  = pytz.timezone('Europe/Berlin')
+    >>> dt      = datetime.fromtimestamp(float(commit.commit_time), tzinfo)
+    >>> timestr = dt.strftime('%c %z')
+    >>> msg     = '\n'.join(['commit {}'.format(commit.tree_id.hex),
+    ...                      'Author: {} <{}>'.format(commit.author.name, commit.author.email),
+    ...                      'Date:   {}'.format(timestr),
+    ...                      '',
+    ...                      commit.message])
 
 ----------------------------------------------------------------------
 References


### PR DESCRIPTION
I couldn't get the diff as shown in the git-show recipe. Therefore
update it to what I think it should be. Maybe there is a better way.

Also add a section on how to assemble a git show-like message. It took
me quite some searching in the Python docs to find out how to do it,
especially the date and time part. So this might save people time. I
wanted to add something that gives me a git show --stat equivalent, but
couldn't figure it out.