### PR TITLE
Cherry-pick recipe: clean up after picking

### DIFF
--- a/docs/merge.rst
+++ b/docs/merge.rst
@@ -40,6 +40,10 @@ Cherrypick
 
 .. automethod:: pygit2.Repository.cherrypick
 
+Note that after a successful cherrypick you have to run
+:py:meth:`.Repository.state_cleanup` in order to get the repository out
+of cherrypicking mode.
+
 
 Lower-level methods
 ===================

--- a/docs/recipes/git-cherry-pick.rst
+++ b/docs/recipes/git-cherry-pick.rst
@@ -30,6 +30,8 @@ working copy and on-disk index.
                            cherry.message, tree_id, [basket.target])
         del basket # outdated, prevent from accidentally using it
 
+        repo.state_cleanup()
+
 
 ----------------------------------------------------------------------
 Cherry-picking a commit without a working copy


### PR DESCRIPTION
In b3025e3fe I had written that when following my recipe, the repository
remains in cherry-picking mode afterwards. In issue #516 I was told that
Repository.state_cleanup() is needed to correct that. Therefore add it
to the recipe.

Also add a note near the documentation for cherry-pick, so that nobody
will overlook this again. Apparently there are other times when you need
to do Repository.state_cleanup() as well, but it's not documented, I
don't know when and I don't want to take the time and find out. So leave
it at that for now.