### PR TITLE
INCREF git objects when wrapping them

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -243,8 +243,9 @@ wrap_object(git_object *c_object, Repository *repo)
         py_obj->obj = c_object;
         if (repo) {
             py_obj->repo = repo;
-            Py_INCREF(repo);
         }
     }
+
+    Py_INCREF(py_obj);
     return (PyObject *)py_obj;
 }


### PR DESCRIPTION
Fixes #754 

After lots of investigation, I found that on some machines (my machines, not the machines in CI apparently) Patch objects would not `Patch.patch` properly if another blob was retrieved from the repo in between its creation and `patch.__get__()` call. As an incomplete example,

```python
blob = repo[sha]
patch = Patch.create_from(blob, None)
print(patch.patch) # Prints expected results

blob = repo[sha]
print(patch.patch) # Prints mangled, unexpected results

patch2 = Patch.create_from(blob, None)
print(patch2.patch) # Prints expected results
```

The problem is that patch needs the blob object to generate the patch. For some reason, the blob object goes away when another blob is retrieved from the repo. The problem is more clearly illustrated with:

```python
blob = repo[sha]
patch = Patch.create_from(blob, None)

# We delete the blob. We don't need it anymore since the patch was created
del blob

# However, this prints mangled stuff since the blob was deleted
print(patch.patch) 
```

The problem isn't just limited to `Patch.create_from`:
```python
blob = self.repo[sha]           
patch_one = blob.diff_to_buffer(None)
                                     
blob = self.repo[sha]           
patch_two = blob.diff_to_buffer(None)
                                     
# This check will fail
self.assertEqual(                    
    patch_one.patch,                 
    patch_two.patch,                 
)                     
```

I didn't do extensive testing, but the problem seemed to stem, in general, from `wrap_object`, which would wrap a `git_object*` in our custom `Object` class, but would not `INCREF` it before returning it. Thus, I've INCREFd it before returning and all seems to work!
