### PR TITLE
repository: add listall_reference_objects() method

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -4,6 +4,7 @@ References
 
 .. contents::
 
+.. automethod:: pygit2.Repository.listall_reference_objects
 .. automethod:: pygit2.Repository.listall_references
 .. automethod:: pygit2.Repository.lookup_reference
 

--- a/src/repository.h
+++ b/src/repository.h
@@ -58,6 +58,8 @@ PyObject* Repository_create_commit(Repository *self, PyObject *args);
 PyObject* Repository_create_tag(Repository *self, PyObject *args);
 PyObject* Repository_create_branch(Repository *self, PyObject *args);
 PyObject* Repository_listall_references(Repository *self, PyObject *args);
+PyObject* Repository_listall_reference_objects(Repository *self,
+                                               PyObject *args);
 PyObject* Repository_listall_branches(Repository *self, PyObject *args);
 PyObject* Repository_lookup_reference(Repository *self, PyObject *py_name);
 

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -42,6 +42,17 @@ LAST_COMMIT = '2be5719152d4f82c7302b1c0932d8e5f0a4a0e98'
 
 class ReferencesTest(utils.RepoTestCase):
 
+    def test_list_all_reference_objects(self):
+        repo = self.repo
+
+        refs = [(ref.name, ref.target.hex)
+                for ref in repo.listall_reference_objects()]
+        self.assertEqual(sorted(refs),
+                         [('refs/heads/i18n',
+                           '5470a671a80ac3789f1a6a8cefbcf43ce7af0563'),
+                          ('refs/heads/master',
+                           '2be5719152d4f82c7302b1c0932d8e5f0a4a0e98')])
+
     def test_list_all_references(self):
         repo = self.repo
 


### PR DESCRIPTION
This allows for efficient reading of many references and their targets,
without incurring the overhead of lookup_reference() (which stats for
a loose ref and then reads packed-refs) which can be expensive on NFS
with thousands of refs.

We've been using this patch for a while and I think it makes sense for upstream pygit2. Any feedback on the idea?