### PR TITLE
improve credentials handling for ssh cloning

### DIFF
--- a/docs/recipes/git-clone-ssh.rst
+++ b/docs/recipes/git-clone-ssh.rst
@@ -1,0 +1,31 @@
+**********************************************************************
+git-clone ssh://git@example.com
+**********************************************************************
+
+Example for cloning a git repository over ssh.
+
+.. code-block:: bash
+
+   $> git clone git@example.com
+
+.. code-block:: python
+
+    class MyRemoteCallbacks(pygit2.RemoteCallbacks):
+
+        def credentials(self, url, username_from_url, allowed_types):
+            if allowed_types == pygit2.GIT_CREDTYPE_USERNAME:
+                return pygit2.Username("git")
+            elif allowed_types == pygit2.GIT_CREDTYPE_SSH_KEY:
+                return pygit2.Keypair("git", "id_rsa.pub", "id_rsa", "")
+            else:
+                return None
+
+    print("Cloning pygit2 over ssh")
+    pygit2.clone_repository("ssh://github.com/libgit2/pygit2", "pygit2.git",
+                            callbacks=MyRemoteCallbacks())
+
+    print("Cloning pygit2 over ssh with the username in the URL")
+    keypair = pygit2.Keypair("git", "id_rsa.pub", "id_rsa", "")
+    callbacks = pygit2.RemoteCallbacks(credentials=keypair)
+    pygit2.clone_repository("ssh://git@github.com/libgit2/pygit2", "pygit2.git",
+                            callbacks=callbacks)

--- a/pygit2/credentials.py
+++ b/pygit2/credentials.py
@@ -27,8 +27,31 @@
 
 from .ffi import C
 
+GIT_CREDTYPE_USERNAME = C.GIT_CREDTYPE_USERNAME
 GIT_CREDTYPE_USERPASS_PLAINTEXT = C.GIT_CREDTYPE_USERPASS_PLAINTEXT
 GIT_CREDTYPE_SSH_KEY = C.GIT_CREDTYPE_SSH_KEY
+
+
+class Username(object):
+    """Username credentials
+
+    This is an object suitable for passing to a remote's credentials
+    callback and for returning from said callback.
+    """
+
+    def __init__(self, username):
+        self._username = username
+
+    @property
+    def credential_type(self):
+        return GIT_CREDTYPE_USERNAME
+
+    @property
+    def credential_tuple(self):
+        return (self._username,)
+
+    def __call__(self, _url, _username, _allowed):
+        return self
 
 
 class UserPass(object):

--- a/pygit2/decl.h
+++ b/pygit2/decl.h
@@ -306,6 +306,9 @@ int git_refspec_dst_matches(const git_refspec *refspec, const char *refname);
 int git_refspec_transform(git_buf *buf, const git_refspec *spec, const char *name);
 int git_refspec_rtransform(git_buf *buf, const git_refspec *spec, const char *name);
 
+int git_cred_username_new(
+	git_cred **out,
+	const char *username);
 int git_cred_userpass_plaintext_new(
 	git_cred **out,
 	const char *username,

--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -469,6 +469,11 @@ def get_credentials(fn, url, username, allowed):
             err = C.git_cred_ssh_key_new(ccred, to_bytes(name),
                                          to_bytes(pubkey), to_bytes(privkey),
                                          to_bytes(passphrase))
+
+    elif cred_type == C.GIT_CREDTYPE_USERNAME:
+        name, = credential_tuple
+        err = C.git_cred_username_new(ccred, to_bytes(name))
+
     else:
         raise TypeError("unsupported credential type")
 

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -31,8 +31,7 @@
 import unittest
 import pygit2
 from pygit2 import GIT_CREDTYPE_USERPASS_PLAINTEXT
-from pygit2 import UserPass, Keypair, KeypairFromAgent
-from pygit2 import UserPass, Keypair
+from pygit2 import Username, UserPass, Keypair, KeypairFromAgent
 from . import utils
 
 REMOTE_NAME = 'origin'
@@ -45,6 +44,12 @@ REMOTE_REPO_BYTES = 2758
 ORIGIN_REFSPEC = '+refs/heads/*:refs/remotes/origin/*'
 
 class CredentialCreateTest(utils.NoRepoTestCase):
+    def test_username(self):
+        username = "git"
+
+        cred = Username(username)
+        self.assertEqual((username,), cred.credential_tuple)
+
     def test_userpass(self):
         username = "git"
         password = "sekkrit"


### PR DESCRIPTION
This patch implements support for the ```GIT_CREDTYPE_USERNAME``` credential. The ssh transport requests this when negotiating authentication methods with libssh2. It seems the only other way to clone over ssh is to include the username in the repository URL, which is undocumented and inconsistent with the behavior prior to the credential callback.