### PR TITLE
Make build reproducible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ else:
 
 libgit2_bin, libgit2_include, libgit2_lib = get_libgit2_paths()
 
-pygit2_exts = [os.path.join('src', name) for name in listdir('src')
+pygit2_exts = [os.path.join('src', name) for name in sorted(listdir('src'))
                if name.endswith('.c')]
 
 


### PR DESCRIPTION
Whilst working on the "reproducible builds" effort [0], we noticed that pygit2 could not be built reproducibly. This patch is fixing it.

[0] https://wiki.debian.org/ReproducibleBuilds