### PR TITLE
Bring back cffi 0.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-#  - "pypy"
-#  - "pypy3"
+  - "pypy"
+  - "pypy3"
 
 env: LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib
 
 before_install:
   - sudo apt-get install cmake
-  - pip install 'cffi>=1.0.0'
+  - pip install cffi
   - "./.travis.sh"
 
 script:

--- a/pygit2/ffi.py
+++ b/pygit2/ffi.py
@@ -32,5 +32,5 @@ from __future__ import absolute_import
 try:
     from ._libgit2 import ffi, lib as C
 except ImportError:
-    from .libgit2_build import ffi, C_HEADER_SRC, C_KEYWORDS
-    C = ffi.verify(C_HEADER_SRC, **C_KEYWORDS)
+    from .libgit2_build import ffi, preamble, C_KEYWORDS
+    C = ffi.verify(preamble, **C_KEYWORDS)


### PR DESCRIPTION
I use pygit2 on Debian Jessie, which only has cffi 0.8.x.

I restored cffi 0.x support by following the instructions on https://cffi.readthedocs.org/en/latest/cdef.html?highlight=verify#upgrading-from-cffi-0-9-to-cffi-1-0.

I also tentatively restored PyPy tests on Travis.