### PR TITLE
Expose setting TLS file and dir lookup locations via settings module

### DIFF
--- a/pygit2/settings.py
+++ b/pygit2/settings.py
@@ -24,6 +24,7 @@
 # along with this program; see the file COPYING.  If not, write to
 # the Free Software Foundation, 51 Franklin Street, Fifth Floor,
 # Boston, MA 02110-1301, USA.
+"""Settings mapping."""
 
 from _pygit2 import option
 from _pygit2 import GIT_OPT_GET_SEARCH_PATH, GIT_OPT_SET_SEARCH_PATH
@@ -45,7 +46,7 @@ class SearchPathList(object):
 
 
 class Settings(object):
-    """Library-wide settings"""
+    """Library-wide settings interface."""
 
     __slots__ = []
 

--- a/pygit2/settings.py
+++ b/pygit2/settings.py
@@ -36,7 +36,11 @@ from _pygit2 import GIT_OPT_ENABLE_CACHING
 from _pygit2 import GIT_OPT_SET_CACHE_MAX_SIZE
 
 
-class SearchPathList(object):
+
+__metaclass__ = type  # make all classes new-style by default
+
+
+class SearchPathList:
 
     def __getitem__(self, key):
         return option(GIT_OPT_GET_SEARCH_PATH, key)
@@ -45,7 +49,7 @@ class SearchPathList(object):
         option(GIT_OPT_SET_SEARCH_PATH, key, value)
 
 
-class Settings(object):
+class Settings:
     """Library-wide settings interface."""
 
     __slots__ = []

--- a/src/options.c
+++ b/src/options.c
@@ -272,6 +272,36 @@ option(PyObject *self, PyObject *args)
             return tup;
         }
 
+        case GIT_OPT_SET_SSL_CERT_LOCATIONS:
+        {
+            PyObject *py_file, *py_dir;
+            const char *file_path, *dir_path;
+            int err;
+
+            py_file = PyTuple_GetItem(args, 1);
+            py_dir = PyTuple_GetItem(args, 2);
+
+            /* py_file and py_dir are only valid if they are strings */
+            if (PyUnicode_Check(py_file) || PyBytes_Check(py_file)) {
+                file_path = py_str_to_c_str(py_file, Py_FileSystemDefaultEncoding);
+            } else {
+                file_path = NULL;
+            }
+
+            if (PyUnicode_Check(py_dir) || PyBytes_Check(py_dir)) {
+                dir_path = py_str_to_c_str(py_dir, Py_FileSystemDefaultEncoding);
+            } else {
+                dir_path = NULL;
+            }
+
+            err = git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, file_path, dir_path);
+
+            if (err < 0)
+                return Error_set(err);
+
+            Py_RETURN_NONE;
+        }
+
     }
 
     PyErr_SetString(PyExc_ValueError, "unknown/unsupported option value");

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -242,6 +242,7 @@ moduleinit(PyObject* m)
     ADD_CONSTANT_INT(m, GIT_OPT_GET_CACHED_MEMORY);
     ADD_CONSTANT_INT(m, GIT_OPT_ENABLE_CACHING);
     ADD_CONSTANT_INT(m, GIT_OPT_SET_CACHE_MAX_SIZE);
+    ADD_CONSTANT_INT(m, GIT_OPT_SET_SSL_CERT_LOCATIONS);
 
     /* Errors */
     GitError = PyErr_NewException("_pygit2.GitError", NULL, NULL);


### PR DESCRIPTION
Usage:
```python
import pygit2
pygit2.settings.ssl_cert_file = '/path/to/file'
pygit2.settings.ssl_cert_dir = '/path/to/folder'
del pygit2.settings.ssl_cert_file
pygit2.settings.set_ssl_cert_locations('/path/to/new/file', '/path/to/new/folder')
```

Co-Authored-By: Sriram Raghu <imbuedhope@gmail.com>

Closes #876
Superseeds and closes #879