### PR TITLE
Added binding for git_submodule_head_id

### DIFF
--- a/docs/submodule.rst
+++ b/docs/submodule.rst
@@ -19,3 +19,4 @@ The Submodule type
 .. autoattribute:: pygit2.Submodule.path
 .. autoattribute:: pygit2.Submodule.url
 .. autoattribute:: pygit2.Submodule.branch
+.. autoattribute:: pygit2.Submodule.head_id

--- a/pygit2/decl.h
+++ b/pygit2/decl.h
@@ -678,6 +678,7 @@ const char *git_submodule_name(git_submodule *subm);
 const char *git_submodule_path(git_submodule *subm);
 const char *git_submodule_url(git_submodule *subm);
 const char *git_submodule_branch(git_submodule *subm);
+const git_oid *git_submodule_head_id(git_submodule *subm);
 
 /*
  * git_index

--- a/pygit2/submodule.py
+++ b/pygit2/submodule.py
@@ -29,6 +29,7 @@
 # Import from the future
 from __future__ import absolute_import, unicode_literals
 
+from _pygit2 import Oid
 from .errors import check_error
 from .ffi import ffi, C
 
@@ -77,3 +78,10 @@ class Submodule(object):
         """Branch that is to be tracked by the submodule."""
         branch = C.git_submodule_branch(self._subm)
         return ffi.string(branch).decode('utf-8')
+
+    @property
+    def head_id(self):
+        """Head of the submodule."""
+        head = C.git_submodule_head_id(self._subm)
+        return Oid(raw=bytes(ffi.buffer(head)[:]))
+

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -95,5 +95,10 @@ class SubmoduleTest(utils.SubmoduleRepoTestCase):
         self.repo.update_submodules(init=True)
         self.assertTrue(os.path.exists(subrepo_file_path))
 
+    @unittest.skipIf(utils.no_network(), "Requires network")
+    def test_head_id(self):
+        s = self.repo.lookup_submodule(SUBM_PATH)
+        self.assertEqual(str(s.head_id), SUBM_HEAD_SHA)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
git_submodule_head_id is required for extructing the Oid targeted by a submodule 