### PR TITLE
appveyor.yml Fix nosetests report upload

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ test_script:
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
     # upload results to AppVeyor
     $wc = New-Object 'System.Net.WebClient'
-    $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\nosetests.xml))
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\nosetests.xml))
 
 artifacts:
 - path: dist\*.whl


### PR DESCRIPTION
Another usability fix for #655.

/xunit/ endpoint in AppVeyor is made for uploading xUnit.net reports
http://help.appveyor.com/discussions/problems/5264-xunit-results-are-not-being-parsed