### PR TITLE
Move remote callbacks to an interface/object

### DIFF
--- a/docs/remotes.rst
+++ b/docs/remotes.rst
@@ -21,6 +21,12 @@ The Remote type
 .. autoclass:: pygit2.Remote
    :members:
 
+The RemoteCallbacks type
+========================
+
+.. autoclass:: pygit2.RemoteCallbacks
+   :members:
+
 The TransferProgress type
 ===========================
 

--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -35,10 +35,10 @@ from _pygit2 import *
 from .blame import Blame, BlameHunk
 from .config import Config
 from .credentials import *
-from .errors import check_error
+from .errors import check_error, Passthrough
 from .ffi import ffi, C
 from .index import Index, IndexEntry
-from .remote import Remote, get_credentials
+from .remote import Remote, RemoteCallbacks, get_credentials
 from .repository import Repository
 from .settings import Settings
 from .submodule import Submodule

--- a/pygit2/errors.py
+++ b/pygit2/errors.py
@@ -62,3 +62,6 @@ def check_error(err, io=False):
 
     # Generic Git error
     raise GitError(message)
+
+# Indicate that we want libgit2 to pretend a function was not set
+Passthrough = Exception("The function asked for pass-through")

--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -78,6 +78,21 @@ class RemoteCallbacks(object):
     in your class, which you can then pass to the network operations.
     """
 
+    def __init__(self, credentials=None, certificate=None):
+        """Initialize some callbacks in-line
+
+        Use this constructor to provide credentials and certificate
+        callbacks in-line, instead of defining your own class for these ones.
+
+        You can e.g. also pass in one of the credential objects as 'credentials'
+        instead of creating a function which returns a hard-coded object.
+        """
+
+        if credentials is not None:
+            self.credentials = credentials
+        if certificate is not None:
+            self.certificate = certificate
+
     def sideband_progress(self, string):
         """Progress output callback
 

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -213,30 +213,37 @@ class EmptyRepositoryTest(utils.EmptyRepoTestCase):
 
     def test_transfer_progress(self):
         self.tp = None
-        def tp_cb(stats):
-            self.tp = stats
+        class MyCallbacks(pygit2.RemoteCallbacks):
+            def transfer_progress(self, stats):
+                self.tp = stats
 
+        callbacks = MyCallbacks()
         remote = self.repo.remotes[0]
-        remote.transfer_progress = tp_cb
-        stats = remote.fetch()
-        self.assertEqual(stats.received_bytes, self.tp.received_bytes)
-        self.assertEqual(stats.indexed_objects, self.tp.indexed_objects)
-        self.assertEqual(stats.received_objects, self.tp.received_objects)
+        stats = remote.fetch(callbacks=callbacks)
+        self.assertEqual(stats.received_bytes, callbacks.tp.received_bytes)
+        self.assertEqual(stats.indexed_objects, callbacks.tp.indexed_objects)
+        self.assertEqual(stats.received_objects, callbacks.tp.received_objects)
 
     def test_update_tips(self):
         remote = self.repo.remotes[0]
-        self.i = 0
-        self.tips = [('refs/remotes/origin/master', Oid(hex='0'*40),
-                      Oid(hex='784855caf26449a1914d2cf62d12b9374d76ae78')),
-                     ('refs/tags/root', Oid(hex='0'*40),
-                      Oid(hex='3d2962987c695a29f1f80b6c3aa4ec046ef44369'))]
+        tips = [('refs/remotes/origin/master', Oid(hex='0'*40),
+                 Oid(hex='784855caf26449a1914d2cf62d12b9374d76ae78')),
+                ('refs/tags/root', Oid(hex='0'*40),
+                 Oid(hex='3d2962987c695a29f1f80b6c3aa4ec046ef44369'))]
 
-        def ut_cb(name, old, new):
-            self.assertEqual(self.tips[self.i], (name, old, new))
-            self.i += 1
+        class MyCallbacks(pygit2.RemoteCallbacks):
+            def __init__(self, test_self, tips):
+                self.test = test_self
+                self.tips = tips
+                self.i = 0
 
-        remote.update_tips = ut_cb
-        remote.fetch()
+            def update_tips(self, name, old, new):
+                self.test.assertEqual(self.tips[self.i], (name, old, new))
+                self.i += 1
+
+        callbacks = MyCallbacks(self, tips)
+        remote.fetch(callbacks=callbacks)
+        self.assertTrue(callbacks.i > 0)
 
 class PushTestCase(unittest.TestCase):
     def setUp(self):

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -514,10 +514,13 @@ class CloneRepositoryTest(utils.NoRepoTestCase):
         self.assertIsNotNone(repo.remotes["custom_remote"])
 
     def test_clone_with_credentials(self):
-        credentials = pygit2.UserPass("libgit2", "libgit2")
+        class MyCallbacks(pygit2.RemoteCallbacks):
+            def __init__(self):
+                self.credentials = pygit2.UserPass("libgit2", "libgit2")
+
         repo = clone_repository(
             "https://bitbucket.org/libgit2/testgitrepository.git",
-            self._temp_dir, credentials=credentials)
+            self._temp_dir, callbacks=MyCallbacks())
 
         self.assertFalse(repo.is_empty)
 

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -514,13 +514,9 @@ class CloneRepositoryTest(utils.NoRepoTestCase):
         self.assertIsNotNone(repo.remotes["custom_remote"])
 
     def test_clone_with_credentials(self):
-        class MyCallbacks(pygit2.RemoteCallbacks):
-            def __init__(self):
-                self.credentials = pygit2.UserPass("libgit2", "libgit2")
-
         repo = clone_repository(
             "https://bitbucket.org/libgit2/testgitrepository.git",
-            self._temp_dir, callbacks=MyCallbacks())
+            self._temp_dir, callbacks=pygit2.RemoteCallbacks(credentials=pygit2.UserPass("libgit2", "libgit2")))
 
         self.assertFalse(repo.is_empty)
 


### PR DESCRIPTION
Instead of setting the methods/fields in the remote itself, which is a vestige of the older method which libgit2 used, have the user pass in an object with their callbacks, which represents what's going on underneath much more accurately, as well as letting us re-use the callbacks implementation across `Remote` and `clone_repsitory()`.

The docs aren't updated yet, so it's still WIP, but this is what I'd like us to move to.