### PR TITLE
Add type attribute to TreeEntry

### DIFF
--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -176,6 +176,7 @@ Tree entries
 .. autoattribute:: pygit2.TreeEntry.id
 .. autoattribute:: pygit2.TreeEntry.hex
 .. autoattribute:: pygit2.TreeEntry.filemode
+.. autoattribute:: pygit2.TreeEntry.type
 
 .. method:: TreeEntry.__cmp__(TreeEntry)
 
@@ -188,14 +189,14 @@ Example::
     6
 
     >>> for entry in tree:               # Iteration
-    ...     print(entry.id, entry.name)
+    ...     print(entry.id, entry.type, entry.name)
     ...
-    7151ca7cd3e59f3eab19c485cfbf3cb30928d7fa .gitignore
-    c36f4cf1e38ec1bb9d9ad146ed572b89ecfc9f18 COPYING
-    32b30b90b062f66957d6790c3c155c289c34424e README.md
-    c87dae4094b3a6d10e08bc6c5ef1f55a7e448659 pygit2.c
-    85a67270a49ef16cdd3d328f06a3e4b459f09b27 setup.py
-    3d8985bbec338eb4d47c5b01b863ee89d044bd53 test
+    7151ca7cd3e59f3eab19c485cfbf3cb30928d7fa blob .gitignore
+    c36f4cf1e38ec1bb9d9ad146ed572b89ecfc9f18 blob COPYING
+    32b30b90b062f66957d6790c3c155c289c34424e blob README.md
+    c87dae4094b3a6d10e08bc6c5ef1f55a7e448659 blob pygit2.c
+    85a67270a49ef16cdd3d328f06a3e4b459f09b27 blob setup.py
+    3d8985bbec338eb4d47c5b01b863ee89d044bd53 tree test
 
     >>> entry = tree['pygit2.c']         # Get an entry by name
     >>> entry

--- a/src/tree.c
+++ b/src/tree.c
@@ -67,6 +67,15 @@ TreeEntry_name__get__(TreeEntry *self)
 }
 
 
+PyDoc_STRVAR(TreeEntry_type__doc__, "Type.");
+
+PyObject *
+TreeEntry_type__get__(TreeEntry *self)
+{
+    return to_path(git_object_type2string(git_tree_entry_type(self->entry)));
+}
+
+
 PyDoc_STRVAR(TreeEntry_id__doc__, "Object id.");
 
 PyObject *
@@ -171,6 +180,7 @@ PyGetSetDef TreeEntry_getseters[] = {
     GETTER(TreeEntry, oid),
     GETTER(TreeEntry, id),
     GETTER(TreeEntry, hex),
+    GETTER(TreeEntry, type),
     {NULL}
 };
 


### PR DESCRIPTION
This allows complete iteration and rebuilding of a tree without hitting
the object store for every entry.