### PR TITLE
Update diff.rst

### DIFF
--- a/docs/diff.rst
+++ b/docs/diff.rst
@@ -111,5 +111,5 @@ The DiffLine type
 .. autoattribute :: pygit2.DiffLine.origin
 .. autoattribute :: pygit2.DiffLine.content
 .. autoattribute :: pygit2.DiffLine.old_lineno
-.. autoattribute :: pygit2.DiffLine.old_lineno
+.. autoattribute :: pygit2.DiffLine.new_lineno
 .. autoattribute :: pygit2.DiffLine.num_lines


### PR DESCRIPTION
`old_lineno` appeared twice. I think it should be `new_lineno` instead.