### PR TITLE
remote.py: Denote optional parameters as such

### DIFF
--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -178,7 +178,7 @@ class Remote(object):
         check_error(err)
 
     def fetch(self, signature=None, message=None):
-        """fetch(signature, message) -> TransferProgress
+        """fetch([signature[, message]]) -> TransferProgress
 
         Perform a fetch against this remote.
         """
@@ -296,8 +296,8 @@ class Remote(object):
         protocol error or unpack failure.
 
         :param [str] specs: push refspecs to use
-        :param Signature signature: signature to use when updating the tips
-        :param str message: message to use when updating the tips
+        :param Signature signature: signature to use when updating the tips (optional)
+        :param str message: message to use when updating the tips (optional)
 
         """
         # Get the default callbacks first


### PR DESCRIPTION
In the online documentation to Pygit2 it was not visible that (some of)
the parameters to Remote.fetch() and Remote.push() were optional. Fix
this. (I'm not sure if the way I did it is the idiomatic way of marking
a parameter optional in Python docstrings.)