### PR TITLE
Fix test_create_reference on windows

### DIFF
--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -380,6 +380,9 @@ class ReferencesTest(utils.RepoTestCase):
         with pytest.raises(AlreadyExistsError) as error:
             self.repo.create_reference('refs/tags/version1', LAST_COMMIT)
         assert isinstance(error.value, ValueError)
+        
+        # Clear error
+        del error
 
         # try to create existing reference with force
         reference = self.repo.create_reference('refs/tags/version1',


### PR DESCRIPTION
Together with #833, this PR will hopefully turn the windows build green again