### PR TITLE
add repository member for cleaning up open file handles 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -26,3 +26,4 @@ Anatoly Techtonik <techtonik@gmail.com>
 Guillermo Pérez <bisho@fb.com> <bisho@freedreams.org>
 Matthew Duggan <mduggan@qti.qualcomm.com> <mgithub@guarana.org>
 Alexander Bayandin <a.bayandin@gmail.com> <bayandin@users.noreply.github.com>
+Bob Carroll <bob.carroll@alum.rit.edu> <bobc@qti.qualcomm.com>

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ Authors
   Ridge Kennedy             Ross Nicoll               Rui Abreu Ferreira
   Sheeo                     Soasme                    Vladimir Rutsky
   Yu Jianjian               chengyuhang               earl
+  Bob Carroll
 
 
 License

--- a/src/repository.c
+++ b/src/repository.c
@@ -1810,6 +1810,20 @@ Repository_reset(Repository *self, PyObject* args)
     Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(Repository_free__doc__,
+  "free()\n"
+  "\n"
+  "Releases handles to the Git database without deallocating the repository.\n");
+
+PyObject *
+Repository_free(Repository *self)
+{
+    if (self->owned)
+        git_repository__cleanup(self->repo);
+
+    Py_RETURN_NONE;
+}
+
 PyDoc_STRVAR(Repository_expand_id__doc__,
     "expand_id(hex) -> Oid\n"
     "\n"
@@ -1863,6 +1877,7 @@ PyMethodDef Repository_methods[] = {
     METHOD(Repository, listall_branches, METH_VARARGS),
     METHOD(Repository, create_branch, METH_VARARGS),
     METHOD(Repository, reset, METH_VARARGS),
+    METHOD(Repository, free, METH_NOARGS),
     METHOD(Repository, expand_id, METH_O),
     METHOD(Repository, _from_c, METH_VARARGS),
     METHOD(Repository, _disown, METH_NOARGS),


### PR DESCRIPTION
This patch implements a repository member for cleaning up resources of the underlying repository struct without deallocating it. This is normally handled when deallocating the repository Python object. But longer running processes can run out of open file handles before the garbage collector runs.