### PR TITLE
Support for git_merge_analysis_for_ref()

### DIFF
--- a/src/repository.h
+++ b/src/repository.h
@@ -79,5 +79,7 @@ PyObject* Repository_blame(Repository *self, PyObject *args, PyObject *kwds);
 PyObject* Repository_merge(Repository *self, PyObject *py_oid);
 PyObject* Repository_cherrypick(Repository *self, PyObject *py_oid);
 PyObject* Repository_apply(Repository *self, PyObject *py_diff);
+PyObject* Repository_merge_analysis(Repository *self, PyObject *py_id);
+PyObject* Repository_merge_analysis_for_ref(Repository *self, PyObject *args);
 
 #endif

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -49,8 +49,13 @@ class MergeTestBasic(utils.RepoTestCaseForMerging):
     def test_merge_analysis_uptodate(self):
         branch_head_hex = '5ebeeebb320790caf276b9fc8b24546d63316533'
         branch_id = self.repo.get(branch_head_hex).id
-        analysis, preference = self.repo.merge_analysis(branch_id)
 
+        analysis, preference = self.repo.merge_analysis(branch_id)
+        assert analysis & GIT_MERGE_ANALYSIS_UP_TO_DATE
+        assert not analysis & GIT_MERGE_ANALYSIS_FASTFORWARD
+        assert {} == self.repo.status()
+
+        analysis, preference = self.repo.merge_analysis_for_ref('HEAD', branch_id)
         assert analysis & GIT_MERGE_ANALYSIS_UP_TO_DATE
         assert not analysis & GIT_MERGE_ANALYSIS_FASTFORWARD
         assert {} == self.repo.status()
@@ -58,7 +63,13 @@ class MergeTestBasic(utils.RepoTestCaseForMerging):
     def test_merge_analysis_fastforward(self):
         branch_head_hex = 'e97b4cfd5db0fb4ebabf4f203979ca4e5d1c7c87'
         branch_id = self.repo.get(branch_head_hex).id
+
         analysis, preference = self.repo.merge_analysis(branch_id)
+        assert not analysis & GIT_MERGE_ANALYSIS_UP_TO_DATE
+        assert analysis & GIT_MERGE_ANALYSIS_FASTFORWARD
+        assert {} == self.repo.status()
+
+        analysis, preference = self.repo.merge_analysis_for_ref('HEAD', branch_id)
         assert not analysis & GIT_MERGE_ANALYSIS_UP_TO_DATE
         assert analysis & GIT_MERGE_ANALYSIS_FASTFORWARD
         assert {} == self.repo.status()


### PR DESCRIPTION
via new `Repository.merge_analysis_for_ref(our_ref, their_head)`

Upstream method was added in [libgit2 v0.28](https://github.com/libgit2/libgit2/releases/tag/v0.28.0)

Code-wise, follows the pattern + tests of the existing `Repository.merge_analysis()`
