### PR TITLE
setup.py: Remove lock on pycparser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setup(name='pygit2',
       packages=['pygit2'],
       package_data={'pygit2': ['decl.h']},
       setup_requires=['cffi'],
-      install_requires=['cffi', 'six', 'pycparser<2.18'],
+      install_requires=['cffi', 'six'],
       zip_safe=False,
       cmdclass=cmdclass,
       **extra_args)


### PR DESCRIPTION
It looks like 2.19 has fixed the problem.