### PR TITLE
doc: link to libgit2 ticket for git_log

### DIFF
--- a/docs/recipes/git-log.rst
+++ b/docs/recipes/git-log.rst
@@ -40,4 +40,8 @@ References
 
 - git-log_.
 
+- `libgit2 discussion about walker behavior
+  <https://github.com/libgit2/libgit2/issues/3041>`_. Note that the libgit2's
+  walker functions differently than ``git-log`` in some ways.
+
 .. _git-log: https://www.kernel.org/pub/software/scm/git/docs/git-log.html


### PR DESCRIPTION
The libgit2 walker is close to git-log in simple cases, but it does not
work quite the same way. For example, I've found that it does not return
the same number of commits compared to running "git log ref1..ref2".