### PR TITLE
git_cred_ssh_key_memory_new() support was added.

### DIFF
--- a/pygit2/credentials.py
+++ b/pygit2/credentials.py
@@ -30,6 +30,7 @@ from .ffi import C
 GIT_CREDTYPE_USERNAME = C.GIT_CREDTYPE_USERNAME
 GIT_CREDTYPE_USERPASS_PLAINTEXT = C.GIT_CREDTYPE_USERPASS_PLAINTEXT
 GIT_CREDTYPE_SSH_KEY = C.GIT_CREDTYPE_SSH_KEY
+GIT_CREDTYPE_SSH_MEMORY = C.GIT_CREDTYPE_SSH_MEMORY
 
 
 class Username(object):
@@ -121,3 +122,9 @@ class Keypair(object):
 class KeypairFromAgent(Keypair):
     def __init__(self, username):
         super(KeypairFromAgent, self).__init__(username, None, None, None)
+
+
+class KeypairFromMemory(Keypair):
+    @property
+    def credential_type(self):
+        return GIT_CREDTYPE_SSH_MEMORY

--- a/pygit2/decl.h
+++ b/pygit2/decl.h
@@ -125,7 +125,8 @@ typedef enum {
 	GIT_CREDTYPE_DEFAULT,
     GIT_CREDTYPE_SSH_INTERACTIVE,
     GIT_CREDTYPE_USERNAME,
-	...
+    GIT_CREDTYPE_SSH_MEMORY,
+    ...
 } git_credtype_t;
 
 typedef enum git_cert_t {
@@ -322,6 +323,12 @@ int git_cred_ssh_key_new(
 int git_cred_ssh_key_from_agent(
     git_cred **out,
     const char *username);
+int git_cred_ssh_key_memory_new(
+    git_cred **out,
+    const char *username,
+    const char *publickey,
+    const char *privatekey,
+    const char *passphrase);
 
 /*
  * git_diff

--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -508,6 +508,13 @@ def get_credentials(fn, url, username, allowed):
         name, = credential_tuple
         err = C.git_cred_username_new(ccred, to_bytes(name))
 
+    elif cred_type == C.GIT_CREDTYPE_SSH_MEMORY:
+        name, pubkey, privkey, passphrase = credential_tuple
+        if pubkey is None and privkey is None:
+            raise TypeError("SSH keys from memroy are empty")
+        err = C.git_cred_ssh_key_memory_new(ccred, to_bytes(name),
+                                            to_bytes(pubkey), to_bytes(privkey),
+                                            to_bytes(passphrase))
     else:
         raise TypeError("unsupported credential type")
 

--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -511,7 +511,7 @@ def get_credentials(fn, url, username, allowed):
     elif cred_type == C.GIT_CREDTYPE_SSH_MEMORY:
         name, pubkey, privkey, passphrase = credential_tuple
         if pubkey is None and privkey is None:
-            raise TypeError("SSH keys from memroy are empty")
+            raise TypeError("SSH keys from memory are empty")
         err = C.git_cred_ssh_key_memory_new(ccred, to_bytes(name),
                                             to_bytes(pubkey), to_bytes(privkey),
                                             to_bytes(passphrase))

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -31,7 +31,7 @@
 import unittest
 import pygit2
 from pygit2 import GIT_CREDTYPE_USERPASS_PLAINTEXT
-from pygit2 import Username, UserPass, Keypair, KeypairFromAgent
+from pygit2 import Username, UserPass, Keypair, KeypairFromAgent, KeypairFromMemory
 from . import utils
 
 REMOTE_NAME = 'origin'
@@ -71,6 +71,15 @@ class CredentialCreateTest(utils.NoRepoTestCase):
  
         cred = KeypairFromAgent(username)
         self.assertEqual((username, None, None, None), cred.credential_tuple)
+
+    def test_ssh_from_memory(self):
+        username = "git"
+        pubkey = "public key data"
+        privkey = "private key data"
+        passphrase = "secret passphrase"
+
+        cred = KeypairFromMemory(username, pubkey, privkey, passphrase)
+        self.assertEqual((username, pubkey, privkey, passphrase), cred.credential_tuple)
 
 
 class CredentialCallback(utils.RepoTestCase):


### PR DESCRIPTION
Now we can use keys which are stored in memory objects.