### PR TITLE
Give patch reference to underlying blob(s)

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -81,7 +81,7 @@ Blob_diff(Blob *self, PyObject *args, PyObject *kwds)
     if (err < 0)
         return Error_set(err);
 
-    return wrap_patch(patch);
+    return wrap_patch(patch, self, py_blob);
 }
 
 
@@ -130,7 +130,7 @@ Blob_diff_to_buffer(Blob *self, PyObject *args, PyObject *kwds)
     if (err < 0)
         return Error_set(err);
 
-    return wrap_patch(patch);
+    return wrap_patch(patch, self, NULL);
 }
 
 static PyMethodDef Blob_methods[] = {

--- a/src/diff.c
+++ b/src/diff.c
@@ -422,7 +422,7 @@ diff_get_patch_byindex(git_diff *diff, size_t idx)
     if (err < 0)
         return Error_set(err);
 
-    return (PyObject*) wrap_patch(patch);
+    return (PyObject*) wrap_patch(patch, NULL, NULL);
 }
 
 PyObject *

--- a/src/patch.c
+++ b/src/patch.c
@@ -40,7 +40,7 @@ PyTypeObject PatchType;
 
 
 PyObject *
-wrap_patch(git_patch *patch)
+wrap_patch(git_patch *patch, Blob *oldblob, Blob *newblob)
 {
     Patch *py_patch;
     PyObject *py_hunk;
@@ -59,6 +59,12 @@ wrap_patch(git_patch *patch)
             if (py_hunk)
                 PyList_SetItem((PyObject*) py_patch->hunks, i, py_hunk);
         }
+
+        Py_XINCREF(oldblob);
+        py_patch->oldblob = oldblob;
+
+        Py_XINCREF(newblob);
+        py_patch->newblob = newblob;
     }
 
     return (PyObject*) py_patch;
@@ -67,6 +73,8 @@ wrap_patch(git_patch *patch)
 static void
 Patch_dealloc(Patch *self)
 {
+    Py_CLEAR(self->oldblob);
+    Py_CLEAR(self->newblob);
     Py_CLEAR(self->hunks);
     git_patch_free(self->patch);
     PyObject_Del(self);
@@ -169,7 +177,7 @@ Patch_create_from(PyObject *self, PyObject *args, PyObject *kwds)
   if (err < 0)
     return Error_set(err);
 
-  return wrap_patch(patch);
+  return wrap_patch(patch, oldblob, newblob);
 }
 
 

--- a/src/patch.h
+++ b/src/patch.h
@@ -32,6 +32,6 @@
 #include <Python.h>
 #include <git2.h>
 
-PyObject* wrap_patch(git_patch *patch);
+PyObject* wrap_patch(git_patch *patch, Blob *oldblob, Blob *newblob);
 
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -95,6 +95,8 @@ typedef struct {
     PyObject_HEAD
     git_patch *patch;
     PyObject* hunks;
+    Blob* oldblob;
+    Blob* newblob;
 } Patch;
 
 /* git_diff */


### PR DESCRIPTION
Fixes #754 and also allows merging of #758 .

As described in #754, Patch objects do not have a reference to their underlying blobs. Thus, if the blob is freed before patch text is generated, the patch text becomes mangled. This is ultimately an issue in libgit2 and the issue is being tracked in https://github.com/libgit2/libgit2/issues/4442

In the meantime, the problem can be solved at the pygit2 level. This PR adds blob references to the pygit2 Patch objects and increments their reference counters when a patch with blobs is generated.

When the fix is ultimately merged into libgit2, this behavior should probably be removed from pygit2. Until then, this is a good fix!