### PR TITLE
appveyor.yml Attempt to fix test failure reporting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ test_script:
 - ps: |
     cp build\Release\git2.dll .
     &$env:PYTHON setup.py nosetests --with-xunit
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
     # upload results to AppVeyor
     $wc = New-Object 'System.Net.WebClient'
     $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\nosetests.xml))


### PR DESCRIPTION
A followup to #655.

PowerShell script in testing does not fail build, see https://ci.appveyor.com/project/jdavid/pygit2/branch/master/job/ra1y9vjcva0exm6m and explanation at http://help.appveyor.com/discussions/problems/4498-powershell-exception-in-test_script-does-not-fail-build