### PR TITLE
Fix "invalid escape sequence \l" warning

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -590,7 +590,12 @@ Repository_descendant_of(Repository *self, PyObject *args)
     if (err < 0)
         return NULL;
 
-    return PyBool_FromLong(git_graph_descendant_of(self->repo, &oid1, &oid2));
+    // err < 0 => error, see source code of `git_graph_descendant_of`
+    err = git_graph_descendant_of(self->repo, &oid1, &oid2);
+    if (err < 0)
+        return Error_set(err);
+
+    return PyBool_FromLong(err);
 }
 
 PyDoc_STRVAR(Repository_merge_base__doc__,

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -359,6 +359,11 @@ class RepositoryTest_II(utils.RepoTestCase):
             'acecd5ea2924a4b900e7e149496e1f4b57976e51',
             '5ebeeebb320790caf276b9fc8b24546d63316533')
 
+        with pytest.raises(pygit2.GitError):
+            self.repo.descendant_of(
+                '2' * 40,  # a valid but inexistent SHA
+                '5ebeeebb320790caf276b9fc8b24546d63316533')
+
     def test_ahead_behind(self):
         ahead, behind = self.repo.ahead_behind(
             '5ebeeebb320790caf276b9fc8b24546d63316533',


### PR DESCRIPTION
Missing raw string, causing a DeprecationWarning in Python 3.6