### PR TITLE
Randomize OID object hashes

### DIFF
--- a/src/oid.c
+++ b/src/oid.c
@@ -209,8 +209,10 @@ Oid_init(Oid *self, PyObject *args, PyObject *kw)
 Py_hash_t
 Oid_hash(PyObject *oid)
 {
-    /* TODO Randomize (use _Py_HashSecret) to avoid collission DoS attacks? */
-    return *(Py_hash_t*) ((Oid*)oid)->oid.id;
+    PyObject *py_oid = git_oid_to_py_str(&((Oid *)oid)->oid);
+    Py_hash_t ret = PyObject_Hash(py_oid);
+    Py_DECREF(py_oid);
+    return ret;
 }
 
 


### PR DESCRIPTION
Instead of using type punning to convert the OID to a Python hash, use
_Py_HashBytes() to hash the OID again. This means we no longer make any
assumptions on the internal representation of OID values or Python
hashes (before this commit, we at least relied on the fact that OID
hases are longer than Python hashes). Moreover, the random seed stored
in PYTHONHASHSEED is now honored.

This also fixes a compiler warning seen with -Wstrict-aliasing.

Signed-off-by: Lukas Fleischer <lfleischer@lfos.de>