### PR TITLE
Fix broken binary diff test

### DIFF
--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -77,6 +77,7 @@ Pc${NM%FIhFs^kIy3n&7R
 
 literal 8
 Pc${NM&PdElPvrst3ey5{
+
 """
 
 DIFF_HEAD_TO_INDEX_EXPECTED = [


### PR DESCRIPTION
In a recent commit to libgit2, binary diffs were changed to have a
trailing empty line. This broke a test in test_diff because it compares
it directly against the string. I've added the extra line to the
expected output and the test now passes correctly.

The relevant libgit2 commit can be found here: https://github.com/libgit2/libgit2/commit/e4b2b919bb35d94d6dbcb5f7a31805788f2e335b