### PR TITLE
CI on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ build_script:
     
     %PIP% install wheel
     %PYTHON% setup.py bdist_wheel 
-  
+test_script:
+- cmd: '%PYTHON% setup.py test'
 artifacts:
 - path: dist\*.whl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 version: 1.0.{build}
 image: Visual Studio 2015
 configuration: Release
-matrix:
+environment:
+  matrix:
   - ARCH: 32
     GENERATOR: '"Visual Studio 11"'
     PYTHON: '"C:\Python35\python.exe"'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,15 @@
 version: 1.0.{build}
 image: Visual Studio 2015
 configuration: Release
+  matrix:
+  - ARCH: 32
+    GENERATOR: '"Visual Studio 11"'
+    PYTHON: '"C:\Python35\python.exe"'
+    PIP: '"C:\Python35\Scripts\pip.exe"'
+  - ARCH: 64
+    GENERATOR: '"Visual Studio 11 Win64"'
+    PYTHON: '"C:\Python35-x64\python.exe"'
+    PIP: '"C:\Python35-x64\Scripts\pip.exe"'
 build_script:
 - cmd: |
     set LIBGIT2=%APPVEYOR_BUILD_FOLDER%\build\libgit2
@@ -8,12 +17,12 @@ build_script:
     mkdir build
     
     cd build
-    cmake -DSTDCALL=OFF -DBUILD_CLAR=OFF -DCMAKE_INSTALL_PREFIX=%LIBGIT2% ../libgit2 -G"Visual Studio 11 Win64"
+    cmake -DSTDCALL=OFF -DBUILD_CLAR=OFF -DCMAKE_INSTALL_PREFIX=%LIBGIT2% ../libgit2 -G %GENERATOR%
     cmake --build . --config Release --target install
     cd ..
     
-    C:\Python35-x64\Scripts\pip.exe install wheel
-    C:\Python35-x64\python.exe setup.py bdist_wheel 
+    %PIP% install wheel
+    %PYTHON% setup.py bdist_wheel 
   
 artifacts:
 - path: dist\*.whl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 image: Visual Studio 2015
 configuration: Release
-  matrix:
+matrix:
   - ARCH: 32
     GENERATOR: '"Visual Studio 11"'
     PYTHON: '"C:\Python35\python.exe"'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ build_script:
     C:\Python35-x64\python.exe setup.py bdist_wheel 
   
 artifacts:
-- path: build\*
+- path: dist\*.whl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,10 @@ build_script:
     git clone --depth=1 -b maint/v0.24 https://github.com/libgit2/libgit2.git libgit2
     mkdir build
     
-    pushd build
+    cd build
     cmake -DSTDCALL=OFF -DBUILD_CLAR=OFF -DCMAKE_INSTALL_PREFIX=%LIBGIT2% ../libgit2 -G"Visual Studio 11 Win64"
     cmake --build . --config Release --target install
-    popd
+    cd ..
     
     C:\Python35-x64\Scripts\pip.exe install wheel
     C:\Python35-x64\python.exe setup.py bdist_wheel 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: 1.0.{build}
+image: Visual Studio 2015
+configuration: Release
+build_script:
+- cmd: |
+    set LIBGIT2=%APPVEYOR_BUILD_FOLDER%\build\libgit2
+    git clone --depth=1 -b maint/v0.24 https://github.com/libgit2/libgit2.git libgit2
+    mkdir build
+    
+    pushd build
+    cmake -DSTDCALL=OFF -DBUILD_CLAR=OFF -DCMAKE_INSTALL_PREFIX=%LIBGIT2% ../libgit2 -G"Visual Studio 11 Win64"
+    cmake --build . --config Release --target install
+    popd
+    
+    C:\Python35-x64\Scripts\pip.exe install wheel
+    C:\Python35-x64\python.exe setup.py bdist_wheel 
+  
+artifacts:
+- path: build\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,8 @@ build_script:
     
     %PIP% install wheel
     %PYTHON% setup.py bdist_wheel 
+    %PIP% install .
+    
 test_script:
 - cmd: '%PYTHON% setup.py test'
 artifacts:


### PR DESCRIPTION
Currently there is only support for CI on linux powered by travis. This pull request adds a appveyor.yml file to support CI on windows using appveyor. Also the pygit wheel is provided as a build artifact, making it easier for windows users to install a pygit2 version. Unfortunately the unit tests do not pass yes, which appears to be a general windows/pygit2 issue.

An example of a build can be found here: https://ci.appveyor.com/project/fourplusone/pygit2/build/job/74l4rw3vp2sqv60d

I would love to hear the repository owners feedback on this

