### PR TITLE
Clarify docstring for Repository.create_commit

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -838,7 +838,7 @@ Repository_create_blob_fromdisk(Repository *self, PyObject *args)
 
 
 PyDoc_STRVAR(Repository_create_commit__doc__,
-  "create_commit(reference, author, committer, message, tree, parents[, encoding]) -> Oid\n"
+  "create_commit(reference_name, author, committer, message, tree, parents[, encoding]) -> Oid\n"
   "\n"
   "Create a new commit object, return its oid.");
 


### PR DESCRIPTION
Change the argument "reference" to "reference_name", because "reference"
might lead to the assumption that one has to pass a pygit2.Reference.