### PR TITLE
Use existing blobs in test_patch; Make create_from args optional

### DIFF
--- a/src/patch.c
+++ b/src/patch.c
@@ -108,7 +108,7 @@ PyDoc_STRVAR(Patch_create_from__doc__,
     "Create a patch from blobs, buffers, or a blob and a buffer");
 
 static PyObject *
-Patch_create_from(PyObject *self, PyObject *args)
+Patch_create_from(PyObject *self, PyObject *args, PyObject *kwds)
 {
   /* A generic wrapper around
    * git_patch_from_blob_and_buffer
@@ -124,8 +124,11 @@ Patch_create_from(PyObject *self, PyObject *args)
   Py_ssize_t oldbuflen, newbuflen;
   int err;
 
-  if (!PyArg_ParseTuple(args, "OzOz|I", &oldobj, &old_as_path, &newobj,
-                        &new_as_path, &opts.flags))
+  char *keywords[] = {"old", "new", "flag", "old_as_path", "new_as_path", NULL};
+
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|Izz", keywords,
+                                   &oldobj, &newobj, &opts.flags,
+                                   &old_as_path, &new_as_path))
     return NULL;
 
   if (oldobj != Py_None && PyObject_TypeCheck(oldobj, &BlobType))
@@ -201,7 +204,8 @@ cleanup:
 }
 
 PyMethodDef Patch_methods[] = {
-    {"create_from", (PyCFunction) Patch_create_from, METH_VARARGS | METH_STATIC, Patch_create_from__doc__},
+    {"create_from", (PyCFunction) Patch_create_from,
+      METH_KEYWORDS | METH_VARARGS | METH_STATIC, Patch_create_from__doc__},
     {NULL}
 };
 

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -31,15 +31,26 @@ from __future__ import unicode_literals
 import pygit2
 from . import utils
 
-BLOB_SHA = 'a520c24d85fbfc815d385957eed41406ca5a860b'
-BLOB_OLD_CONTENT = """hello world
+BLOB_OLD_SHA = 'a520c24d85fbfc815d385957eed41406ca5a860b'
+BLOB_NEW_SHA = '3b18e512dba79e4c8300dd08aeb37f8e728b8dad'
+BLOB_OLD_CONTENT = b"""hello world
 hola mundo
 bonjour le monde
-""".encode()
+"""
 BLOB_NEW_CONTENT = b'foo bar\n'
 
 BLOB_OLD_PATH = 'a/file'
 BLOB_NEW_PATH = 'b/file'
+
+BLOB_PATCH2 = """diff --git a/a/file b/b/file
+index a520c24..3b18e51 100644
+--- a/a/file
++++ b/b/file
+@@ -1,3 +1 @@
+ hello world
+-hola mundo
+-bonjour le monde
+"""
 
 BLOB_PATCH = """diff --git a/a/file b/b/file
 index a520c24..d675fa4 100644
@@ -78,33 +89,33 @@ class PatchTest(utils.RepoTestCase):
     def test_patch_create_from_buffers(self):
         patch = pygit2.Patch.create_from(
             BLOB_OLD_CONTENT,
-            BLOB_OLD_PATH,
             BLOB_NEW_CONTENT,
-            BLOB_NEW_PATH,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
         )
 
         self.assertEqual(patch.patch, BLOB_PATCH)
 
     def test_patch_create_from_blobs(self):
-        old_blob = self.repo.create_blob(BLOB_OLD_CONTENT)
-        new_blob = self.repo.create_blob(BLOB_NEW_CONTENT)
+        old_blob = self.repo[BLOB_OLD_SHA]
+        new_blob = self.repo[BLOB_NEW_SHA]
 
         patch = pygit2.Patch.create_from(
-            self.repo[old_blob],
-            BLOB_OLD_PATH,
-            self.repo[new_blob],
-            BLOB_NEW_PATH,
+            old_blob,
+            new_blob,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
         )
 
-        self.assertEqual(patch.patch, BLOB_PATCH)
+        self.assertEqual(patch.patch, BLOB_PATCH2)
 
     def test_patch_create_from_blob_buffer(self):
-        old_blob = self.repo.create_blob(BLOB_OLD_CONTENT)
+        old_blob = self.repo[BLOB_OLD_SHA]
         patch = pygit2.Patch.create_from(
-            self.repo[old_blob],
-            BLOB_OLD_PATH,
+            old_blob,
             BLOB_NEW_CONTENT,
-            BLOB_NEW_PATH,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
         )
 
         self.assertEqual(patch.patch, BLOB_PATCH)
@@ -112,21 +123,21 @@ class PatchTest(utils.RepoTestCase):
     def test_patch_create_from_blob_buffer_add(self):
         patch = pygit2.Patch.create_from(
             None,
-            BLOB_OLD_PATH,
             BLOB_NEW_CONTENT,
-            BLOB_NEW_PATH,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
         )
 
         self.assertEqual(patch.patch, BLOB_PATCH_ADDED)
 
     def test_patch_create_from_blob_buffer_delete(self):
-        old_blob = self.repo.create_blob(BLOB_OLD_CONTENT)
+        old_blob = self.repo[BLOB_OLD_SHA]
 
         patch = pygit2.Patch.create_from(
-            self.repo[old_blob],
-            BLOB_OLD_PATH,
+            old_blob,
             None,
-            BLOB_NEW_PATH,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
         )
 
         self.assertEqual(patch.patch, BLOB_PATCH_DELETED)
@@ -135,16 +146,12 @@ class PatchTest(utils.RepoTestCase):
         with self.assertRaises(TypeError):
             pygit2.Patch.create_from(
                 self.repo,
-                BLOB_OLD_PATH,
                 BLOB_NEW_CONTENT,
-                BLOB_NEW_PATH,
             )
 
     def test_patch_create_from_bad_new_type_arg(self):
         with self.assertRaises(TypeError):
             pygit2.Patch.create_from(
                 None,
-                BLOB_OLD_PATH,
                 self.repo,
-                BLOB_NEW_PATH,
             )


### PR DESCRIPTION
Fixes #748 

For some reason, when using `repo.create_blob(CONTENT)` in the test cases, tests failed (as reported in the issue) on some machines (Did not fail on my Mac OS machine, Did not fail on AppVeyor Windows machines, **Did fail** on my CentOS machine).

I have no idea why that is. Perhaps I was doing something wrong.. perhaps there is something wrong with `create_blob`. I will create a followup issue to track it.

In any case, this PR fixes the issue by using the already existing repo blobs for the test cases. Further, after learning more about pygit2, I switched `create_from` to take optional params.

I think that 0.26.3 should be released after this PR is merged since 0.26.2 tests are broken for some users..