### PR TITLE
Fix typo in documentation

### DIFF
--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -183,7 +183,7 @@ class RemoteCallbacks(object):
         refname : str
             The name of the reference (on the remote).
 
-        messsage : str
+        message : str
             Rejection message from the remote. If None, the update was accepted.
         """
 


### PR DESCRIPTION
I just found a small typo in the documentation :slightly_smiling_face:.