### PR TITLE
test_repository: Replace deprecated assertEquals with assertEqual

### DIFF
--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -446,13 +446,13 @@ class RepositoryTest_II(utils.RepoTestCase):
         revert_index = self.repo.revert_commit(commit_to_revert, master)
         revert_diff_stats = revert_index.diff_to_tree(master.tree).stats
 
-        self.assertEquals(
+        self.assertEqual(
             revert_diff_stats.insertions, commit_diff_stats.deletions
         )
-        self.assertEquals(
+        self.assertEqual(
             revert_diff_stats.deletions, commit_diff_stats.insertions
         )
-        self.assertEquals(
+        self.assertEqual(
             revert_diff_stats.files_changed, commit_diff_stats.files_changed
         )
 


### PR DESCRIPTION
When running tests, I got a nag message about assertEquals being deprecated. This fixes the issue.