### PR TITLE
Added Repository.apply

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -1909,6 +1909,32 @@ out:
     return py_result;
 }
 
+PyDoc_STRVAR(Repository_apply__doc__,
+  "apply(id)\n"
+  "\n"
+  "Applies the given id into HEAD.\n"
+  "\n"
+  "Applies a diff into HEAD, writing the results into the\n"
+  "working directory.");
+
+PyObject *
+Repository_apply(Repository *self, PyObject *py_diff)
+{
+    int err;
+    git_apply_location_t location = GIT_APPLY_LOCATION_WORKDIR;
+    git_apply_options options = GIT_APPLY_OPTIONS_INIT;
+
+    err = git_apply(self->repo,
+                    ((Diff*)py_diff)->diff,
+                    location,
+	                &options);
+
+    if (err < 0)
+        return Error_set(err);
+
+    Py_RETURN_NONE;
+}
+
 PyMethodDef Repository_methods[] = {
     METHOD(Repository, create_blob, METH_VARARGS),
     METHOD(Repository, create_blob_fromworkdir, METH_VARARGS),
@@ -1923,6 +1949,7 @@ PyMethodDef Repository_methods[] = {
     METHOD(Repository, merge_analysis, METH_O),
     METHOD(Repository, merge, METH_O),
     METHOD(Repository, cherrypick, METH_O),
+    METHOD(Repository, apply, METH_O),
     METHOD(Repository, read, METH_O),
     METHOD(Repository, write, METH_VARARGS),
     METHOD(Repository, create_reference_direct, METH_VARARGS),

--- a/src/repository.h
+++ b/src/repository.h
@@ -78,5 +78,6 @@ PyObject* Repository_blame(Repository *self, PyObject *args, PyObject *kwds);
 
 PyObject* Repository_merge(Repository *self, PyObject *py_oid);
 PyObject* Repository_cherrypick(Repository *self, PyObject *py_oid);
+PyObject* Repository_apply(Repository *self, PyObject *py_diff);
 
 #endif

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -476,6 +476,26 @@ class RepositoryTest_II(utils.RepoTestCase):
         assert revert_diff_stats.deletions == commit_diff_stats.insertions
         assert revert_diff_stats.files_changed == commit_diff_stats.files_changed
 
+    def test_diff_patch(self):
+        new_content = 'bye world\nadiós\nau revoir monde\n'
+
+        # create the patch
+        with open(os.path.join(self.repo.workdir, 'hello.txt'), 'w') as f:
+            f.write(new_content)
+
+        patch = self.repo.diff().patch
+
+        # rollback all changes
+        self.repo.checkout('HEAD', strategy=pygit2.GIT_CHECKOUT_FORCE)
+
+        # apply the patch and compare
+        self.repo.apply(pygit2.Diff.parse_diff(patch))
+
+        with open(os.path.join(self.repo.workdir, 'hello.txt'), 'r') as f:
+            content = f.read()
+
+        self.assertEqual(content, new_content)
+
 
 class RepositorySignatureTest(utils.RepoTestCase):
 


### PR DESCRIPTION
Fixed #841 

This is a minimal version that does not accept options nor location. We can iterate on this.

Also, not sure if I should just accept the argument and cast it to `Diff*`, instead of properly check for its type. If yes, what is the idiom to do that? `PyArg_ParseTuple` only seems to accept positional arguments.


**DO NOT MERGE THIS**: this PR changes travis and appveyor to point to `master` of `libgit2`, since it is required for this feature to be tested. This should be changed to point to the release branch of a version of libgit2 that has the `git_apply` implemented in [this PR](
https://github.com/libgit2/libgit2/pull/4705)