### PR TITLE
Don't throw if there is no merge base

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -541,7 +541,8 @@ Repository_workdir__set__(Repository *self, PyObject *py_workdir)
 PyDoc_STRVAR(Repository_merge_base__doc__,
   "merge_base(oid, oid) -> Oid\n"
   "\n"
-  "Find as good common ancestors as possible for a merge.");
+  "Find as good common ancestors as possible for a merge.\n"
+  "Returns None if there is no merge base between the commits");
 
 PyObject *
 Repository_merge_base(Repository *self, PyObject *args)
@@ -565,6 +566,10 @@ Repository_merge_base(Repository *self, PyObject *args)
         return NULL;
 
     err = git_merge_base(&oid, self->repo, &oid1, &oid2);
+
+    if (err == GIT_ENOTFOUND)
+        Py_RETURN_NONE;
+
     if (err < 0)
         return Error_set(err);
 

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -333,6 +333,13 @@ class RepositoryTest_II(utils.RepoTestCase):
         self.assertEqual(commit.hex,
                          'acecd5ea2924a4b900e7e149496e1f4b57976e51')
 
+        # Create a commit without any merge base to any other
+        sig = pygit2.Signature("me", "me@example.com")
+        indep = self.repo.create_commit(None, sig, sig, "a new root commit",
+                                        self.repo[commit].peel(pygit2.Tree).id, [])
+
+        self.assertEqual(None, self.repo.merge_base(indep, commit))
+
     def test_ahead_behind(self):
         ahead, behind = self.repo.ahead_behind('5ebeeebb320790caf276b9fc8b24546d63316533',
                                                '4ec4389a8068641da2d6578db0419484972284c8')


### PR DESCRIPTION
Not finding a merge base between two commits isn't an exceptional case,
it's just a different result.