### PR TITLE
Add hint to Diff.__iter__()

### DIFF
--- a/docs/diff.rst
+++ b/docs/diff.rst
@@ -35,6 +35,10 @@ The Diff type
 ====================
 
 .. autoattribute:: pygit2.Diff.patch
+.. method:: Diff.__iter__()
+
+   Returns an iterator over the deltas/patches in this diff.
+
 .. method:: Diff.__len__()
 
    Returns the number of deltas/patches in this diff.


### PR DESCRIPTION
I'm not the guy who looks at examples in the first place and I guess
there are other people like me. When I wanted find out how to get
information out of a Diff, I looked at the documented methods and didn't
find anything. Only later @cmn showed me the [p for p in diff] example
in the documentation. Add a short piece of information that gives a hint
to those who prefer the dry API docs.