### PR TITLE
make diff of blob to blob in `repository.diff` work

### DIFF
--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -381,14 +381,12 @@ class Repository(_Repository):
             try:
                 obj = obj.peel(Blob)
             except Exception:
-                pass
-
-            # And if that failed, try to get a tree, raising a type
-            # error if that still doesn't work
-            try:
-                obj = obj.peel(Tree)
-            except Exception:
-                raise TypeError('unexpected "%s"' % type(obj))
+              # And if that failed, try to get a tree, raising a type
+              # error if that still doesn't work
+              try:
+                  obj = obj.peel(Tree)
+              except Exception:
+                  raise TypeError('unexpected "%s"' % type(obj))
 
             return obj
 

--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -413,7 +413,7 @@ class Repository(_Repository):
 
         # Case 4: Diff blob to blob
         if isinstance(a, Blob) and isinstance(b, Blob):
-            raise NotImplementedError('git_diff_blob_to_blob()')
+            return a.diff(b)
 
         raise ValueError("Only blobs and treeish can be diffed")
 


### PR DESCRIPTION
I usually do `blob1.diff(blob2)` but I ran into this the other day and I figured I might as well just fix it. That said, it's not clear to me it's a good idea to have two different ways of doing (what seems to be) the same thing (i.e., `blob1.diff(blob2)` and `repo.diff(blob1, blob2)`) but I leave that up to you. (The other alternative is to have `repo.diff` be only for showing changes between WT, index, and head)