### PR TITLE
make pygit2 work with pyinstaller

### DIFF
--- a/pygit2/_utils.py
+++ b/pygit2/_utils.py
@@ -80,7 +80,10 @@ def get_ffi():
 
     # Load C definitions
     if getattr(sys, 'frozen', False):
-        dir_path = dirname(abspath(sys.executable))
+        if hasattr(sys, '_MEIPASS'):
+            dir_path = sys._MEIPASS
+        else:
+            dir_path = dirname(abspath(sys.executable))
     else:
         dir_path = dirname(abspath(__file__))
 


### PR DESCRIPTION
This makes pygit2 work with pyinstaller's onefile mode, and it should be a no-op if you are using something other than pyinstaller