### PR TITLE
Don't use the deprecated cffi.verify by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env: LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib
 
 before_install:
   - sudo apt-get install cmake
-  - pip install cffi
+  - pip install 'cffi>=1.0.0'
   - "./.travis.sh"
 
 script:

--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -43,7 +43,7 @@ from .repository import Repository
 from .settings import Settings
 from .submodule import Submodule
 from .utils import to_bytes, to_str
-from ._utils import __version__
+from .libgit2_build import __version__
 
 
 # Features

--- a/pygit2/ffi.py
+++ b/pygit2/ffi.py
@@ -29,7 +29,8 @@
 from __future__ import absolute_import
 
 # Import from pygit2
-from ._utils import get_ffi
-
-
-ffi, C = get_ffi()
+try:
+    from ._libgit2 import ffi, lib as C
+except ImportError:
+    from .libgit2_build import ffi, C_HEADER_SRC, C_KEYWORDS
+    C = ffi.verify(C_HEADER_SRC, **C_KEYWORDS)


### PR DESCRIPTION
Instead this does what is recommend in the CFFI docs here: https://cffi.readthedocs.org/en/latest/cdef.html?highlight=verify#out-of-line-api

This also means building the cffi extension is neatly handled by cffi's setuptools integration itself, so we can delete the code in setup.py that used to do this.

This change means it's easier to install pygit2 with the binary extensions bundled. It will fallback to the previous behavior in case the bundled extension was not found.