### PR TITLE
Fix the docstring for Repository.descendant_of()

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -567,7 +567,7 @@ Repository_workdir__set__(Repository *self, PyObject *py_workdir)
 PyDoc_STRVAR(Repository_descendant_of__doc__,
   "descendant_of(oid, oid) -> bool\n"
   "\n"
-  "Determine if the second commit is a descendant of the first commit.\n"
+  "Determine if the first commit is a descendant of the second commit.\n"
   "Note that a commit is not considered a descendant of itself.");
 
 PyObject *


### PR DESCRIPTION
This fixes the docstring for `Repository.descendant_of()`.

For example, here is the documentation for libgit2's [`git_graph_descendant_of`](https://libgit2.org/libgit2/#HEAD/group/graph/git_graph_descendant_of):

> 1 if the given commit is a descendant of the potential ancestor [the second commit], 0 if not,

I confirmed that the existing pygit2 test case behaves as the language I'm suggesting.