### PR TITLE
Remove unused code

### DIFF
--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -279,11 +279,6 @@ class Repository(_Repository):
         oid = reference.resolve().target
         treeish = self[oid]
         self.checkout_tree(treeish, **kwargs)
-        head = self.lookup_reference('HEAD')
-        if head.type == C.GIT_REF_SYMBOLIC:
-            from_ = self.head.shorthand
-        else:
-            from_ = head.target.hex
 
         self.set_head(refname)
 


### PR DESCRIPTION
Removed a chunk of code from `checkout` that did nothing, but had a bug.
When checking out from a branch-less state (like the state when a repository is first initialized) the code failed.
The failure was due to trying to get some properties of the current branch, which were never used in the code.