### PR TITLE
List OpenSSL as a dependency in the docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,6 +16,7 @@ Requirements
 - Python 2.7, 3.2+ or PyPy 2.6+ (including the development headers)
 - Libgit2 v0.23.x
 - cffi 1.0+
+- OpenSSL development headers, optional, used for HTTPS network operations.
 - Libssh2, optional, used for SSH network operations.
 - pkg-config, optional, used for SSH network operations.
 


### PR DESCRIPTION
For interacting / authenticating against an HTTPS repository we need the OpenSSL development headers present when installing pygit2, yet the documentation fails to mention it, which led to #573.