### PR TITLE
Make pygit2 throw if tree of a commit is not found

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -35,6 +35,7 @@
 #include "oid.h"
 
 extern PyTypeObject TreeType;
+extern PyObject *GitError;
 
 
 PyDoc_STRVAR(Commit_message_encoding__doc__, "Message encoding.");
@@ -131,8 +132,11 @@ Commit_tree__get__(Commit *commit)
     int err;
 
     err = git_commit_tree(&tree, commit->commit);
-    if (err == GIT_ENOTFOUND)
-        Py_RETURN_NONE;
+    if (err == GIT_ENOTFOUND) {
+        char tree_id[GIT_OID_HEXSZ + 1] = { 0 };
+        git_oid_fmt(tree_id, git_commit_tree_id(commit->commit));
+        return PyErr_Format(GitError, "Unable to read tree %s", tree_id);
+    }
 
     if (err < 0)
         return Error_set(err);


### PR DESCRIPTION
`Commit` objects in git always have a `tree_id` associated, that points to the corresponding `Tree` object.

When the `Tree` object is missing, the repo is corrupted.

In those cases:
* official git cli fatals with status code `128` and message:
  `fatal: unable to read tree <hash>`
* libgit2 returns error `GIT_ENOTFOUND` when calling `git_commit_tree()`
* pygit2 when accessing the tree by id with `repo[commit.tree_id]` raises a `KeyError: <hash>`

But on the other hand, on the commit object, rather than throwing and exception, pygit2 is swallowing the error returned by libgit2 and setting the `<Commit object>.tree` property to `None`.

This patch changes the behavior to raise an error in those cases.

**Rationale:**
`None` is arguably the wrong choice to encode an error condition, specially in python that is used heavily.

In particular this caused in our system to assume there was an empty tree, and the sync service that tails git repo changes decided to DELETE everything. The code was using None to represent empty tree, useful for example when we need to compare a path between two commits (the path might be non-existent at one of the commits you are comparing).

I think that in this case the right decision would be to raise since is an exceptional case, caused by a corrupted repo, is more consistent with other tools, and ensures user code does not take the wrong decisions.

For curiosity the corrupted repository can happen more commonly than expected. We run our repositories on a shared NFS filer, and one of our servers didn't have the lookupcache=positive option. This makes NFS cache the metadata (files on a directory for example) and use that for negative lookups (to deny existance of files). In this case, the commit object was on a directory not cached, so the commit was seen immediately, but the tree object was in a folder that was cached, the cache didn't contained the tree object, and thus for some seconds the tree was not existing and the repo was corrupted. Our sync service saw tree being None and decided to delete everything, causing a lot of issues down the way.

**Repro steps:**
* Create a test repo with a couple of commits.
* Find the tree_id for HEAD:
<pre>
$ git cat-file -p HEAD
tree 3683f870be446c7cc05ffaef9fa06415276e1828
parent 37d122c3ffcaa77dbe12930c2a573648fdecee06
[...]
</pre>
* Delete the tree object:
`rm .git/objects/36/83f870be446c7cc05ffaef9fa06415276e1828`
* Try using that repo with pygit2:
Before: `repo.revparse_single('HEAD').tree` will be `None`
After: it `repo.revparse_single('HEAD')` raises `GitError: Unable to read tree 3683f870be446c7cc05ffaef9fa06415276e1828`