### PR TITLE
merge: combine merge_analysis_for_ref() into merge_analysis()

### DIFF
--- a/src/repository.h
+++ b/src/repository.h
@@ -79,7 +79,6 @@ PyObject* Repository_blame(Repository *self, PyObject *args, PyObject *kwds);
 PyObject* Repository_merge(Repository *self, PyObject *py_oid);
 PyObject* Repository_cherrypick(Repository *self, PyObject *py_oid);
 PyObject* Repository_apply(Repository *self, PyObject *py_diff);
-PyObject* Repository_merge_analysis(Repository *self, PyObject *py_id);
-PyObject* Repository_merge_analysis_for_ref(Repository *self, PyObject *args);
+PyObject* Repository_merge_analysis(Repository *self, PyObject *args);
 
 #endif

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -55,7 +55,7 @@ class MergeTestBasic(utils.RepoTestCaseForMerging):
         assert not analysis & GIT_MERGE_ANALYSIS_FASTFORWARD
         assert {} == self.repo.status()
 
-        analysis, preference = self.repo.merge_analysis_for_ref('HEAD', branch_id)
+        analysis, preference = self.repo.merge_analysis(branch_id, 'refs/heads/ff-branch')
         assert analysis & GIT_MERGE_ANALYSIS_UP_TO_DATE
         assert not analysis & GIT_MERGE_ANALYSIS_FASTFORWARD
         assert {} == self.repo.status()
@@ -69,7 +69,7 @@ class MergeTestBasic(utils.RepoTestCaseForMerging):
         assert analysis & GIT_MERGE_ANALYSIS_FASTFORWARD
         assert {} == self.repo.status()
 
-        analysis, preference = self.repo.merge_analysis_for_ref('HEAD', branch_id)
+        analysis, preference = self.repo.merge_analysis(branch_id, 'refs/heads/master')
         assert not analysis & GIT_MERGE_ANALYSIS_UP_TO_DATE
         assert analysis & GIT_MERGE_ANALYSIS_FASTFORWARD
         assert {} == self.repo.status()


### PR DESCRIPTION
As suggested by @jdavid in https://github.com/libgit2/pygit2/pull/888#issuecomment-472542196

Base reference becomes an additional method parameter to `Repository.merge_analysis()`.

```python
my_repo.merge_analysis('abcde12345')                             # default ref is HEAD
my_repo.merge_analysis('abcde12345', 'refs/heads/other-branch')  # different ref
# was:
my_repo.merge_analysis_for_ref('refs/heads/other-branch', 'abcde12345')
```