### PR TITLE
Build manylinux1 OS-specific binary wheels in Travis (CI) and publish them to PyPI (CD)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /build/
 /dist/
 /docs/_build/
+/wheelhouse/
 /MANIFEST
 __pycache__/
 *.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /build/
 /dist/
 /docs/_build/
-/wheelhouse/
 /MANIFEST
 __pycache__/
 *.egg-info

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
 
+LIBGIT2_VERSION="$1"
+if [ -z "$LIBGIT2_VERSION" ]
+then
+    >&2 echo "Please pass libgit2 version as a first argument of this script ($0)"
+    exit 1
+fi
+
 cd ~
 
-git clone --depth=1 -b maint/v0.27 https://github.com/libgit2/libgit2.git
+git clone --depth=1 -b "maint/v${LIBGIT2_VERSION}" https://github.com/libgit2/libgit2.git
 cd libgit2/
 
 mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 
 cache: pip
@@ -7,38 +8,36 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "pypy"
 #  - "pypy3"
 
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+env:
+  global:
+    LIBGIT2: /libgit2/_install/
+    LD_LIBRARY_PATH: ~/libgit2/_install/lib
 
-env: LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib
 
-matrix:
+.mixins:
+- &docker-job
+  dist: xenial
+  python: "3.7"
+  services:
+  - docker
+  env:
+    DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
+  script: &docker-script
+  - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh
+  - ls wheelhouse/
+
+
+jobs:
   include:
-    - sudo: required
-      python: 3.4
-      services:
-        - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-           LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib
-      script:
-        - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh
-        - ls wheelhouse/
-    - sudo: required
-      python: 3.4
-      services:
-        - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
-           PRE_CMD=linux32
-           LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib
-      script:
-        - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh
-        - ls wheelhouse/
+  - <<: *docker-job
+  - <<: *docker-job
+    env:
+      DOCKER_IMAGE: quay.io/pypa/manylinux1_i686
+      PRE_CMD: linux32
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ jobs:
     script: &docker-script
     - travis/build-all-manylinux1-wheels.sh "pygit2" "${LIBGIT2_VERSION}"
     before_deploy:
-    - mv wheelhouse dist
     - ls dist
     - pip install twine
     - twine check dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
 
 .mixins:
 - &docker-job
+  stage: Publish to PyPI (runs only for tagged commits)
   dist: xenial
   python: "3.7"
   services:
@@ -37,7 +38,11 @@ env:
 jobs:
   include:
   - <<: *docker-job
+    name: >-
+      manylinux1: 64-bit
   - <<: *docker-job
+    name: >-
+      manylinux1: 32-bit
     env:
       # DOCKER_IMAGE: quay.io/pypa/manylinux1_i686
       DOCKER_IMAGE: pyca/cryptography-manylinux1:i686

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
+#  - "pypy3"
 
 matrix:
   include:
@@ -16,6 +17,27 @@ matrix:
       sudo: true
 
 env: LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib
+
+matrix:
+  include:
+    - sudo: required
+      python: 3.4
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+      script:
+        - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh
+        - ls wheelhouse/
+    - sudo: required
+      python: 3.4
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+           PRE_CMD=linux32
+      script:
+        - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh
+        - ls wheelhouse/
+
 
 before_install:
   - sudo apt-get install cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
 .mixins:
 - &docker-job
   stage: Publish to PyPI (runs only for tagged commits)
-  dist: xenial
   python: "3.7"
   services:
   - docker
@@ -33,6 +32,37 @@ env:
   script: &docker-script
   - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh pygit2 "${LIBGIT2_VERSION}"
   - ls wheelhouse/
+  before_deploy:
+  - mv wheelhouse dist
+  - pip install twine
+  - twine check dist/*
+  deploy:
+    provider: pypi
+    # `skip-cleanup: true` is required to preserve binary wheels, built
+    # inside of manylinux1 docker container during `script` step above.
+    skip-cleanup: true
+    # `skip-existing: true` is required to skip uploading dists, already
+    # present in PYPI instead of failing the whole process.
+    # This happens when other CI (AppVeyor etc.) has already uploaded
+    # the very same dist (usually sdist).
+    skip-existing: true
+    user: jdavid
+    password:
+      # Encrypted with `travis encrypt -r aio-libs/aiohttp --api-endpoint 'https://api.travis-ci.com/'`:
+      secure: >-
+        TODO: REPLACE THIS WITH AN ENCRYPTED PASSWORD
+    # Although Travis CI instructs `setup.py` to build source distribution,
+    # which is default value for distribution option (`distribution: sdist`),
+    # it will also upload all wheels we've previously built in manylinux1
+    # docker container using `twine upload -r pypi dist/*` command.
+    # Also since commit https://github.com/travis-ci/dpl/commit/90b5e39
+    # it is default that Travis PYPI provider has `skip_upload_docs: true`
+    # set by default.
+    # Besides above, we don't do cleanup of `dist/*`, because it's being done
+    # by Travis CI PYPI deployment provider after upload, unconditionally.
+    on:
+      tags: true
+      all_branches: true
 
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
     install: skip
     script: &docker-script
     - travis/build-all-manylinux1-wheels.sh "pygit2" "${LIBGIT2_VERSION}"
+    - ls -alh dist
     before_deploy:
     - ls dist
     - pip install twine

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   include:
-  - stage: Publish to PyPI (runs only for tagged commits)
+  - stage: &deploy_stage Publish to PyPI (runs only for tagged commits)
     name: >-
       OS-specific manylinux1 wheels
     python: "3.7"
@@ -72,3 +72,8 @@ install:
 
 script:
   - pytest
+
+stages:
+- test
+- name: *deploy_stage
+  if: 1=1 OR tag IS present OR type IN (cron, api)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "pypy"
-#  - "pypy3"
+  - "pypy2.7-6.0"
+  - "pypy3.5-6.0"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,64 +19,49 @@ env:
     LIBGIT2_VERSION: "0.27"
 
 
-.mixins:
-- &docker-job
-  stage: Publish to PyPI (runs only for tagged commits)
-  python: "3.7"
-  services:
-  - docker
-  env:
-    # DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
-    DOCKER_IMAGE: pyca/cryptography-manylinux1:x86_64
-  install: skip
-  script: &docker-script
-  - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh pygit2 "${LIBGIT2_VERSION}"
-  - ls wheelhouse/
-  before_deploy:
-  - mv wheelhouse dist
-  - pip install twine
-  - twine check dist/*
-  deploy:
-    provider: pypi
-    # `skip-cleanup: true` is required to preserve binary wheels, built
-    # inside of manylinux1 docker container during `script` step above.
-    skip-cleanup: true
-    # `skip-existing: true` is required to skip uploading dists, already
-    # present in PYPI instead of failing the whole process.
-    # This happens when other CI (AppVeyor etc.) has already uploaded
-    # the very same dist (usually sdist).
-    skip-existing: true
-    user: jdavid
-    password:
-      # Encrypted with `travis encrypt -r aio-libs/aiohttp --api-endpoint 'https://api.travis-ci.com/'`:
-      secure: >-
-        TODO: REPLACE THIS WITH AN ENCRYPTED PASSWORD
-    # Although Travis CI instructs `setup.py` to build source distribution,
-    # which is default value for distribution option (`distribution: sdist`),
-    # it will also upload all wheels we've previously built in manylinux1
-    # docker container using `twine upload -r pypi dist/*` command.
-    # Also since commit https://github.com/travis-ci/dpl/commit/90b5e39
-    # it is default that Travis PYPI provider has `skip_upload_docs: true`
-    # set by default.
-    # Besides above, we don't do cleanup of `dist/*`, because it's being done
-    # by Travis CI PYPI deployment provider after upload, unconditionally.
-    on:
-      tags: true
-      all_branches: true
-
-
 jobs:
   include:
-  - <<: *docker-job
+  - stage: Publish to PyPI (runs only for tagged commits)
     name: >-
-      manylinux1: 64-bit
-  - <<: *docker-job
-    name: >-
-      manylinux1: 32-bit
-    env:
-      # DOCKER_IMAGE: quay.io/pypa/manylinux1_i686
-      DOCKER_IMAGE: pyca/cryptography-manylinux1:i686
-      PRE_CMD: linux32
+      OS-specific manylinux1 wheels
+    python: "3.7"
+    services:
+    - docker
+    install: skip
+    script: &docker-script
+    - travis/build-all-manylinux1-wheels.sh "pygit2" "${LIBGIT2_VERSION}"
+    before_deploy:
+    - mv wheelhouse dist
+    - ls dist
+    - pip install twine
+    - twine check dist/*
+    deploy:
+      provider: pypi
+      # `skip-cleanup: true` is required to preserve binary wheels, built
+      # inside of manylinux1 docker container during `script` step above.
+      skip-cleanup: true
+      # `skip-existing: true` is required to skip uploading dists, already
+      # present in PYPI instead of failing the whole process.
+      # This happens when other CI (AppVeyor etc.) has already uploaded
+      # the very same dist (usually sdist).
+      skip-existing: true
+      user: jdavid
+      password:
+        # Encrypted with `travis encrypt -r aio-libs/aiohttp --api-endpoint 'https://api.travis-ci.com/'`:
+        secure: >-
+          TODO: REPLACE THIS WITH AN ENCRYPTED PASSWORD
+      # Although Travis CI instructs `setup.py` to build source distribution,
+      # which is default value for distribution option (`distribution: sdist`),
+      # it will also upload all wheels we've previously built in manylinux1
+      # docker container using `twine upload -r pypi dist/*` command.
+      # Also since commit https://github.com/travis-ci/dpl/commit/90b5e39
+      # it is default that Travis PYPI provider has `skip_upload_docs: true`
+      # set by default.
+      # Besides above, we don't do cleanup of `dist/*`, because it's being done
+      # by Travis CI PYPI deployment provider after upload, unconditionally.
+      on:
+        tags: true
+        all_branches: true
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   global:
     LIBGIT2: /libgit2/_install/
     LD_LIBRARY_PATH: ~/libgit2/_install/lib
+    LIBGIT2_VERSION: "0.27"
 
 
 .mixins:
@@ -25,9 +26,10 @@ env:
   services:
   - docker
   env:
-    DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
+    # DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
+    DOCKER_IMAGE: pyca/cryptography-manylinux1:x86_64
   script: &docker-script
-  - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh
+  - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh pygit2 "${LIBGIT2_VERSION}"
   - ls wheelhouse/
 
 
@@ -36,13 +38,14 @@ jobs:
   - <<: *docker-job
   - <<: *docker-job
     env:
-      DOCKER_IMAGE: quay.io/pypa/manylinux1_i686
+      # DOCKER_IMAGE: quay.io/pypa/manylinux1_i686
+      DOCKER_IMAGE: pyca/cryptography-manylinux1:i686
       PRE_CMD: linux32
 
 
 before_install:
   - sudo apt-get install cmake
-  - "./.travis.sh"
+  - ./.travis.sh "${LIBGIT2_VERSION}"
 
 install:
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ python:
 
 env:
   global:
-    LIBGIT2: /libgit2/_install/
-    LD_LIBRARY_PATH: ~/libgit2/_install/lib
+    LIBGIT2: ~/libgit2/_install/
+    LD_LIBRARY_PATH: ${LIBGIT2}/lib:${LD_LIBRARY_PATH}
     LIBGIT2_VERSION: "0.27"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
       services:
         - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+           LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib
       script:
         - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh
         - ls wheelhouse/
@@ -34,6 +35,7 @@ matrix:
         - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
            PRE_CMD=linux32
+           LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib
       script:
         - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh
         - ls wheelhouse/

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
   env:
     # DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
     DOCKER_IMAGE: pyca/cryptography-manylinux1:x86_64
+  install: skip
   script: &docker-script
   - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-manylinux1-wheels.sh pygit2 "${LIBGIT2_VERSION}"
   - ls wheelhouse/

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -144,12 +144,11 @@ class CommitTest(utils.BareRepoTestCase):
 
         commit = self.repo[COMMIT_SHA]
 
-        error_type = AttributeError if not pypy2 else TypeError
-        with pytest.raises(error_type): setattr(commit, 'message', message)
-        with pytest.raises(error_type): setattr(commit, 'committer', committer)
-        with pytest.raises(error_type): setattr(commit, 'author', author)
-        with pytest.raises(error_type): setattr(commit, 'tree', None)
-        with pytest.raises(error_type): setattr(commit, 'parents', None)
+        with pytest.raises(AttributeError): setattr(commit, 'message', message)
+        with pytest.raises(AttributeError): setattr(commit, 'committer', committer)
+        with pytest.raises(AttributeError): setattr(commit, 'author', author)
+        with pytest.raises(AttributeError): setattr(commit, 'tree', None)
+        with pytest.raises(AttributeError): setattr(commit, 'parents', None)
 
 
 class GpgSignatureTestCase(utils.GpgSignedRepoTestCase):

--- a/test/test_tag.py
+++ b/test/test_tag.py
@@ -90,11 +90,10 @@ class TagTest(utils.BareRepoTestCase):
         tagger = ('John Doe', 'jdoe@example.com', 12347)
 
         tag = self.repo[TAG_SHA]
-        error_type = AttributeError if not pypy2 else TypeError
-        with pytest.raises(error_type): setattr(tag, 'name', name)
-        with pytest.raises(error_type): setattr(tag, 'target', target)
-        with pytest.raises(error_type): setattr(tag, 'tagger', tagger)
-        with pytest.raises(error_type): setattr(tag, 'message', message)
+        with pytest.raises(AttributeError): setattr(tag, 'name', name)
+        with pytest.raises(AttributeError): setattr(tag, 'target', target)
+        with pytest.raises(AttributeError): setattr(tag, 'tagger', tagger)
+        with pytest.raises(AttributeError): setattr(tag, 'message', message)
 
     def test_get_object(self):
         repo = self.repo

--- a/travis/build-all-manylinux1-wheels.sh
+++ b/travis/build-all-manylinux1-wheels.sh
@@ -1,0 +1,51 @@
+#! /usr/bin/env bash
+if [ -n "$DEBUG" ]
+then
+  set -x
+fi
+
+package_name="$1"
+LIBGIT2_VERSION="$2"
+
+set -euo pipefail
+
+if [ -z "$package_name" ]
+then
+    >&2 echo "Please pass package name as a first argument of this script ($0)"
+    exit 1
+fi
+
+if [ -z "$LIBGIT2_VERSION" ]
+then
+    >&2 echo "Please pass libgit2 version as a second argument of this script ($0)"
+    exit 1
+fi
+
+manylinux1_image_prefix="quay.io/pypa/manylinux1_"
+manylinux1_image_prefix="pyca/cryptography-manylinux1:"
+dock_ext_args=""
+declare -A docker_pull_pids=()  # This syntax requires at least bash v4
+
+for arch in x86_64 i686
+do
+    docker pull "${manylinux1_image_prefix}${arch}" &
+    docker_pull_pids[$arch]=$!
+done
+
+for arch in x86_64 i686
+do
+    echo
+    echo
+    arch_pull_pid=${docker_pull_pids[$arch]}
+    echo Waiting for docker pull PID $arch_pull_pid to complete downloading container for $arch arch...
+    wait $arch_pull_pid  # await for docker image for current arch to be pulled from hub
+    [ $arch == "i686" ] && dock_ext_args="linux32"
+
+    echo Building wheel for $arch arch
+    docker run --rm -v `pwd`:/io "${manylinux1_image_prefix}${arch}" $dock_ext_args /io/travis/build-manylinux1-wheels.sh "$package_name" "$LIBGIT2_VERSION" &
+
+    dock_ext_args=""  # Reset docker args, just in case
+done
+wait
+
+set +u

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -38,8 +38,8 @@ mkdir -p "$WHEELHOUSE_DIR"
 export PYCA_OPENSSL_PATH=/opt/pyca/cryptography/openssl
 export OPENSSL_PATH=/opt/openssl
 
-export CFLAGS="-I${PYCA_OPENSSL_PATH}/include -I${OPENSSL_PATH}/include"
-export LDFLAGS="-L${PYCA_OPENSSL_PATH}/lib -L${OPENSSL_PATH}/lib -L/usr/local/lib/"
+export CFLAGS="-I${PYCA_OPENSSL_PATH}/include -I${OPENSSL_PATH}/include -I/usr/include"
+export LDFLAGS="-L${PYCA_OPENSSL_PATH}/lib -L${OPENSSL_PATH}/lib -L/usr/local/lib -L/usr/lib64"
 export LD_LIBRARY_PATH="${LIBGIT2}/lib:$LD_LIBRARY_PATH"
 export PKG_CONFIG_PATH="${PYCA_OPENSSL_PATH}/lib/pkgconfig/:${OPENSSL_PATH}/lib/pkgconfig/:$PKG_CONFIG_PATH"
 

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -42,6 +42,8 @@ export CFLAGS="-I${PYCA_OPENSSL_PATH}/include -I${OPENSSL_PATH}/include"
 export LDFLAGS="-L${PYCA_OPENSSL_PATH}/lib -L${OPENSSL_PATH}/lib -L/usr/local/lib/"
 export LD_LIBRARY_PATH="${LIBGIT2}/lib:$LD_LIBRARY_PATH"
 
+ARCH=`uname -m`
+
 
 >&2 echo Installing system deps...
 # Install a system package required by our library
@@ -73,16 +75,18 @@ done
 
 >&2 echo Reparing wheels:
 # Bundle external shared libraries into the wheels
-for whl in ${ORIG_WHEEL_DIR}/${DIST_NAME}*.whl; do
-    >&2 echo Reparing "${whl}"...
-    auditwheel repair "${whl}" -w ${WHEELHOUSE_DIR}
+for PY in $PYTHONS; do
+    for whl in ${ORIG_WHEEL_DIR}/${DIST_NAME}-*-${PY}-linux_${ARCH}.whl; do
+        >&2 echo Reparing "${whl}"...
+        auditwheel repair "${whl}" -w ${WHEELHOUSE_DIR}
+    done
 done
 
 # Download deps
 >&2 echo Downloading dependencies:
 for PY in $PYTHONS; do
     PIP_BIN="/opt/python/${PY}/bin/pip"
-    WHEEL_FILE=`ls ${WHEELHOUSE_DIR}/${DIST_NAME}-*-${PY}-manylinux1_*.whl`
+    WHEEL_FILE=`ls ${WHEELHOUSE_DIR}/${DIST_NAME}-*-${PY}-manylinux1_${ARCH}.whl`
     >&2 echo Downloading ${WHEEL_FILE} deps using ${PIP_BIN}...
     ${PIP_BIN} download -d "${WHEEL_DEP_DIR}" "${WHEEL_FILE}"
 done

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -101,4 +101,4 @@ wait
 
 chown -R 1000:1000 ${WHEELHOUSE_DIR}
 >&2 echo Final OS-specific wheels for ${DIST_NAME}:
-ls -l ${WHEELHOUSE_DIR}/*.whl
+ls -l ${WHEELHOUSE_DIR}

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -65,7 +65,7 @@ popd
 
 >&2 echo Building wheels:
 for PIP_BIN in /opt/python/*/bin/pip; do
-    >&2 echo Using "${whl}"...
+    >&2 echo Using "${PIP_BIN}"...
     ${PIP_BIN} wheel "${SRC_DIR}" -w "${ORIG_WHEEL_DIR}"
 done
 

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -10,7 +10,7 @@ yum -y install git libssh2-devel libffi-devel openssl-devel pkgconfig
 
 yum -y install cmake28
 
-git clone --depth=1 -b maint/v0.24 https://github.com/libgit2/libgit2.git
+git clone --depth=1 -b maint/v0.27 https://github.com/libgit2/libgit2.git
 cd libgit2/
 
 

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -29,6 +29,10 @@ LIBGIT2_CLONE_DIR="${BUILD_DIR}/libgit2"
 LIBGIT2_BUILD_DIR="${LIBGIT2_CLONE_DIR}/build"
 export LIBGIT2="${LIBGIT2_CLONE_DIR}/_install"
 
+LIBSSH2_VERSION=1.8.0
+LIBSSH2_CLONE_DIR="${BUILD_DIR}/libssh2"
+LIBSSH2_BUILD_DIR="${LIBSSH2_CLONE_DIR}/build"
+
 ORIG_WHEEL_DIR="${BUILD_DIR}/original-wheelhouse"
 WHEEL_DEP_DIR="${BUILD_DIR}/deps-wheelhouse"
 WHEELHOUSE_DIR="${SRC_DIR}/dist"
@@ -41,7 +45,7 @@ export OPENSSL_PATH=/opt/openssl
 export CFLAGS="-I${PYCA_OPENSSL_PATH}/include -I${OPENSSL_PATH}/include -I/usr/include"
 export LDFLAGS="-L${PYCA_OPENSSL_PATH}/lib -L${OPENSSL_PATH}/lib -L/usr/local/lib -L/usr/lib64"
 export LD_LIBRARY_PATH="${LIBGIT2}/lib:$LD_LIBRARY_PATH"
-export PKG_CONFIG_PATH="${PYCA_OPENSSL_PATH}/lib/pkgconfig/:${OPENSSL_PATH}/lib/pkgconfig/:$PKG_CONFIG_PATH"
+export PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig:${PYCA_OPENSSL_PATH}/lib/pkgconfig:${OPENSSL_PATH}/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 ARCH=`uname -m`
 
@@ -50,9 +54,27 @@ ARCH=`uname -m`
 # Install a system package required by our library
 # libgit2 needs cmake 2.8, which can be found in EPEL
 yum -y install \
-    git libssh2-devel libffi-devel \
+    git libffi-devel \
     openssl-devel pkgconfig \
     cmake28
+
+>&2 echo downloading source of libssh2 v${LIBSSH2_VERSION}:
+git clone \
+    --depth=1 \
+    -b "libssh2-${LIBSSH2_VERSION}" \
+    https://github.com/libssh2/libssh2 \
+    "${LIBSSH2_CLONE_DIR}"
+
+mkdir -p "${LIBSSH2_BUILD_DIR}"
+pushd "${LIBSSH2_BUILD_DIR}"
+cmake28 "${LIBSSH2_CLONE_DIR}" \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_TESTING=OFF \
+    -DCRYPTO_BACKEND=OpenSSL \
+    -DENABLE_ZLIB_COMPRESSION=ON
+cmake28 --build "${LIBSSH2_BUILD_DIR}" --target install
+popd
 
 >&2 echo downloading source of libgit2 v${LIBGIT2_VERSION}:
 git clone \

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -63,7 +63,11 @@ git clone \
 >&2 echo Building libgit2...
 mkdir -p "${LIBGIT2_BUILD_DIR}"
 pushd "${LIBGIT2_BUILD_DIR}"
-cmake28 "${LIBGIT2_CLONE_DIR}" -DCMAKE_INSTALL_PREFIX="${LIBGIT2}" -DBUILD_CLAR=OFF
+# Ref https://libgit2.org/docs/guides/build-and-link/
+cmake28 "${LIBGIT2_CLONE_DIR}" \
+    -DCMAKE_INSTALL_PREFIX="${LIBGIT2}" \
+    -DBUILD_CLAR=OFF \
+    -DTHREADSAFE=ON
 cmake28 --build "${LIBGIT2_BUILD_DIR}" --target install
 popd
 

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -31,7 +31,7 @@ export LIBGIT2="${LIBGIT2_CLONE_DIR}/_install"
 
 ORIG_WHEEL_DIR="${BUILD_DIR}/original-wheelhouse"
 WHEEL_DEP_DIR="${BUILD_DIR}/deps-wheelhouse"
-WHEELHOUSE_DIR="${SRC_DIR}/wheelhouse"
+WHEELHOUSE_DIR="${SRC_DIR}/dist"
 
 mkdir -p "$WHEELHOUSE_DIR"
 

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -66,17 +66,15 @@ popd
 >&2 echo Building wheels:
 for PIP_BIN in /opt/python/*/bin/pip; do
     >&2 echo Using "${PIP_BIN}"...
-    ${PIP_BIN} wheel "${SRC_DIR}" -w "${ORIG_WHEEL_DIR}" &
+    ${PIP_BIN} wheel "${SRC_DIR}" -w "${ORIG_WHEEL_DIR}"
 done
-wait
 
 >&2 echo Reparing wheels:
 # Bundle external shared libraries into the wheels
 for whl in ${ORIG_WHEEL_DIR}/${DIST_NAME}*.whl; do
     >&2 echo Reparing "${whl}"...
-    auditwheel repair "${whl}" -w ${WHEELHOUSE_DIR} &
+    auditwheel repair "${whl}" -w ${WHEELHOUSE_DIR}
 done
-wait
 
 # Download deps
 >&2 echo Downloading dependencies:

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -66,15 +66,17 @@ popd
 >&2 echo Building wheels:
 for PIP_BIN in /opt/python/*/bin/pip; do
     >&2 echo Using "${PIP_BIN}"...
-    ${PIP_BIN} wheel "${SRC_DIR}" -w "${ORIG_WHEEL_DIR}"
+    ${PIP_BIN} wheel "${SRC_DIR}" -w "${ORIG_WHEEL_DIR}" &
 done
+wait
 
 >&2 echo Reparing wheels:
 # Bundle external shared libraries into the wheels
 for whl in ${ORIG_WHEEL_DIR}/${DIST_NAME}*.whl; do
     >&2 echo Reparing "${whl}"...
-    auditwheel repair "${whl}" -w ${WHEELHOUSE_DIR}
+    auditwheel repair "${whl}" -w ${WHEELHOUSE_DIR} &
 done
+wait
 
 # Download deps
 >&2 echo Downloading dependencies:
@@ -89,8 +91,9 @@ done
 >&2 echo Testing wheels installation:
 for PIP_BIN in /opt/python/*/bin/pip; do
     >&2 echo Using ${PIP_BIN}...
-    ${PIP_BIN} install "${DIST_NAME}" --no-index -f ${WHEEL_DEP_DIR}
+    ${PIP_BIN} install "${DIST_NAME}" --no-index -f ${WHEEL_DEP_DIR} &
 done
+wait
 
 chown -R 1000:1000 ${WHEELHOUSE_DIR}
 >&2 echo Final OS-specific wheels for ${DIST_NAME}:

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -99,6 +99,6 @@ for PIP_BIN in /opt/python/*/bin/pip; do
 done
 wait
 
-chown -R 1000:1000 ${WHEELHOUSE_DIR}
+chown -R --reference=/io/.travis.yml ${WHEELHOUSE_DIR}
 >&2 echo Final OS-specific wheels for ${DIST_NAME}:
 ls -l ${WHEELHOUSE_DIR}

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -41,6 +41,7 @@ export OPENSSL_PATH=/opt/openssl
 export CFLAGS="-I${PYCA_OPENSSL_PATH}/include -I${OPENSSL_PATH}/include"
 export LDFLAGS="-L${PYCA_OPENSSL_PATH}/lib -L${OPENSSL_PATH}/lib -L/usr/local/lib/"
 export LD_LIBRARY_PATH="${LIBGIT2}/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="${PYCA_OPENSSL_PATH}/lib/pkgconfig/:${OPENSSL_PATH}/lib/pkgconfig/:$PKG_CONFIG_PATH"
 
 ARCH=`uname -m`
 

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e -x
+CURDIR=`pwd`
+
+# Install a system package required by our library
+yum -y install git libssh2-devel libffi-devel openssl-devel pkgconfig
+
+# libgit2 needs cmake 2.8, which can be found in EPEL
+
+yum -y install cmake28
+
+git clone --depth=1 -b maint/v0.24 https://github.com/libgit2/libgit2.git
+cd libgit2/
+
+
+mkdir build && cd build
+cmake28 .. -DCMAKE_INSTALL_PREFIX=../_install -DBUILD_CLAR=OFF
+cmake28 --build . --target install
+export LIBGIT2=$CURDIR/libgit2/_install/
+export LD_LIBRARY_PATH=$CURDIR/libgit2/_install/lib
+
+mkdir -p wheelhouse
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    ${PYBIN}/pip wheel /io/ -w wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/pygit*.whl; do
+    auditwheel repair $whl -w /io/wheelhouse/
+done
+
+# Install packages
+for PYBIN in /opt/python/*/bin/; do
+    ${PYBIN}/pip install pygit2 --no-index -f /io/wheelhouse
+done
+
+chmod 0777 wheelhouse/*.whl

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -33,6 +33,8 @@ ORIG_WHEEL_DIR="${BUILD_DIR}/original-wheelhouse"
 WHEEL_DEP_DIR="${BUILD_DIR}/deps-wheelhouse"
 WHEELHOUSE_DIR="${SRC_DIR}/wheelhouse"
 
+mkdir -p "$WHEELHOUSE_DIR"
+
 export PYCA_OPENSSL_PATH=/opt/pyca/cryptography/openssl
 export OPENSSL_PATH=/opt/openssl
 

--- a/travis/build-manylinux1-wheels.sh
+++ b/travis/build-manylinux1-wheels.sh
@@ -66,6 +66,7 @@ pushd "${LIBGIT2_BUILD_DIR}"
 # Ref https://libgit2.org/docs/guides/build-and-link/
 cmake28 "${LIBGIT2_CLONE_DIR}" \
     -DCMAKE_INSTALL_PREFIX="${LIBGIT2}" \
+    -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_CLAR=OFF \
     -DTHREADSAFE=ON
 cmake28 --build "${LIBGIT2_BUILD_DIR}" --target install


### PR DESCRIPTION
Closes #793

In its current state the changed added in this PR enable Travis CI _build and publish_ OS-specific wheel distributions which are compliant with a manylinux1 standard.

This PR has a few intentionally incomplete bits:
1) it requires a PyPI password to be filled in
2) it requires uncommenting deploy stage clause so that publishing would only happen for tagged commits

Considerations
--------------------

For simplicity, this PR reuses image by pyca/cryptography which inherits the official image by pypa/manylinux1 and adds a pre-compiled openssl 1.1.1 on top of it so we don't have to.

As a further build time performance improvement I see how we can improve things by publishing our own image to a public registry (Docker Hub or better quay.io) but it's out of scope of this PR.

Credits
---------

This patch is based on the prior art by @beniwohli and my own experience of building manylinux1 wheels for other projects.