### PR TITLE
Add bindings for git_reference_is_valid_name

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -23,6 +23,24 @@ Example::
     >>> repo.references.delete('refs/tags/version1')
 
 
+Functions
+===================================
+
+.. autofunction:: pygit2.reference_is_valid_name
+
+Check if the passed string is a valid reference name.
+
+   Example::
+
+     >>> from pygit2 import reference_is_valid_name
+     >>> reference_is_valid_name("refs/heads/master")
+     True
+     >>> reference_is_valid_name("HEAD")
+     True
+     >>> reference_is_valid_name("refs/heads/..")
+     False
+
+
 The Reference type
 ====================
 

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -183,6 +183,26 @@ cleanup:
 }
 
 
+PyDoc_STRVAR(reference_is_valid_name__doc__,
+    "reference_is_valid_name(refname) -> bool\n"
+    "\n"
+    "Check if the passed string is a valid reference name.");
+PyObject *
+reference_is_valid_name(PyObject *self, PyObject *args)
+{
+    char* refname;
+    int result;
+
+    if (!PyArg_ParseTuple(args, "es", "utf-8", &refname)) {
+        return NULL;
+    }
+
+    result = git_reference_is_valid_name(refname);
+    PyMem_Free(refname);
+    return PyBool_FromLong(result);
+}
+
+
 PyMethodDef module_methods[] = {
     {"init_file_backend", init_file_backend, METH_VARARGS,
     init_file_backend__doc__},
@@ -190,6 +210,7 @@ PyMethodDef module_methods[] = {
      discover_repository__doc__},
     {"hashfile", hashfile, METH_VARARGS, hashfile__doc__},
     {"hash", hash, METH_VARARGS, hash__doc__},
+    {"reference_is_valid_name", reference_is_valid_name, METH_VARARGS, reference_is_valid_name__doc__},
     {"option", option, METH_VARARGS, option__doc__},
     {NULL}
 };


### PR DESCRIPTION
Useful for checking if a branch or tag name is valid, e.g. for a UI that wants to validate a name before trying to create it.

See https://libgit2.org/libgit2/#HEAD/group/reference/git_reference_is_valid_name

I exposed it as a module function `reference_is_valid_name` similar to other free-standing functions that were already there (e.g. `discover_repository`, `hashfile`). A class method on `Reference` would be another option I could look into if you'd prefer that.