### PR TITLE
Add static Diff.parse_diff

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -831,9 +831,6 @@ Diff_merge(Diff *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O!", &DiffType, &py_diff))
         return NULL;
 
-    if (py_diff->repo->repo != self->repo->repo)
-        return Error_set(GIT_ERROR);
-
     err = git_diff_merge(self->diff, py_diff->diff);
     if (err < 0)
         return Error_set(err);

--- a/src/repository.c
+++ b/src/repository.c
@@ -1465,32 +1465,6 @@ Repository_create_reference_symbolic(Repository *self,  PyObject *args,
     return wrap_reference(c_reference, self);
 }
 
-PyDoc_STRVAR(Repository_parse_diff__doc__,
-  "parse_diff(git_diff: str) -> Diff\n"
-  "\n"
-  "Parses a git unified diff into a diff object applied to the repository");
-
-PyObject *
-Repository_parse_diff(PyObject *self, PyObject *args)
-{
-  /* A wrapper around
-   * git_diff_from_buffer
-  */
-  git_diff *diff;
-  const char *content = NULL;
-  Py_ssize_t content_len;
-  int err;
-
-  if (!PyArg_ParseTuple(args, "s#", &content, &content_len))
-    return NULL;
-
-  err = git_diff_from_buffer(&diff, content, content_len);
-  if (err < 0)
-    return Error_set(err);
-
-  return wrap_diff(diff, (Repository *) self);
-}
-
 PyDoc_STRVAR(Repository_status__doc__,
   "status() -> {str: int}\n"
   "\n"
@@ -1839,7 +1813,6 @@ PyMethodDef Repository_methods[] = {
     METHOD(Repository, init_submodules, METH_VARARGS | METH_KEYWORDS),
     METHOD(Repository, lookup_reference, METH_O),
     METHOD(Repository, revparse_single, METH_O),
-    METHOD(Repository, parse_diff, METH_VARARGS),
     METHOD(Repository, status, METH_NOARGS),
     METHOD(Repository, status_file, METH_O),
     METHOD(Repository, notes, METH_VARARGS),

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -343,6 +343,16 @@ class DiffTest(utils.BareRepoTestCase):
             # As explained in the libgit2 documentation, flags are not set
             #self.assertEqual(delta.flags, patch_delta.flags)
 
+    def test_diff_parse(self):
+        diff = pygit2.Diff.parse_diff(PATCH)
+
+        stats = diff.stats
+        self.assertEqual(2, stats.deletions)
+        self.assertEqual(1, stats.insertions)
+        self.assertEqual(2, stats.files_changed)
+
+        deltas = list(diff.deltas)
+        self.assertEqual(2, len(deltas))
 
 class BinaryDiffTest(utils.BinaryFileRepoTestCase):
     def test_binary_diff(self):

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -29,6 +29,7 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import textwrap
 import unittest
 import pygit2
 from pygit2 import GIT_DIFF_INCLUDE_UNMODIFIED
@@ -353,6 +354,23 @@ class DiffTest(utils.BareRepoTestCase):
 
         deltas = list(diff.deltas)
         self.assertEqual(2, len(deltas))
+
+    def test_parse_diff_null(self):
+        with self.assertRaises(Exception):
+            self.repo.parse_diff(None)
+
+    def test_parse_diff_bad(self):
+        diff = textwrap.dedent(
+        """
+        diff --git a/file1 b/file1
+        old mode 0644
+        new mode 0644
+        @@ -1,1 +1,1 @@
+        -Hi!
+        """)
+        with self.assertRaises(Exception):
+            self.repo.parse_diff(diff)
+
 
 class BinaryDiffTest(utils.BinaryFileRepoTestCase):
     def test_binary_diff(self):

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -35,7 +35,6 @@ from __future__ import unicode_literals
 import binascii
 import unittest
 import tempfile
-import textwrap
 import os
 from os.path import join, realpath
 import sys
@@ -196,45 +195,6 @@ class RepositoryTest(utils.BareRepoTestCase):
         hashed_sha1 = pygit2.hash(data)
         written_sha1 = self.repo.create_blob(data)
         self.assertEqual(hashed_sha1, written_sha1)
-
-    def test_parse_diff_null(self):
-        with self.assertRaises(Exception):
-            self.repo.parse_diff(None)
-
-    def test_parse_diff_bad(self):
-        diff = textwrap.dedent(
-        """
-        diff --git a/file1 b/file1
-        old mode 0644
-        new mode 0644
-        @@ -1,1 +1,1 @@
-        -Hi!
-        """)
-        with self.assertRaises(Exception):
-            self.repo.parse_diff(diff)
-
-    def test_parse_diff(self):
-        diff = textwrap.dedent(
-        """
-        diff --git a/file1 b/file1
-        old mode 0644
-        new mode 0644
-        @@ -1,1 +1,1 @@
-        -Hello, world!
-        +Hola, Mundo!
-        """
-        )
-        git_diff = self.repo.parse_diff(diff)
-        stats = git_diff.stats
-        deltas = list(git_diff.deltas)
-
-        self.assertEqual(1, stats.deletions)
-        self.assertEqual(1, stats.insertions)
-        self.assertEqual(1, stats.files_changed)
-
-        self.assertEqual(1, len(deltas))
-        self.assertEqual("file1", deltas[0].old_file.path)
-        self.assertEqual("file1", deltas[0].new_file.path)
 
     def test_hashfile(self):
         data = "bazbarfoo"


### PR DESCRIPTION
I think this PR is a little less straight forward than #772 

I think the user should be able to create a Diff object from a unified diff without needing a repository, as in [`git_diff_from_buffer`](https://libgit2.github.com/libgit2/#HEAD/group/diff/git_diff_from_buffer). The existing pygit2 API, however, requires that a Repository be provided when creating a Diff object.

This PR relaxes that requirement and allows `NULL` to be provided for the Repository when creating a Diff object. This allows Diffs to be created without repos.

If this is a good idea, let's merge this in! If not, let's have a discussion. I'm also open to the idea of having an optional kwarg `repository=` so that we can reuse this code in `Repository.parse_diff`