### PR TITLE
revert: Add support for git_revert_commit via Repository.revert_commit()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Authors
   Peter Dave Hello          Philippe Ombredanne       Ridge Kennedy
   Ross Nicoll               Rui Abreu Ferreira        Sheeo
   Soasme                    Vladimir Rutsky           Yu Jianjian
-  chengyuhang               earl
+  chengyuhang               earl                      Mark Adams
 
 License
 ==============

--- a/pygit2/decl.h
+++ b/pygit2/decl.h
@@ -922,3 +922,5 @@ typedef enum {
 
 int git_attr_get(const char **value_out, git_repository *repo, uint32_t flags, const char *path, const char *name);
 git_attr_t git_attr_value(const char *attr);
+
+int git_revert_commit(git_index **out, git_repository *repo, git_commit *revert_commit, git_commit *our_commit, unsigned int mainline, const git_merge_options *merge_options);

--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -157,6 +157,9 @@ class Index(object):
         It returns the id of the resulting tree.
         """
         coid = ffi.new('git_oid *')
+
+        repo = repo or self._repo
+
         if repo:
             err = C.git_index_write_tree_to(coid, self._index, repo._repo)
         else:


### PR DESCRIPTION
This change adds `Repository.revert_commit()` which wraps around `git_revert_commit` which will return an `Index` with the appropriate changes to revert the specified commit.

Fixes #710