### PR TITLE
Allow creating a remote with a particular fetch refspec

### DIFF
--- a/pygit2/decl.h
+++ b/pygit2/decl.h
@@ -193,6 +193,7 @@ int git_remote_create(
 	git_repository *repo,
 	const char *name,
 	const char *url);
+int git_remote_create_with_fetchspec(git_remote **out, git_repository *repo, const char *name, const char *url, const char *fetch);
 int git_remote_delete(git_repository *repo, const char *name);
 int git_repository_state_cleanup(git_repository *repo);
 

--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -518,15 +518,21 @@ class RemoteCollection(object):
 
         return Remote(self._repo, cremote[0])
 
-    def create(self, name, url):
-        """create(name, url) -> Remote
+    def create(self, name, url, fetch=None):
+        """create(name, url [, fetch]) -> Remote
 
         Create a new remote with the given name and url.
+
+        If 'fetch' is provided, this fetch refspec will be used instead of the default
         """
 
         cremote = ffi.new('git_remote **')
 
-        err = C.git_remote_create(cremote, self._repo._repo, to_bytes(name), to_bytes(url))
+        if fetch:
+            err = C.git_remote_create_with_fetchspec(cremote, self._repo._repo, to_bytes(name), to_bytes(url), to_bytes(fetch))
+        else:
+            err = C.git_remote_create(cremote, self._repo._repo, to_bytes(name), to_bytes(url))
+
         check_error(err)
 
         return Remote(self._repo, cremote[0])

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -62,6 +62,19 @@ class RepositoryTest(utils.RepoTestCase):
 
         self.assertRaises(ValueError, self.repo.create_remote, *(name, url))
 
+    def test_remote_create_with_refspec(self):
+        name = 'upstream'
+        url = 'git://github.com/libgit2/pygit2.git'
+        fetch = "+refs/*:refs/*"
+
+        remote = self.repo.remotes.create(name, url, fetch)
+
+        self.assertEqual(type(remote), pygit2.Remote)
+        self.assertEqual(name, remote.name)
+        self.assertEqual(url, remote.url)
+        self.assertEqual([fetch], remote.fetch_refspecs)
+        self.assertEqual(None, remote.push_url)
+
     def test_remote_delete(self):
         name = 'upstream'
         url = 'git://github.com/libgit2/pygit2.git'


### PR DESCRIPTION
This makes it a lot more convenient to create a remote and override the
fetch refspec it gets created with.