### PR TITLE
Raise more specific exceptions for GIT_EEXISTS and GIT_EINVALIDSPEC

### DIFF
--- a/docs/general.rst
+++ b/docs/general.rst
@@ -59,3 +59,16 @@ Exceptions
    :show-inheritance:
    :undoc-members:
 
+.. autoexception:: pygit2.AlreadyExistsError
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Exception when trying to create an object (reference, etc) that already exists.
+
+.. autoexception:: pygit2.InvalidSpecError
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Exception when an input specification such as a reference name is invalid.

--- a/src/error.c
+++ b/src/error.c
@@ -28,6 +28,8 @@
 #include "error.h"
 
 PyObject *GitError;
+PyObject *AlreadyExistsError;
+PyObject *InvalidSpecError;
 
 PyObject *
 Error_type(int type)
@@ -41,7 +43,7 @@ Error_type(int type)
 
         /* A reference with this name already exists */
         case GIT_EEXISTS:
-            return PyExc_ValueError;
+            return AlreadyExistsError;
 
         /* The given short oid is ambiguous */
         case GIT_EAMBIGUOUS:
@@ -53,7 +55,7 @@ Error_type(int type)
 
         /* Invalid input spec */
         case GIT_EINVALIDSPEC:
-            return PyExc_ValueError;
+            return InvalidSpecError;
 
         /* Skip and passthrough the given ODB backend */
         case GIT_PASSTHROUGH:

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -37,6 +37,8 @@
 #include "options.h"
 
 extern PyObject *GitError;
+extern PyObject *AlreadyExistsError;
+extern PyObject *InvalidSpecError;
 
 extern PyTypeObject RepositoryType;
 extern PyTypeObject OidType;
@@ -244,6 +246,14 @@ moduleinit(PyObject* m)
     GitError = PyErr_NewException("_pygit2.GitError", NULL, NULL);
     Py_INCREF(GitError);
     PyModule_AddObject(m, "GitError", GitError);
+
+    AlreadyExistsError = PyErr_NewException("_pygit2.AlreadyExistsError", PyExc_ValueError, NULL);
+    Py_INCREF(AlreadyExistsError);
+    PyModule_AddObject(m, "AlreadyExistsError", AlreadyExistsError);
+
+    InvalidSpecError = PyErr_NewException("_pygit2.InvalidSpecError", PyExc_ValueError, NULL);
+    Py_INCREF(InvalidSpecError);
+    PyModule_AddObject(m, "InvalidSpecError", InvalidSpecError);
 
     /* Repository */
     INIT_TYPE(RepositoryType, NULL, PyType_GenericNew)


### PR DESCRIPTION
Before, both would raise ValueError, making it hard to distinguish
between them to show users a meaningful error message.

The new exceptions AlreadyExistsError and InvalidSpecError extend
ValueError, so this change should be backwards-compatible.

(Fixes #828)