### PR TITLE
Update for libgit2 v0.26

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -2,7 +2,7 @@
 
 cd ~
 
-git clone --depth=1 -b maint/v0.25 https://github.com/libgit2/libgit2.git
+git clone --depth=1 -b maint/v0.26 https://github.com/libgit2/libgit2.git
 cd libgit2/
 
 mkdir build && cd build

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,7 +14,7 @@ Requirements
 ============
 
 - Python 2.7, 3.3+ or PyPy 2.6+ (including the development headers)
-- Libgit2 v0.25.x
+- Libgit2 v0.26.x
 - cffi 1.0+
 - six
 - tox (optional)
@@ -43,11 +43,11 @@ while the last number |lq| *.micro* |rq| auto-increments independently.
 
 As illustration see this table of compatible releases:
 
-+-----------+----------------+------------------------+
-|**libgit2**| 0.25.0, 0.25.1 | 0.24.0, 0.24.1, 0.24.2 |
-+-----------+----------------+------------------------+
-|**pygit2** | 0.25.0, 0.25.1 | 0.24.0, 0.24.1, 0.24.2 |
-+-----------+----------------+------------------------+
++-----------+--------+-------=========+------------------------+
+|**libgit2**| 0.26.0 | 0.25.0, 0.25.1 | 0.24.0, 0.24.1, 0.24.2 |
++-----------+--------+----------------+------------------------+
+|**pygit2** | 0.26.0 | 0.25.0, 0.25.1 | 0.24.0, 0.24.1, 0.24.2 |
++-----------+--------+----------------+------------------------+
 
 .. warning::
 
@@ -64,9 +64,9 @@ directory, do:
 
 .. code-block:: sh
 
-   $ wget https://github.com/libgit2/libgit2/archive/v0.25.1.tar.gz
-   $ tar xzf v0.25.1.tar.gz
-   $ cd libgit2-0.25.1/
+   $ wget https://github.com/libgit2/libgit2/archive/v0.26.0.tar.gz
+   $ tar xzf v0.26.0.tar.gz
+   $ cd libgit2-0.26.0/
    $ cmake .
    $ make
    $ sudo make install
@@ -148,9 +148,9 @@ Install libgit2 (see we define the installation prefix):
 
 .. code-block:: sh
 
-   $ wget https://github.com/libgit2/libgit2/archive/v0.25.1.tar.gz
-   $ tar xzf v0.25.1.tar.gz
-   $ cd libgit2-0.25.1/
+   $ wget https://github.com/libgit2/libgit2/archive/v0.26.0.tar.gz
+   $ tar xzf v0.26.0.tar.gz
+   $ cd libgit2-0.26.0/
    $ cmake . -DCMAKE_INSTALL_PREFIX=$LIBGIT2
    $ make
    $ make install
@@ -186,7 +186,7 @@ everytime. Verify yourself if curious:
 
 .. code-block:: sh
 
-   $ readelf --dynamic lib/python2.7/site-packages/pygit2-0.25.1-py2.7-linux-x86_64.egg/_pygit2.so | grep PATH
+   $ readelf --dynamic lib/python2.7/site-packages/pygit2-0.26.0-py2.7-linux-x86_64.egg/_pygit2.so | grep PATH
     0x000000000000001d (RUNPATH)            Library runpath: [/tmp/venv/lib]
 
 
@@ -203,9 +203,9 @@ from a bash shell:
 .. code-block:: sh
 
    $ export LIBGIT2=C:/Dev/libgit2
-   $ wget https://github.com/libgit2/libgit2/archive/v0.25.1.tar.gz
-   $ tar xzf v0.25.1.tar.gz
-   $ cd libgit2-0.25.1/
+   $ wget https://github.com/libgit2/libgit2/archive/v0.26.0.tar.gz
+   $ tar xzf v0.26.0.tar.gz
+   $ cd libgit2-0.26.0/
    $ cmake . -DSTDCALL=OFF -DCMAKE_INSTALL_PREFIX=$LIBGIT2 -G "Visual Studio 9 2008"
    $ cmake --build . --config release --target install
    $ ctest -v

--- a/src/types.h
+++ b/src/types.h
@@ -32,8 +32,8 @@
 #include <Python.h>
 #include <git2.h>
 
-#if !(LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR == 25)
-#error You need a compatible libgit2 version (v0.25.x)
+#if !(LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR == 26)
+#error You need a compatible libgit2 version (v0.26.x)
 #endif
 
 /*

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -97,7 +97,7 @@ class ConfigTest(utils.RepoTestCase):
 
         self.assertRaises(TypeError, lambda: config[()])
         self.assertRaises(TypeError, lambda: config[-4])
-        self.assertRaisesWithArg(ValueError, "Invalid config item name 'abc'",
+        self.assertRaisesWithArg(ValueError, "invalid config item name 'abc'",
                                  lambda: config['abc'])
         self.assertRaisesWithArg(KeyError, 'abc.def',
                                  lambda: config['abc.def'])


### PR DESCRIPTION
The API isn't changing as much recently so all we needed to adjust was the
proper capitalisation of the error string.

I've left the version of pygit2 in code alone, as that should probably happen in changes for release on its own.