### PR TITLE
Update Config.__iter__ to match the documentation

### DIFF
--- a/pygit2/config.py
+++ b/pygit2/config.py
@@ -63,7 +63,10 @@ class ConfigIterator(object):
 
     def __next__(self):
         entry = self._next_entry()
-        return ffi.string(entry.name).decode('utf-8')
+        return (
+            ffi.string(entry.name).decode('utf-8'),
+            ffi.string(entry.value).decode('utf-8'),
+        )
 
 
 class ConfigMultivarIterator(ConfigIterator):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -173,8 +173,8 @@ class ConfigTest(utils.RepoTestCase):
         config = self.repo.config
         lst = {}
 
-        for name in config:
-            lst[name] = config[name]
+        for key, value in config:
+            lst[key] = value
 
         self.assertTrue('core.bare' in lst)
         self.assertTrue(lst['core.bare'])


### PR DESCRIPTION
## Problem

[The `Config.__iter__` docs](http://www.pygit2.org/config.html#Config.__iter__) say the method iterates over all entries, where "[e]ach element is a tuple containing the name and the value", which could be problematic as the method "may return multiple versions of each entry if they are set multiple times." However, the (final) `next` method on the iterator only [returns the `name` of the entry](https://github.com/libgit2/pygit2/blob/master/pygit2/config.py#L64). There's a very good chance it's never returned a tuple, [evidenced by the `blame`](https://github.com/libgit2/pygit2/blame/master/pygit2/config.py#L66).

### Example
```python
from __future__ import print_function
from tempfile import NamedTemporaryFile
from pygit2 import Config

# Start with a blank slate
blank = Config()

# https://git-scm.com/docs/git-config#git-config-pushdefault
for index, value in list(enumerate(['nothing', 'current', 'upstream'])):
    # There's probably a better way to do this
    with NamedTemporaryFile() as config_file:
        config_file.write("[push]\n\tdefault = %s" % value)
        config_file.seek(0)
        blank.add_file(config_file.name, index)

# This executes Config.__iter__
for key in blank:
    # Since it doesn't return a value, we're stuck with the default return
    print(key, blank[key])
# push.default upstream
# push.default upstream
# push.default upstream

# It's not actually a multivar, but we can see everything this way
for value in blank.get_multivar('push.default'):
    print(value)
# nothing
# current
# upstream
```
## Pull Request

I updated `__next__`'s return to also include the value. This matches what the docs describe, returning a tuple of name and value. Since the change only affects the iterator, the default value return isn't affected.

I also updated the test to consume the tuple. There's probably more that could go there, but I'm not quite sure what yet.

### `libgit2`

I think `libgit2` supports my interpretation of things. [`git_config_iterator`](https://libgit2.github.com/libgit2/#HEAD/type/git_config_iterator) iterates over [`git_config_entry`](https://libgit2.github.com/libgit2/#HEAD/type/git_config_entry), which contains both the name and the value (as well as some other information that might be useful to use). 

### Extension

Looking at my example above, it doesn't seem like `(key, value)` is all that useful. It might be a good idea to also return `level`. It's [in `git_config_entry`](https://libgit2.github.com/libgit2/#HEAD/type/git_config_entry), so it's available to the iterator.

## Alternative

As I pointed out, I don't think this has worked as intended [for years](https://github.com/thecjharries/pygit2/blame/master/pygit2/config.py). An equally simple solution would be to update the docs to match the current behavior. I'd be more than happy to do that if this PR is rejected.
