### PR TITLE
Keep path references in merge_file_from_index

### DIFF
--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -551,9 +551,12 @@ class Repository(_Repository):
         """
         cmergeresult = ffi.new('git_merge_file_result *')
 
-        cancestor = ancestor._to_c()[0] if ancestor is not None else ffi.NULL
-        cours = ours._to_c()[0] if ours is not None else ffi.NULL
-        ctheirs = theirs._to_c()[0] if theirs is not None else ffi.NULL
+        cancestor, ancestor_str_ref = (
+            ancestor._to_c() if ancestor is not None else (ffi.NULL, ffi.NULL))
+        cours, ours_str_ref = (
+            ours._to_c() if ours is not None else (ffi.NULL, ffi.NULL))
+        ctheirs, theirs_str_ref = (
+            theirs._to_c() if theirs is not None else (ffi.NULL, ffi.NULL))
 
         err = C.git_merge_file_from_index(
                 cmergeresult, self._repo,


### PR DESCRIPTION
IndexEntry._to_c requires its caller to hold a reference to the path it
returns until it no longer needs the C structure.
Repository.merge_file_from_index was not doing so, causing the merge
text to contain garbage from freed memory in some cases.