### PR TITLE
Add classifiers to publicize which versions of Python are compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,16 @@ class sdist_files_from_git(sdist):
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.4",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Version Control"]
 
 with codecs.open('README.rst', 'r', 'utf-8') as readme:


### PR DESCRIPTION
This helps tools like pyup determine whether or not the library is Python3 compatible.