### PR TITLE
Allow setting git opt set sll cert locations option in libgit2

### DIFF
--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -28,6 +28,9 @@
 # Import from the future
 from __future__ import absolute_import
 
+# Import from core python modules
+from ssl import get_default_verify_paths as default_ssl_verify_paths
+
 # Low level API
 from _pygit2 import *
 
@@ -267,3 +270,9 @@ def clone_repository(
     return Repository._from_c(crepo[0], owned=True)
 
 settings = Settings()
+
+try:
+    # try to set default ssl cert locations
+    settings._ssl_cert_locations = default_ssl_verify_paths()
+except:
+    pass

--- a/pygit2/settings.py
+++ b/pygit2/settings.py
@@ -33,7 +33,7 @@ from _pygit2 import GIT_OPT_SET_CACHE_OBJECT_LIMIT
 from _pygit2 import GIT_OPT_GET_CACHED_MEMORY
 from _pygit2 import GIT_OPT_ENABLE_CACHING
 from _pygit2 import GIT_OPT_SET_CACHE_MAX_SIZE
-
+from _pygit2 import GIT_OPT_SET_SSL_CERT_LOCATIONS
 
 class SearchPathList(object):
 
@@ -101,4 +101,30 @@ class Settings(object):
         """
         return option(GIT_OPT_SET_CACHE_OBJECT_LIMIT, object_type, value)
 
+    def __set_ssl_cert_file(self, value):
+        """Set the ssl cert file. The value cannot be read.
+        """
+        return option(GIT_OPT_SET_SSL_CERT_LOCATIONS, value, None)
+
+    ssl_cert_file = property(fset=__set_ssl_cert_file)
+
+    def __set_ssl_cert_dir(self, value):
+        """Set the ssl cert folder. The value cannot be read.
+        """
+        return option(GIT_OPT_SET_SSL_CERT_LOCATIONS, None, value)
+
+    ssl_cert_dir = property(fset=__set_ssl_cert_dir)
+
+    def __set_ssl_cert_locations(self, locations):
+        """
+        Passes both file_path and dir_path to libgit2.
+
+        locations must be a list/tuple type with the the file path
+        at index 0 and the directory path at index 1
+
+        The values set cannot be read.
+        """
+        return option(GIT_OPT_SET_SSL_CERT_LOCATIONS, locations[0], locations[1])
+
+    _ssl_cert_locations = property(fset=__set_ssl_cert_locations)
 

--- a/src/options.c
+++ b/src/options.c
@@ -272,6 +272,36 @@ option(PyObject *self, PyObject *args)
             return tup;
         }
 
+        case GIT_OPT_SET_SSL_CERT_LOCATIONS:
+        {
+            PyObject *py_file, *py_dir;
+            const char *file_path, *dir_path;
+            int err;
+
+            py_file = PyTuple_GetItem(args, 1);
+            py_dir = PyTuple_GetItem(args, 2);
+
+            /* py_file and py_dir are only valid if they are strings */
+            if (PyUnicode_Check(py_file) || PyBytes_Check(py_file)) {
+                file_path = py_str_to_c_str(py_file, Py_FileSystemDefaultEncoding);
+            } else {
+                file_path = NULL;
+            }
+
+            if (PyUnicode_Check(py_dir) || PyBytes_Check(py_dir)) {
+                dir_path = py_str_to_c_str(py_dir, Py_FileSystemDefaultEncoding);
+            } else {
+                dir_path = NULL;
+            }
+
+            err = git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, file_path, dir_path);
+
+            if (err < 0)
+                return Error_set(err);
+
+            Py_RETURN_NONE;
+        }
+
     }
 
     PyErr_SetString(PyExc_ValueError, "unknown/unsupported option value");

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -241,6 +241,7 @@ moduleinit(PyObject* m)
     ADD_CONSTANT_INT(m, GIT_OPT_GET_CACHED_MEMORY);
     ADD_CONSTANT_INT(m, GIT_OPT_ENABLE_CACHING);
     ADD_CONSTANT_INT(m, GIT_OPT_SET_CACHE_MAX_SIZE);
+    ADD_CONSTANT_INT(m, GIT_OPT_SET_SSL_CERT_LOCATIONS);
 
     /* Errors */
     GitError = PyErr_NewException("_pygit2.GitError", NULL, NULL);


### PR DESCRIPTION
Closes #876 

Adds support for the following

```python3
import pygit2
pygit2.settings.ssl_cert_file = '/path/to/file'
pygit2.settings.ssl_cert_dir = '/path/to/folder'
```
Which is the equivalent of the following in C
```C
git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, '/path/to/file', NULL);
git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, NULL, '/path/to/folder');
```

Also adds support for directly loading the settings from the `ssl` module like follows
```python3
import pygit2
import ssl
pygit2.settings._ssl_cert_locations = ssl.get_default_verify_paths()
```

All the new properties that were added to `pygit2.settings.Settings` are write only, since it is write only in `libgit2`.

In addition, `pygit2` also attempts sets `_ssl_cert_locations` based on the `ssl` module on import. This probably won't work on Windows until the wheels are changed to support this in the `libgit2` being shipped with it.