### PR TITLE
Add DiffStats

### DIFF
--- a/docs/diff.rst
+++ b/docs/diff.rst
@@ -23,6 +23,10 @@ Examples
     >>> diff = repo.diff('HEAD^', 'HEAD~3')
     >>> patches = [p for p in diff]
 
+    # Get the stats for a diff
+    >>> diff = repo.diff('HEAD^', 'HEAD~3')
+    >>> diff.stats
+
     # Diffing the empty tree
     >>> tree = revparse_single('HEAD').tree
     >>> tree.diff_to_tree()
@@ -89,3 +93,11 @@ The DiffHunk type
 .. autoattribute:: pygit2.DiffHunk.new_start
 .. autoattribute:: pygit2.DiffHunk.new_lines
 .. autoattribute:: pygit2.DiffHunk.lines
+
+The DiffStats type
+====================
+
+.. autoattribute :: pygit2.DiffStats.insertions
+.. autoattribute :: pygit2.DiffStats.deletions
+.. autoattribute :: pygit2.DiffStats.files_changed
+.. automethod :: pygit2.DiffStats.format

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -48,6 +48,7 @@ extern PyTypeObject DiffDeltaType;
 extern PyTypeObject DiffFileType;
 extern PyTypeObject DiffHunkType;
 extern PyTypeObject DiffLineType;
+extern PyTypeObject DiffStatsType;
 extern PyTypeObject PatchType;
 extern PyTypeObject TreeType;
 extern PyTypeObject TreeBuilderType;
@@ -294,12 +295,14 @@ moduleinit(PyObject* m)
     INIT_TYPE(DiffFileType, NULL, NULL)
     INIT_TYPE(DiffHunkType, NULL, NULL)
     INIT_TYPE(DiffLineType, NULL, NULL)
+    INIT_TYPE(DiffStatsType, NULL, NULL)
     INIT_TYPE(PatchType, NULL, NULL)
     ADD_TYPE(m, Diff)
     ADD_TYPE(m, DiffDelta)
     ADD_TYPE(m, DiffFile)
     ADD_TYPE(m, DiffHunk)
     ADD_TYPE(m, DiffLine)
+    ADD_TYPE(m, DiffStats)
     ADD_TYPE(m, Patch)
     ADD_CONSTANT_INT(m, GIT_DIFF_NORMAL)
     ADD_CONSTANT_INT(m, GIT_DIFF_REVERSE)
@@ -322,6 +325,11 @@ moduleinit(PyObject* m)
     ADD_CONSTANT_INT(m, GIT_DIFF_INCLUDE_TYPECHANGE)
     ADD_CONSTANT_INT(m, GIT_DIFF_INCLUDE_TYPECHANGE_TREES)
     ADD_CONSTANT_INT(m, GIT_DIFF_RECURSE_IGNORED_DIRS)
+    ADD_CONSTANT_INT(m, GIT_DIFF_STATS_NONE)
+    ADD_CONSTANT_INT(m, GIT_DIFF_STATS_FULL)
+    ADD_CONSTANT_INT(m, GIT_DIFF_STATS_SHORT)
+    ADD_CONSTANT_INT(m, GIT_DIFF_STATS_NUMBER)
+    ADD_CONSTANT_INT(m, GIT_DIFF_STATS_INCLUDE_SUMMARY)
     /* Flags for diff find similar */
     /* --find-renames */
     ADD_CONSTANT_INT(m, GIT_DIFF_FIND_RENAMES)

--- a/src/types.h
+++ b/src/types.h
@@ -146,6 +146,8 @@ typedef struct {
     PyObject *content;
 } DiffLine;
 
+SIMPLE_TYPE(DiffStats, git_diff_stats, stats);
+
 /* git_tree_walk , git_treebuilder*/
 SIMPLE_TYPE(TreeBuilder, git_treebuilder, bld)
 

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -101,6 +101,11 @@ HUNK_EXPECTED = """- a contents 2
 + a contents
 """
 
+STATS_EXPECTED = """ a   | 2 +-
+ c/d | 1 -
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+ delete mode 100644 c/d
+"""
 
 class DiffDirtyTest(utils.DirtyRepoTestCase):
     def test_diff_empty_index(self):
@@ -288,6 +293,20 @@ class DiffTest(utils.BareRepoTestCase):
         diff.find_similar()
         self.assertAny(lambda x: x.delta.status == GIT_DELTA_RENAMED, diff)
         self.assertAny(lambda x: x.delta.status_char() == 'R', diff)
+
+    def test_diff_stats(self):
+        commit_a = self.repo[COMMIT_SHA1_1]
+        commit_b = self.repo[COMMIT_SHA1_2]
+
+        diff = commit_a.tree.diff_to_tree(commit_b.tree)
+        stats = diff.stats
+        self.assertEqual(1, stats.insertions)
+        self.assertEqual(2, stats.deletions)
+        self.assertEqual(2, stats.files_changed)
+        formatted = stats.format(format=pygit2.GIT_DIFF_STATS_FULL |
+                                        pygit2.GIT_DIFF_STATS_INCLUDE_SUMMARY,
+                                 width=80)
+        self.assertEqual(STATS_EXPECTED, formatted)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This wraps git_diff_stats and can be retrieved through a Diff. It
includes a formatting method.

I wasn't quite sure what to call the formatting function. It's called `_to_buf()` in C but the type is irrelevant in python, and something like `to_string()` didn't seem to fit as it takes options.