### PR TITLE
mitigate python3 import error

### DIFF
--- a/pygit2/_run.py
+++ b/pygit2/_run.py
@@ -39,7 +39,10 @@ import sys
 from cffi import FFI
 
 # Import from pygit2
-from _build import get_libgit2_paths
+if sys.version_info < (3, 0):
+    from _build import get_libgit2_paths
+else:
+    from ._build import get_libgit2_paths
 
 
 # C_HEADER_SRC


### PR DESCRIPTION
I think it can be made better, but this one works so far for me. NOT tested with anything but 3.4.2 @ Debian Jessie !

> ImportError: No module named '_build'
