### PR TITLE
Add patch Property to Patch Objects

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -119,7 +119,7 @@ Blob_diff_to_buffer(Blob *self, PyObject *args, PyObject *kwds)
     char *keywords[] = {"buffer", "flag", "old_as_path", "buffer_as_path",
                         NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|s#Iss", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|z#Iss", keywords,
                                      &buffer, &buffer_len, &opts.flags,
                                      &old_as_path, &buffer_as_path))
         return NULL;

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -57,6 +57,28 @@ index a520c24..95d09f2 100644
 \ No newline at end of file
 """
 
+BLOB_PATCH_DELETED = """diff --git a/file b/file
+deleted file mode 100644
+index a520c24..0000000
+--- a/file
++++ /dev/null
+@@ -1,3 +0,0 @@
+-hello world
+-hola mundo
+-bonjour le monde
+"""
+
+BLOB_PATCH_ADDED = """diff --git a/file b/file
+new file mode 100644
+index 0000000..a520c24
+--- /dev/null
++++ b/file
+@@ -0,0 +1,3 @@
++hello world
++hola mundo
++bonjour le monde
+"""
+
 class BlobTest(utils.RepoTestCase):
 
     def test_read_blob(self):
@@ -152,6 +174,17 @@ class BlobTest(utils.RepoTestCase):
         blob = self.repo[BLOB_SHA]
         patch = blob.diff_to_buffer("hello world")
         self.assertEqual(patch.patch, BLOB_PATCH)
+
+    def test_diff_blob_to_buffer_delete(self):
+        blob = self.repo[BLOB_SHA]
+        patch = blob.diff_to_buffer(None)
+        self.assertEqual(patch.patch, BLOB_PATCH_DELETED)
+
+    def test_diff_blob_to_buffer_add(self):
+        # We can emulate an add by reversing a delete
+        blob = self.repo[BLOB_SHA]
+        patch = blob.diff_to_buffer(None, pygit2.GIT_DIFF_REVERSE)
+        self.assertEqual(patch.patch, BLOB_PATCH_ADDED)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -45,6 +45,17 @@ bonjour le monde
 BLOB_NEW_CONTENT = b'foo bar\n'
 BLOB_FILE_CONTENT = b'bye world\n'
 
+BLOB_PATCH = """diff --git a/file b/file
+index a520c24..95d09f2 100644
+--- a/file
++++ b/file
+@@ -1,3 +1 @@
+-hello world
+-hola mundo
+-bonjour le monde
++hello world
+\ No newline at end of file
+"""
 
 class BlobTest(utils.RepoTestCase):
 
@@ -136,6 +147,11 @@ class BlobTest(utils.RepoTestCase):
         blob = self.repo[BLOB_SHA]
         patch = blob.diff_to_buffer("hello world")
         self.assertEqual(len(patch.hunks), 1)
+
+    def test_diff_blob_to_buffer_patch_patch(self):
+        blob = self.repo[BLOB_SHA]
+        patch = blob.diff_to_buffer("hello world")
+        self.assertEqual(patch.patch, BLOB_PATCH)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -68,16 +68,6 @@ index a520c24..0000000
 -bonjour le monde
 """
 
-BLOB_PATCH_ADDED = """diff --git a/file b/file
-new file mode 100644
-index 0000000..a520c24
---- /dev/null
-+++ b/file
-@@ -0,0 +1,3 @@
-+hello world
-+hola mundo
-+bonjour le monde
-"""
 
 class BlobTest(utils.RepoTestCase):
 
@@ -179,12 +169,6 @@ class BlobTest(utils.RepoTestCase):
         blob = self.repo[BLOB_SHA]
         patch = blob.diff_to_buffer(None)
         self.assertEqual(patch.patch, BLOB_PATCH_DELETED)
-
-    def test_diff_blob_to_buffer_add(self):
-        # We can emulate an add by reversing a delete
-        blob = self.repo[BLOB_SHA]
-        patch = blob.diff_to_buffer(None, pygit2.GIT_DIFF_REVERSE)
-        self.assertEqual(patch.patch, BLOB_PATCH_ADDED)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #739 

PR Does the following:
* Adds the `patch` property to Patch objects, which follows the blueprint of `Diff.patch` almost exactly.

* Changes the parameter type for `Blob.diff_to_buffer` to allow for `None` as a valid parameter, signalling deletion.

* Adds two tests