### PR TITLE
Add _name attribute to TreeEntry

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -67,6 +67,15 @@ TreeEntry_name__get__(TreeEntry *self)
 }
 
 
+PyDoc_STRVAR(TreeEntry__name__doc__, "Name (bytes).");
+
+PyObject *
+TreeEntry__name__get__(TreeEntry *self)
+{
+    return PyBytes_FromString(git_tree_entry_name(self->entry));
+}
+
+
 PyDoc_STRVAR(TreeEntry_type__doc__, "Type.");
 
 PyObject *
@@ -177,6 +186,7 @@ TreeEntry_repr(TreeEntry *self)
 PyGetSetDef TreeEntry_getseters[] = {
     GETTER(TreeEntry, filemode),
     GETTER(TreeEntry, name),
+    GETTER(TreeEntry, _name),
     GETTER(TreeEntry, oid),
     GETTER(TreeEntry, id),
     GETTER(TreeEntry, hex),

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -45,6 +45,7 @@ class TreeTest(utils.BareRepoTestCase):
     def assertTreeEntryEqual(self, entry, sha, name, filemode):
         self.assertEqual(entry.hex, sha)
         self.assertEqual(entry.name, name)
+        self.assertEqual(entry._name, name.encode('utf-8'))
         self.assertEqual(entry.filemode, filemode,
                          '0%o != 0%o' % (entry.filemode, filemode))
 


### PR DESCRIPTION
This mirrors the _message attribute for Tag, which gives you the raw
bytes from the entry name. Useful to parse repos where some filenames
aren't encoded as utf-8, such as https://github.com/wuts/earthquake.