### PR TITLE
add hash and equality operations on git objects

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -181,9 +181,10 @@ Object_peel(Object *self, PyObject *py_type)
 }
 
 Py_hash_t
-Object_hash(PyObject *object)
+Object_hash(Object *object)
 {
-    PyObject *py_oid = PyObject_GetAttrString(object, "oid");
+    const git_oid *oid = git_object_id(object->obj);
+    PyObject *py_oid = git_oid_to_py_str(oid);
     Py_hash_t ret = PyObject_Hash(py_oid);
     Py_DECREF(py_oid);
     return ret;

--- a/src/object.c
+++ b/src/object.c
@@ -27,6 +27,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include <git2.h>
 #include "error.h"
 #include "types.h"
 #include "utils.h"
@@ -192,8 +193,8 @@ PyObject *
 Object_richcompare(PyObject *o1, PyObject *o2, int op)
 {
     PyObject *res;
-    PyObject *oid1;
-    PyObject *oid2;
+    Object *obj1;
+    Object *obj2;
 
     if (!PyObject_TypeCheck(o2, &ObjectType)) {
         Py_INCREF(Py_NotImplemented);
@@ -202,18 +203,22 @@ Object_richcompare(PyObject *o1, PyObject *o2, int op)
 
     switch (op) {
         case Py_NE:
-            oid1 = PyObject_GetAttrString(o1, "oid");
-            oid2 = PyObject_GetAttrString(o2, "oid");
-            res = PyObject_RichCompare(oid1, oid2, Py_NE);
-            Py_DECREF(oid1);
-            Py_DECREF(oid2);
+            obj1 = (Object *) o1;
+            obj2 = (Object *) o2;
+            if (git_oid_equal(git_object_id(obj1->obj), git_object_id(obj2->obj))) {
+                res = Py_False;
+            } else {
+                res = Py_True;
+            }
             break;
         case Py_EQ:
-            oid1 = PyObject_GetAttrString(o1, "oid");
-            oid2 = PyObject_GetAttrString(o2, "oid");
-            res = PyObject_RichCompare(oid1, oid2, Py_EQ);
-            Py_DECREF(oid1);
-            Py_DECREF(oid2);
+            obj1 = (Object *) o1;
+            obj2 = (Object *) o2;
+            if (git_oid_equal(git_object_id(obj1->obj), git_object_id(obj2->obj))) {
+                res = Py_True;
+            } else {
+                res = Py_False;
+            }
             break;
         case Py_LT:
         case Py_LE:
@@ -226,6 +231,7 @@ Object_richcompare(PyObject *o1, PyObject *o2, int op)
             return NULL;
     }
 
+    Py_INCREF(res);
     return res;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -179,6 +179,15 @@ Object_peel(Object *self, PyObject *py_type)
     return wrap_object(peeled, self->repo);
 }
 
+Py_hash_t
+Object_hash(PyObject *object)
+{
+    PyObject *py_oid = PyObject_GetAttrString(object, "oid");
+    Py_hash_t ret = PyObject_Hash(py_oid);
+    Py_DECREF(py_oid);
+    return ret;
+}
+
 PyObject *
 Object_richcompare(PyObject *o1, PyObject *o2, int op)
 {
@@ -253,7 +262,7 @@ PyTypeObject ObjectType = {
     0,                                         /* tp_as_number      */
     0,                                         /* tp_as_sequence    */
     0,                                         /* tp_as_mapping     */
-    0,                                         /* tp_hash           */
+    (hashfunc)Object_hash,                     /* tp_hash           */
     0,                                         /* tp_call           */
     0,                                         /* tp_str            */
     0,                                         /* tp_getattro       */

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -46,6 +46,46 @@ BLOB_FILE_CONTENT = b'bye world\n'
 
 class ObjectTest(utils.RepoTestCase):
 
+    def test_equality(self):
+        # get a commit object twice and see if it equals itself
+        commit_id = self.repo.lookup_reference('refs/heads/master').target
+        commit_a = self.repo[commit_id]
+        commit_b = self.repo[commit_id]
+
+        assert commit_a is not commit_b
+        assert commit_a == commit_b
+        assert not(commit_a != commit_b)
+
+    def test_hashing(self):
+        # get a commit object twice and compare hashes
+        commit_id = self.repo.lookup_reference('refs/heads/master').target
+        commit_a = self.repo[commit_id]
+        commit_b = self.repo[commit_id]
+
+        assert hash(commit_a)
+
+        assert commit_a is not commit_b
+        assert commit_a == commit_b
+        # if the commits are equal then their hash *must* be equal
+        # but different objects can have the same commit
+        assert hash(commit_a) == hash(commit_b)
+
+        # sanity check that python container types work as expected
+        s = set()
+        s.add(commit_a)
+        s.add(commit_b)
+        assert len(s) == 1
+        assert commit_a in s
+        assert commit_b in s
+
+        d = {}
+        d[commit_a] = True
+        assert commit_b in d
+        assert d[commit_b]
+
+        l = [commit_a]
+        assert commit_b in l
+
     def test_peel_commit(self):
         # start by looking up the commit
         commit_id = self.repo.lookup_reference('refs/heads/master').target


### PR DESCRIPTION
Resolves issue #852 by implementing `__eq__`, `__ne__`, and `__hash__` for git `_pygit.Object` types. Uses contained `Oid` as a unique identifier and falls back to the `Oid` operations for the same.

The net result is that the following now happens without issue
```python
>>> import pygit2
>>> repo = pygit2.Repository('.')
>>> repo.head.get_object() == repo.head.get_object()
True
>>> repo.head.get_object() != repo.head.get_object()
False
```
Note that unlike `Oid` `__ge__`, `__gt__`, `__le__`, and `__lt__` are not supported. These comparisions don't really make sense for `Object`.

As a bonus `Object` and its subtypes can be used in with `set` and other hash depenent containers. For example,
```python
>>> import pygit2
>>> repo = pygit2.Repository('.')
>>> s = set()
>>> s.add(repo.head.get_object())
>>> s.add(repo.head.get_object())
>>> len(s)
1
```

Note that following is also true, but is probably not a gurantee since a later imlpementation may break it.
```python
>>> import pygit2
>>> repo = pygit2.Repository('.')
>>> hash(repo.head.get_object()) == hash(repo.head.get_object().oid)
True
```