### PR TITLE
Refactor Config.__iter__ to iterate over ConfigEntry objects

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -17,10 +17,10 @@ The Config type
 .. method:: Config.__iter__()
 
    The :class:`Config` class has an iterator which can be used to loop
-   through all the entries in the configuration. Each element is a tuple
-   containing the name and the value of each configuration variable. Be
-   aware that this may return multiple versions of each entry if they are
-   set multiple times in the configuration files.
+   through all the entries in the configuration. Each element is a
+   ``ConfigEntry`` object containing the name, level, and value of each
+   configuration variable. Be aware that this may return multiple versions of
+   each entry if they are set multiple times in the configuration files.
 
 .. currentmodule:: pygit2
 
@@ -32,3 +32,14 @@ string. In order to apply the git-config parsing rules, you can use
 
 .. automethod:: pygit2.Config.get_bool
 .. automethod:: pygit2.Config.get_int
+
+
+The ConfigEntry type
+====================
+
+.. automethod:: pygit2.ConfigEntry.decode_as_string
+.. automethod:: pygit2.ConfigEntry._from_c
+.. automethod:: pygit2.ConfigEntry.name
+.. automethod:: pygit2.ConfigEntry.level
+.. automethod:: pygit2.ConfigEntry.value
+.. automethod:: pygit2.ConfigEntry.value_string

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -173,8 +173,9 @@ class ConfigTest(utils.RepoTestCase):
         config = self.repo.config
         lst = {}
 
-        for name in config:
-            lst[name] = config[name]
+        for entry in config:
+            self.assertGreater(entry.level, -1)
+            lst[entry.name] = entry.value
 
         self.assertTrue('core.bare' in lst)
         self.assertTrue(lst['core.bare'])


### PR DESCRIPTION
This PR supersedes #776.

## Summary

`Config.__iter__` iterates over a list of `ConfigEntry` objects instead of a list of names, matching the behavior of [`git_config_iterator`](https://libgit2.github.com/libgit2/#HEAD/type/git_config_iterator).

## Changes

### `ConfigEntry`

* Added a new `staticmethod`, `decode_as_string`, to simplify all the `ffi.string(value).decode('utf-8')` calls.
* Added a new flag to `_from_c`, `from_iterator=False`, to track the origin of the entry.
* Changed `__del__` behavior to only [`git_config_entry_free`](https://libgit2.github.com/libgit2/#HEAD/group/config/git_config_entry_free) `ConfigEntry`s created from [`git_config_get_entry`](https://libgit2.github.com/libgit2/#HEAD/group/config/git_config_get_entry). Attempting to free entries while iterating results in a seg fault. (If anyone can explain that to me, I'm curious. My C is pretty weak.)
* Exposed `level`, [the `git_config_level_t` value](https://libgit2.github.com/libgit2/#HEAD/type/git_config_level_t). (It looks like `pygit2` has a shortened list; I didn't play with this too much because that's a different feature.)
* Exposed `name`, the name of the entry, as a string (using `decode_as_string`).
* Exposed `value_string`, a convenience accessor for `decode_as_string(self.value)`.

All of these changes make it possible to create a `ConfigEntry` both from [`git_config_next`](https://libgit2.github.com/libgit2/#HEAD/group/config/git_config_next) and from [`git_config_get_entry`](https://libgit2.github.com/libgit2/#HEAD/group/config/git_config_get_entry). They expose some useful properties (`level`, `name`) which make it easier to track what an entry is and where it came from. `value` is the raw value that must be interpreted; `value_string` is conveniently a string that can be used immediately.

### `ConfigIterator`

* `_next_entry` returns a `ConfigEntry` instead of a pointer to a [`git_config_entry`](https://libgit2.github.com/libgit2/#HEAD/type/git_config_entry).
* `__next__` returns a `ConfigEntry` instead of the entry's name (see #776 for more info about that).

### `ConfigMultivarIterator`

* `__next__` returns `entry.value_string` instead of calling `ffi.string(entry.value).decode('utf-8')`

### `Config`

* `__getitem__` returns `entry.value_string` instead of calling `ffi.string(entry.value).decode('utf-8')`

### Tests

`test_iterator` was refactored to check that each entry's `level > -1` (again, `pygit2` seems to have a reduced set of items; this seemed like a safe check). It still checks that `core.bare` is in the list of entries and that it is set, which is what the original tests did.

`ConfigEntry` didn't gain any tests. My knowledge of `cffi` is pretty limited so I'm not quite sure how to set up mocks for that.

### Docs

* Updated `Config.__iter__` description
* Added `ConfigEntry` section

## Example

```python
from __future__ import print_function

from tempfile import NamedTemporaryFile

from pygit2 import Config, GIT_CONFIG_LEVEL_GLOBAL, GIT_CONFIG_LEVEL_LOCAL

blank = Config()

with NamedTemporaryFile() as config_file:
    config_file.write("[push]\n\tdefault = %s" % 'simple')
    config_file.seek(0)
    blank.add_file(config_file.name, GIT_CONFIG_LEVEL_GLOBAL)

with NamedTemporaryFile() as config_file:
    config_file.write("[push]\n\tdefault = %s\n[core]\n\tbare = no" % 'matching')
    config_file.seek(0)
    blank.add_file(config_file.name, GIT_CONFIG_LEVEL_LOCAL)

for entry in blank:
    print(entry.name, entry.value_string, entry.level)

# push.default simple 4
# push.default matching 5
# core.bare no 5

print(blank['push.default'])

# matching

print(blank['core.bare'])

# no

print(blank.get_bool('core.bare'))

# False
```