### PR TITLE
Update example to use peel() instead of get_object().

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -15,7 +15,7 @@ Example::
     >>> all_refs = list(repo.references)
 
     >>> master_ref = repo.lookup_reference("refs/heads/master")
-    >>> commit = master_ref.get_object() # or repo[master_ref.target]
+    >>> commit = master_ref.peel() # or repo[master_ref.target]
 
     # Create a reference
     >>> ref = repo.references.create('refs/tags/version1', LAST_COMMIT)


### PR DESCRIPTION
According to http://www.pygit2.org/references.html get_object() is deprecated, and we should be using peel() instead. Update the example at the top of the page to follow this advice.