### PR TITLE
Fix repository crash if path passed is not a str

### DIFF
--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -37,6 +37,8 @@ if sys.version_info[0] < 3:
 else:
     from io import BytesIO as StringIO
 
+import six
+
 # Import from pygit2
 from _pygit2 import Repository as _Repository
 from _pygit2 import Oid, GIT_OID_HEXSZ, GIT_OID_MINPREFIXLEN
@@ -56,8 +58,10 @@ from .submodule import Submodule
 
 class Repository(_Repository):
 
-    def __init__(self, *args, **kwargs):
-        super(Repository, self).__init__(*args, **kwargs)
+    def __init__(self, path, *args, **kwargs):
+        if not isinstance(path, six.string_types):
+            path = path.decode('utf-8')
+        super(Repository, self).__init__(path, *args, **kwargs)
         self._common_init()
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ del sys.path[0]
 
 # Python 2 support
 # See https://github.com/libgit2/pygit2/pull/180 for a discussion about this.
+# Using six isn't an option here yet, we don't necessarily have six installed
 if sys.version_info[0] == 2:
     u = lambda s: unicode(s, 'utf-8')
 else:
@@ -186,7 +187,7 @@ extra_args = {
 if cffi_major_version == 0:
     extra_args['ext_modules'].append(ffi.verifier.get_extension())
 else:
-    extra_args['cffi_modules']=['pygit2/_run.py:ffi']
+    extra_args['cffi_modules'] = ['pygit2/_run.py:ffi']
 
 
 setup(name='pygit2',
@@ -202,7 +203,7 @@ setup(name='pygit2',
       packages=['pygit2'],
       package_data={'pygit2': ['decl.h']},
       setup_requires=['cffi'],
-      install_requires=['cffi'],
+      install_requires=['cffi', 'six'],
       zip_safe=False,
       cmdclass=cmdclass,
       **extra_args)

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -39,6 +39,8 @@ import os
 from os.path import join, realpath
 import sys
 
+import six
+
 # Import from pygit2
 from pygit2 import GIT_OBJ_ANY, GIT_OBJ_BLOB, GIT_OBJ_COMMIT
 from pygit2 import init_repository, clone_repository, discover_repository
@@ -482,10 +484,15 @@ class EmptyRepositoryTest(utils.EmptyRepoTestCase):
         self.assertFalse(self.repo.head_is_detached)
 
 
-class BytesStringRepositoryTest(utils.NoRepoTestCase):
+class StringTypesRepositoryTest(utils.NoRepoTestCase):
 
     def test_bytes_string(self):
         repo_path = b'./test/data/testrepo.git/'
+        pygit2.Repository(repo_path)
+
+    def test_unicode_string(self):
+        # String is unicode because of unicode_literals
+        repo_path = './test/data/testrepo.git/'
         pygit2.Repository(repo_path)
 
 


### PR DESCRIPTION
This perhaps isnt' the most elegant fix, but otherwise all callers need to be patched.

Closes #588 
