### PR TITLE
tag._message: avoid NULL pointer dereference

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -111,7 +111,11 @@ PyDoc_STRVAR(Tag__message__doc__, "Tag message (bytes).");
 PyObject *
 Tag__message__get__(Tag *self)
 {
-    return PyBytes_FromString(git_tag_message(self->tag));
+    const char *message;
+    message = git_tag_message(self->tag);
+    if (!message)
+        Py_RETURN_NONE;
+    return PyBytes_FromString(message);
 }
 
 PyMethodDef Tag_methods[] = {


### PR DESCRIPTION
A tag message can be empty. In that case, git_tag_message returns
NULL. PyBytes_FromString doesn't check its argument for nullness, and
therefore accessing _message on a tag with an empty message segfaults
Python.