### PR TITLE
Patch.create_from: Add support for context_lines and interhunk_lines

### DIFF
--- a/src/patch.c
+++ b/src/patch.c
@@ -124,11 +124,14 @@ Patch_create_from(PyObject *self, PyObject *args, PyObject *kwds)
   Py_ssize_t oldbuflen, newbuflen;
   int err;
 
-  char *keywords[] = {"old", "new", "flag", "old_as_path", "new_as_path", NULL};
+  char *keywords[] = {"old", "new", "old_as_path", "new_as_path",
+                      "flag", "context_lines", "interhunk_lines",
+                      NULL};
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|Izz", keywords,
-                                   &oldobj, &newobj, &opts.flags,
-                                   &old_as_path, &new_as_path))
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|zzIHH", keywords,
+                                   &oldobj, &newobj, &old_as_path, &new_as_path,
+                                   &opts.flags, &opts.context_lines,
+                                   &opts.interhunk_lines))
     return NULL;
 
   if (oldobj != Py_None && PyObject_TypeCheck(oldobj, &BlobType))

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -155,3 +155,38 @@ class PatchTest(utils.RepoTestCase):
                 None,
                 self.repo,
             )
+
+    def test_context_lines(self):
+        old_blob = self.repo[BLOB_OLD_SHA]
+        new_blob = self.repo[BLOB_NEW_SHA]
+
+        patch = pygit2.Patch.create_from(
+            old_blob,
+            new_blob,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
+        )
+
+        context_count = (
+            len([line for line in patch.patch.splitlines() if line.startswith(" ")])
+        )
+
+        self.assertNotEquals(context_count, 0)
+
+    def test_no_context_lines(self):
+        old_blob = self.repo[BLOB_OLD_SHA]
+        new_blob = self.repo[BLOB_NEW_SHA]
+
+        patch = pygit2.Patch.create_from(
+            old_blob,
+            new_blob,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
+            context_lines=0,
+        )
+
+        context_count = (
+            len([line for line in patch.patch.splitlines() if line.startswith(" ")])
+        )
+
+        self.assertEquals(context_count, 0)


### PR DESCRIPTION
Adds support for specifying context_lines and interhunk_lines when calling `Patch.create_from`.

I've also added two tests to test the context lines functionality.

The behavior in this PR mimics the behavior in `tree.c` for adding these flags into the options.