### PR TITLE
Add more tests to test_patch and test_blob

### DIFF
--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -57,6 +57,17 @@ index a520c24..95d09f2 100644
 \ No newline at end of file
 """
 
+BLOB_PATCH_2 = """diff --git a/file b/file
+index a520c24..d675fa4 100644
+--- a/file
++++ b/file
+@@ -1,3 +1 @@
+-hello world
+-hola mundo
+-bonjour le monde
++foo bar
+"""
+
 BLOB_PATCH_DELETED = """diff --git a/file b/file
 deleted file mode 100644
 index a520c24..0000000
@@ -169,6 +180,13 @@ class BlobTest(utils.RepoTestCase):
         blob = self.repo[BLOB_SHA]
         patch = blob.diff_to_buffer(None)
         self.assertEqual(patch.patch, BLOB_PATCH_DELETED)
+
+    def test_diff_blob_create(self):
+        old = self.repo[self.repo.create_blob(BLOB_CONTENT)]
+        new = self.repo[self.repo.create_blob(BLOB_NEW_CONTENT)]
+
+        patch = old.diff(new)
+        self.assertEqual(patch.patch, BLOB_PATCH_2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -188,5 +188,17 @@ class BlobTest(utils.RepoTestCase):
         patch = old.diff(new)
         self.assertEqual(patch.patch, BLOB_PATCH_2)
 
+    def test_blob_from_repo(self):
+        blob = self.repo[BLOB_SHA]
+        patch_one = blob.diff_to_buffer(None)
+
+        blob = self.repo[BLOB_SHA]
+        patch_two = blob.diff_to_buffer(None)
+
+        self.assertEqual(
+            patch_one.patch,
+            patch_two.patch,
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_patch.py
+++ b/test/test_patch.py
@@ -155,3 +155,77 @@ class PatchTest(utils.RepoTestCase):
                 None,
                 self.repo,
             )
+
+    def test_patch_create_blob_blobs(self):
+        old_blob = self.repo[self.repo.create_blob(BLOB_OLD_CONTENT)]
+        new_blob = self.repo[self.repo.create_blob(BLOB_NEW_CONTENT)]
+        patch = pygit2.Patch.create_from(
+            old_blob,
+            new_blob,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
+        )
+
+        self.assertEqual(patch.patch, BLOB_PATCH)
+
+    def test_patch_create_blob_buffer(self):
+        blob = self.repo[self.repo.create_blob(BLOB_OLD_CONTENT)]
+        patch = pygit2.Patch.create_from(
+            blob,
+            BLOB_NEW_CONTENT,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
+        )
+
+        self.assertEqual(patch.patch, BLOB_PATCH)
+
+    def test_patch_create_blob_delete(self):
+        blob = self.repo[self.repo.create_blob(BLOB_OLD_CONTENT)]
+        patch = pygit2.Patch.create_from(
+            blob,
+            None,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
+        )
+
+        self.assertEqual(patch.patch, BLOB_PATCH_DELETED)
+
+    def test_patch_create_blob_add(self):
+        blob = self.repo[self.repo.create_blob(BLOB_NEW_CONTENT)]
+        patch = pygit2.Patch.create_from(
+            None,
+            blob,
+            old_as_path=BLOB_OLD_PATH,
+            new_as_path=BLOB_NEW_PATH,
+        )
+
+        self.assertEqual(patch.patch, BLOB_PATCH_ADDED)
+
+    def test_patch_multi_content(self):
+        patch_text = []
+        patches = []
+        for content in [BLOB_OLD_CONTENT, BLOB_NEW_CONTENT]*10:
+            patch = pygit2.Patch.create_from(
+                content,
+                None,
+            )
+
+            patch_text.append(patch.patch)
+            patches.append(patch)
+
+        self.assertEqual(patch_text, [patch.patch for patch in patches])
+
+    def test_patch_multi_blob(self):
+        patch_text = []
+        patches = []
+        for sha in [BLOB_OLD_SHA, BLOB_NEW_SHA]*10:
+            blob = self.repo[sha]
+            patch = pygit2.Patch.create_from(
+                blob,
+                None
+            )
+
+            patch_text.append(patch.patch)
+            patches.append(patch)
+
+        self.assertEqual(patch_text, [patch.patch for patch in patches])


### PR DESCRIPTION
As reported in #754 , there are some strange corruption-looking things happening with creating patches. In order to find strange behavior, I've crafted the tests attached to this PR. 

At the time of writing, I could only get one of the tests to reliably fail: **test_patch_multi_blob**

```
Traceback (most recent call last):
  File "/home/engshare/third-party2/pygit2/0.26.2/src/build-gcc-5-glibc-2.23/pic/test/test_patch.py", line 231, in test_patch_multi_blob
    self.assertEqual(patch_text, [patch.patch for patch in patches])
AssertionError: Lists differ: [u'diff --git a/file b/file\nd... != [u'diff --git a/file b/file\nd...

First differing element 0:
diff --git a/file b/file
deleted file mode 100644
index a520c24..0000000
--- a/file
+++ /dev/null
@@ -1,3 +0,0 @@
-hello world
-hola mundo
-bonjour le monde

diff --git a/file b/file
deleted file mode 100644
index a520c24..0000000
--- a/file
+++ /dev/null
@@ -1,3 +0,0 @@
-@^H05

Diff is 11160 characters long. Set self.maxDiff to None to see it.
```

I don't think this PR should be merged in until the problem is fixed.