### PR TITLE
Improved support for navigating trees:

### DIFF
--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -191,8 +191,7 @@ Tree entries
 .. autoattribute:: pygit2.TreeEntry.hex
 .. autoattribute:: pygit2.TreeEntry.filemode
 .. autoattribute:: pygit2.TreeEntry.type
-.. autoattribute:: pygit2.TreeEntry.blob
-.. autoattribute:: pygit2.TreeEntry.tree
+.. autoattribute:: pygit2.TreeEntry.obj
 
 .. method:: TreeEntry.__cmp__(TreeEntry)
 
@@ -218,8 +217,8 @@ Example::
     >>> entry
     <pygit2.TreeEntry object at 0xcc10f0>
 
-    >>> blob = entry.blob                 # Get the object the entry points to
-    >>> blob
+    >>> obj = entry.obj                   # Get the blob the entry points to
+    >>> obj
     <pygit2.Blob object at 0xcc12d0>
 
 Creating trees

--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -157,6 +157,16 @@ interfaces.
    Return the TreeEntry object for the given *name*. Raise ``KeyError`` if
    there is not a tree entry with that name.
 
+.. method:: Tree.__truediv__(name)
+
+   Return the TreeEntry object for the given *name*. Raise ``KeyError`` if
+   there is not a tree entry with that name. This allows navigating the tree
+   similarly to Pathlib using the slash operator via:
+
+Example::
+
+    >>> entry = tree / 'path' / 'deeper' / 'some.file'
+
 .. method:: Tree.__contains__(name)
 
    Return True if there is a tree entry with the given name, False otherwise.
@@ -181,6 +191,8 @@ Tree entries
 .. autoattribute:: pygit2.TreeEntry.hex
 .. autoattribute:: pygit2.TreeEntry.filemode
 .. autoattribute:: pygit2.TreeEntry.type
+.. autoattribute:: pygit2.TreeEntry.blob
+.. autoattribute:: pygit2.TreeEntry.tree
 
 .. method:: TreeEntry.__cmp__(TreeEntry)
 
@@ -202,11 +214,11 @@ Example::
     85a67270a49ef16cdd3d328f06a3e4b459f09b27 blob setup.py
     3d8985bbec338eb4d47c5b01b863ee89d044bd53 tree test
 
-    >>> entry = tree['pygit2.c']         # Get an entry by name
+    >>> entry = tree / 'pygit2.c'         # Get an entry by name
     >>> entry
     <pygit2.TreeEntry object at 0xcc10f0>
 
-    >>> blob = repo[entry.id]           # Get the object the entry points to
+    >>> blob = entry.blob                 # Get the object the entry points to
     >>> blob
     <pygit2.Blob object at 0xcc12d0>
 

--- a/pygit2/config.py
+++ b/pygit2/config.py
@@ -96,7 +96,10 @@ class Config(object):
         return config
 
     def __del__(self):
-        C.git_config_free(self._config)
+        try:
+            C.git_config_free(self._config)
+        except AttributeError:
+            pass
 
     def _get(self, key):
         assert_string(key, "key")

--- a/src/tree.c
+++ b/src/tree.c
@@ -51,6 +51,9 @@ void
 TreeEntry_dealloc(TreeEntry *self)
 {
     git_tree_entry_free((git_tree_entry*)self->entry);
+    if (self->repo) {
+        Py_CLEAR(self->repo);
+    }
     PyObject_Del(self);
 }
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -43,7 +43,7 @@ extern PyTypeObject TreeIterType;
 extern PyTypeObject IndexType;
 
 #if PY_MAJOR_VERSION >= 3
-#define Py_TPFLAGS_CHECKTYPES 0  // removed in Py3, needed in Py2
+#define Py_TPFLAGS_CHECKTYPES 0  /* removed in Py3, needed in Py2 */
 #endif
 
 
@@ -184,6 +184,7 @@ treeentry_to_subtree(TreeEntry* self)
 {
     Repository *py_repo;
     git_tree *subtree = NULL;
+    int err;
 
     if (git_tree_entry_type(self->entry) != GIT_OBJ_TREE) {
         PyErr_SetString(PyExc_TypeError, "Only for trees");
@@ -196,7 +197,7 @@ treeentry_to_subtree(TreeEntry* self)
     }
 
     py_repo = self->repo;
-    int err = git_tree_lookup(&subtree, py_repo->repo, git_tree_entry_id(self->entry));
+    err = git_tree_lookup(&subtree, py_repo->repo, git_tree_entry_id(self->entry));
     if (err < 0) {
         Error_set(err);
         return NULL;
@@ -210,6 +211,7 @@ treeentry_to_object(TreeEntry* self)
 {
     Repository *py_repo;
     git_object *obj= NULL;
+    int err;
 
     if (self->repo == NULL) {
         PyErr_SetString(PyExc_ValueError, "No repository associated with this TreeEntry");
@@ -217,7 +219,7 @@ treeentry_to_object(TreeEntry* self)
     }
     py_repo = self->repo;
 
-    int err = git_tree_entry_to_object(&obj, py_repo->repo, self->entry);
+    err = git_tree_entry_to_object(&obj, py_repo->repo, self->entry);
     if (err < 0) {
         Error_set(err);
         return NULL;
@@ -230,8 +232,9 @@ PyDoc_STRVAR(TreeEntry_obj__doc__, "Object (subtree/blob)");
 PyObject *
 TreeEntry_obj__get__(TreeEntry *self)
 {
+    git_tree* subtree;
     if (git_tree_entry_type(self->entry) == GIT_OBJ_TREE) {
-        git_tree* subtree = treeentry_to_subtree(self);
+        subtree = treeentry_to_subtree(self);
         if (subtree == NULL)
             return NULL;
 
@@ -339,8 +342,9 @@ PyMappingMethods TreeEntry_as_mapping = {
     0,                          /* mp_ass_subscript */
 };
 
-// Py2/3 compatible structure
-// see https://py3c.readthedocs.io/en/latest/ext-types.html#pynumbermethods
+/* Py2/3 compatible structure
+ * see https://py3c.readthedocs.io/en/latest/ext-types.html#pynumbermethods
+ */
 PyNumberMethods TreeEntry_as_number = {
     0,                          /* nb_add */
     0,                          /* nb_subtract */
@@ -479,7 +483,7 @@ wrap_tree_entry(const git_tree_entry *entry, Repository *repo)
     if (py_entry)
     {
         py_entry->entry = entry;
-        py_entry->repo = repo;  // can be NULL
+        py_entry->repo = repo;  /* can be NULL */
         Py_XINCREF(repo);
    }
 
@@ -790,8 +794,9 @@ PyMethodDef Tree_methods[] = {
     {NULL}
 };
 
-// Py2/3 compatible structure
-// see https://py3c.readthedocs.io/en/latest/ext-types.html#pynumbermethods
+/* Py2/3 compatible structure
+ * see https://py3c.readthedocs.io/en/latest/ext-types.html#pynumbermethods
+ */
 PyNumberMethods Tree_as_number = {
     0,                          /* nb_add */
     0,                          /* nb_subtract */

--- a/src/tree.c
+++ b/src/tree.c
@@ -42,7 +42,7 @@ extern PyTypeObject TreeIterType;
 extern PyTypeObject IndexType;
 
 #if PY_MAJOR_VERSION >= 3
-#define Py_TPFLAGS_CHECKTYPES 0
+#define Py_TPFLAGS_CHECKTYPES 0  // removed in Py3, needed in Py2
 #endif
 
 
@@ -455,8 +455,12 @@ wrap_tree_entry(const git_tree_entry *entry, Repository *repo)
     if (py_entry)
     {
         py_entry->entry = entry;
-        py_entry->repo = repo;
-    }
+        if (repo)
+        {
+            py_entry->repo = repo;
+            Py_INCREF(repo);
+        }
+   }
 
     return py_entry;
 }

--- a/src/tree.c
+++ b/src/tree.c
@@ -51,9 +51,7 @@ void
 TreeEntry_dealloc(TreeEntry *self)
 {
     git_tree_entry_free((git_tree_entry*)self->entry);
-    if (self->repo) {
-        Py_CLEAR(self->repo);
-    }
+    Py_CLEAR(self->repo);
     PyObject_Del(self);
 }
 
@@ -506,11 +504,8 @@ wrap_tree_entry(const git_tree_entry *entry, Repository *repo)
     if (py_entry)
     {
         py_entry->entry = entry;
-        if (repo)
-        {
-            py_entry->repo = repo;
-            Py_INCREF(repo);
-        }
+        py_entry->repo = repo;  // can be NULL
+        Py_XINCREF(repo);
    }
 
     return py_entry;

--- a/src/tree.c
+++ b/src/tree.c
@@ -41,6 +41,11 @@ extern PyTypeObject DiffType;
 extern PyTypeObject TreeIterType;
 extern PyTypeObject IndexType;
 
+#if PY_MAJOR_VERSION >= 3
+#define Py_TPFLAGS_CHECKTYPES 0
+#endif
+
+
 void
 TreeEntry_dealloc(TreeEntry *self)
 {
@@ -310,26 +315,38 @@ PyMappingMethods TreeEntry_as_mapping = {
     0,                          /* mp_ass_subscript */
 };
 
+// Py2/3 compatible structure
+// see https://py3c.readthedocs.io/en/latest/ext-types.html#pynumbermethods
 PyNumberMethods TreeEntry_as_number = {
     0,                          /* nb_add */
     0,                          /* nb_subtract */
     0,                          /* nb_multiply */
+#if PY_MAJOR_VERSION < 3
+    (binaryfunc)TreeEntry_truediv,  /* Py2: nb_divide */
+#endif
     0,                          /* nb_remainder */
     0,                          /* nb_divmod */
     0,                          /* nb_power */
     0,                          /* nb_negative */
     0,                          /* nb_positive */
     0,                          /* nb_absolute */
-    0,                          /* nb_bool */
+    0,                          /* nb_bool (Py2: nb_nonzero) */
     0,                          /* nb_invert */
     0,                          /* nb_lshift */
     0,                          /* nb_rshift */
     0,                          /* nb_and */
     0,                          /* nb_xor */
     0,                          /* nb_or */
+#if PY_MAJOR_VERSION < 3
+    0,                          /* Py2: nb_coerce */
+#endif
     0,                          /* nb_int */
-    0,                          /* nb_reserved */
+    0,                          /* nb_reserved (Py2: nb_long) */
     0,                          /* nb_float */
+#if PY_MAJOR_VERSION < 3
+    0,                          /* Py2: nb_oct */
+    0,                          /* Py2: nb_hex */
+#endif
     0,                          /* nb_inplace_add */
     0,                          /* nb_inplace_subtract */
     0,                          /* nb_inplace_multiply */
@@ -344,6 +361,11 @@ PyNumberMethods TreeEntry_as_number = {
     TreeEntry_truediv,          /* nb_true_divide */
     0,                          /* nb_inplace_floor_divide */
     0,                          /* nb_inplace_true_divide */
+    0,                          /* nb_index */
+#if PY_MAJOR_VERSION >= 3
+    0,                          /* nb_matrix_multiply */
+    0,                          /* nb_inplace_matrix_multiply */
+#endif
 };
 
 
@@ -369,7 +391,7 @@ PyTypeObject TreeEntryType = {
     0,                                         /* tp_getattro       */
     0,                                         /* tp_setattro       */
     0,                                         /* tp_as_buffer      */
-    Py_TPFLAGS_DEFAULT,                        /* tp_flags          */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_CHECKTYPES,  /* tp_flags */
     TreeEntry__doc__,                          /* tp_doc            */
     0,                                         /* tp_traverse       */
     0,                                         /* tp_clear          */
@@ -750,26 +772,38 @@ PyMethodDef Tree_methods[] = {
     {NULL}
 };
 
+// Py2/3 compatible structure
+// see https://py3c.readthedocs.io/en/latest/ext-types.html#pynumbermethods
 PyNumberMethods Tree_as_number = {
     0,                          /* nb_add */
     0,                          /* nb_subtract */
     0,                          /* nb_multiply */
+#if PY_MAJOR_VERSION < 3
+    (binaryfunc)Tree_truediv,   /* Py2: nb_divide */
+#endif
     0,                          /* nb_remainder */
     0,                          /* nb_divmod */
     0,                          /* nb_power */
     0,                          /* nb_negative */
     0,                          /* nb_positive */
     0,                          /* nb_absolute */
-    0,                          /* nb_bool */
+    0,                          /* nb_bool (Py2: nb_nonzero) */
     0,                          /* nb_invert */
     0,                          /* nb_lshift */
     0,                          /* nb_rshift */
     0,                          /* nb_and */
     0,                          /* nb_xor */
     0,                          /* nb_or */
+#if PY_MAJOR_VERSION < 3
+    0,                          /* Py2: nb_coerce */
+#endif
     0,                          /* nb_int */
-    0,                          /* nb_reserved */
+    0,                          /* nb_reserved (Py2: nb_long) */
     0,                          /* nb_float */
+#if PY_MAJOR_VERSION < 3
+    0,                          /* Py2: nb_oct */
+    0,                          /* Py2: nb_hex */
+#endif
     0,                          /* nb_inplace_add */
     0,                          /* nb_inplace_subtract */
     0,                          /* nb_inplace_multiply */
@@ -784,6 +818,11 @@ PyNumberMethods Tree_as_number = {
     Tree_truediv,               /* nb_true_divide */
     0,                          /* nb_inplace_floor_divide */
     0,                          /* nb_inplace_true_divide */
+    0,                          /* nb_index */
+#if PY_MAJOR_VERSION >= 3
+    0,                          /* nb_matrix_multiply */
+    0,                          /* nb_inplace_matrix_multiply */
+#endif
 };
 
 PyDoc_STRVAR(Tree__doc__, "Tree objects.");
@@ -808,7 +847,7 @@ PyTypeObject TreeType = {
     0,                                         /* tp_getattro       */
     0,                                         /* tp_setattro       */
     0,                                         /* tp_as_buffer      */
-    Py_TPFLAGS_DEFAULT,                        /* tp_flags          */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_CHECKTYPES,  /* tp_flags */
     Tree__doc__,                               /* tp_doc            */
     0,                                         /* tp_traverse       */
     0,                                         /* tp_clear          */

--- a/src/tree.c
+++ b/src/tree.c
@@ -224,7 +224,7 @@ treeentry_to_object(TreeEntry* self)
 
     return wrap_object(obj, py_repo);
 }
-PyDoc_STRVAR(TreeEntry_tree__doc__, "Subtree");
+PyDoc_STRVAR(TreeEntry_tree__doc__, "Subtree. (for type=tree entries)");
 
 PyObject *
 TreeEntry_tree__get__(TreeEntry *self)
@@ -236,7 +236,7 @@ TreeEntry_tree__get__(TreeEntry *self)
     return wrap_object((git_object*)subtree, self->repo);
 }
 
-PyDoc_STRVAR(TreeEntry_blob__doc__, "Blob");
+PyDoc_STRVAR(TreeEntry_blob__doc__, "Blob. (for type=blob entries)");
 
 PyObject *
 TreeEntry_blob__get__(TreeEntry *self)

--- a/src/tree.h
+++ b/src/tree.h
@@ -38,8 +38,7 @@ PyObject* TreeEntry_get_filemode(TreeEntry *self);
 PyObject* TreeEntry_get_name(TreeEntry *self);
 PyObject* TreeEntry_get_oid(TreeEntry *self);
 PyObject* TreeEntry_get_hex(TreeEntry *self);
-PyObject* TreeEntry_get_blob(TreeEntry *self);
-PyObject* TreeEntry_get_tree(TreeEntry *self);
+PyObject* TreeEntry_get_obj(TreeEntry *self);
 
 TreeEntry* tree_getitem_by_index(const git_tree *tree, Repository *repo, PyObject *py_index);
 TreeEntry* tree_getitem_by_path(const git_tree *tree, Repository *repo, PyObject *py_path);

--- a/src/tree.h
+++ b/src/tree.h
@@ -38,6 +38,8 @@ PyObject* TreeEntry_get_filemode(TreeEntry *self);
 PyObject* TreeEntry_get_name(TreeEntry *self);
 PyObject* TreeEntry_get_oid(TreeEntry *self);
 PyObject* TreeEntry_get_hex(TreeEntry *self);
+PyObject* TreeEntry_get_blob(TreeEntry *self);
+PyObject* TreeEntry_get_tree(TreeEntry *self);
 
 TreeEntry* tree_getitem_by_index(const git_tree *tree, Repository *repo, PyObject *py_index);
 TreeEntry* tree_getitem_by_path(const git_tree *tree, Repository *repo, PyObject *py_path);

--- a/src/tree.h
+++ b/src/tree.h
@@ -33,14 +33,16 @@
 #include <git2.h>
 #include "types.h"
 
-TreeEntry * wrap_tree_entry(const git_tree_entry *entry);
+TreeEntry * wrap_tree_entry(const git_tree_entry *entry, Repository *repo);
 PyObject* TreeEntry_get_filemode(TreeEntry *self);
 PyObject* TreeEntry_get_name(TreeEntry *self);
 PyObject* TreeEntry_get_oid(TreeEntry *self);
 PyObject* TreeEntry_get_hex(TreeEntry *self);
 
-TreeEntry* Tree_getitem_by_index(Tree *self, PyObject *py_index);
-TreeEntry* Tree_getitem(Tree *self, PyObject *value);
+TreeEntry* tree_getitem_by_index(const git_tree *tree, Repository *repo, PyObject *py_index);
+TreeEntry* tree_getitem_by_path(const git_tree *tree, Repository *repo, PyObject *py_path);
 PyObject* Tree_diff_tree(Tree *self, PyObject *args);
+
+
 
 #endif

--- a/src/treebuilder.c
+++ b/src/treebuilder.c
@@ -124,7 +124,7 @@ TreeBuilder_get(TreeBuilder *self, PyObject *py_filename)
         PyErr_SetNone(PyExc_MemoryError);
         return NULL;
     }
-    return (PyObject*)wrap_tree_entry(entry, Py_None);
+    return (PyObject*)wrap_tree_entry(entry, NULL);
 }
 
 

--- a/src/treebuilder.c
+++ b/src/treebuilder.c
@@ -124,7 +124,7 @@ TreeBuilder_get(TreeBuilder *self, PyObject *py_filename)
         PyErr_SetNone(PyExc_MemoryError);
         return NULL;
     }
-    return (PyObject*)wrap_tree_entry(entry);
+    return (PyObject*)wrap_tree_entry(entry, Py_None);
 }
 
 

--- a/src/types.h
+++ b/src/types.h
@@ -163,6 +163,7 @@ SIMPLE_TYPE(TreeBuilder, git_treebuilder, bld)
 
 typedef struct {
     PyObject_HEAD
+    Repository *repo;\
     const git_tree_entry *entry;
 } TreeEntry;
 

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -53,9 +53,11 @@ class TreeTest(utils.BareRepoTestCase):
     def test_read_tree(self):
         tree = self.repo[TREE_SHA]
         with pytest.raises(TypeError): tree[()]
+        with pytest.raises(TypeError): tree / 123
         self.assertRaisesWithArg(KeyError, 'abcd', lambda: tree['abcd'])
         self.assertRaisesWithArg(IndexError, -4, lambda: tree[-4])
         self.assertRaisesWithArg(IndexError, 3, lambda: tree[3])
+        self.assertRaisesWithArg(KeyError, 'abcd', lambda: tree / 'abcd')
 
         assert 3 == len(tree)
         sha = '7f129fd57e31e935c6d60a0c794efe4e6927664b'
@@ -63,16 +65,25 @@ class TreeTest(utils.BareRepoTestCase):
         self.assertTreeEntryEqual(tree[0], sha, 'a', 0o0100644)
         self.assertTreeEntryEqual(tree[-3], sha, 'a', 0o0100644)
         self.assertTreeEntryEqual(tree['a'], sha, 'a', 0o0100644)
+        self.assertTreeEntryEqual(tree / 'a', sha, 'a', 0o0100644)
 
         sha = '85f120ee4dac60d0719fd51731e4199aa5a37df6'
         assert 'b' in tree
         self.assertTreeEntryEqual(tree[1], sha, 'b', 0o0100644)
         self.assertTreeEntryEqual(tree[-2], sha, 'b', 0o0100644)
         self.assertTreeEntryEqual(tree['b'], sha, 'b', 0o0100644)
+        self.assertTreeEntryEqual(tree / 'b', sha, 'b', 0o0100644)
 
         sha = '297efb891a47de80be0cfe9c639e4b8c9b450989'
         self.assertTreeEntryEqual(tree['c/d'], sha, 'd', 0o0100644)
+        self.assertTreeEntryEqual(tree / 'c/d', sha, 'd', 0o0100644)
+        self.assertTreeEntryEqual(tree / 'c' / 'd', sha, 'd', 0o0100644)
+        self.assertTreeEntryEqual(tree['c']['d'], sha, 'd', 0o0100644)
+        self.assertTreeEntryEqual((tree / 'c')['d'], sha, 'd', 0o0100644)
         self.assertRaisesWithArg(KeyError, 'ab/cd', lambda: tree['ab/cd'])
+        self.assertRaisesWithArg(KeyError, 'ab/cd', lambda: tree / 'ab/cd')
+        self.assertRaisesWithArg(KeyError, 'ab', lambda: tree / 'c' / 'ab')
+        self.assertRaisesWithArg(TypeError, 'Only supported for trees', lambda: tree / 'a' / 'cd')
 
     def test_equality(self):
         tree_a = self.repo['18e2d2e9db075f9eb43bcb2daa65a2867d29a15e']
@@ -90,6 +101,10 @@ class TreeTest(utils.BareRepoTestCase):
     def test_read_subtree(self):
         tree = self.repo[TREE_SHA]
         subtree_entry = tree['c']
+        self.assertTreeEntryEqual(subtree_entry, SUBTREE_SHA, 'c', 0o0040000)
+        assert subtree_entry.type == 'tree'
+
+        subtree_entry = tree / 'c'
         self.assertTreeEntryEqual(subtree_entry, SUBTREE_SHA, 'c', 0o0040000)
         assert subtree_entry.type == 'tree'
 
@@ -120,6 +135,13 @@ class TreeTest(utils.BareRepoTestCase):
         x = tree['x']
         y = tree['y']
         z = tree['z']
+        assert x.filemode == 0o0100644
+        assert y.filemode == 0o0100755
+        assert z.filemode == GIT_FILEMODE_TREE
+
+        x = tree / 'x'
+        y = tree / 'y'
+        z = tree / 'z'
         assert x.filemode == 0o0100644
         assert y.filemode == 0o0100755
         assert z.filemode == GIT_FILEMODE_TREE
@@ -156,3 +178,6 @@ class TreeTest(utils.BareRepoTestCase):
         assert 'c/d' in tree
         assert 'c/e' not in tree
         assert 'd' not in tree
+
+        assert 'd' in tree['c']
+        assert 'e' not in tree['c']

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -53,7 +53,8 @@ class TreeTest(utils.BareRepoTestCase):
     def test_read_tree(self):
         tree = self.repo[TREE_SHA]
         with pytest.raises(TypeError): tree[()]
-        with pytest.raises(TypeError): tree / 123
+        with pytest.raises(IndexError):
+            tree / 123
         self.assertRaisesWithArg(KeyError, 'abcd', lambda: tree['abcd'])
         self.assertRaisesWithArg(IndexError, -4, lambda: tree[-4])
         self.assertRaisesWithArg(IndexError, 3, lambda: tree[3])
@@ -66,6 +67,7 @@ class TreeTest(utils.BareRepoTestCase):
         self.assertTreeEntryEqual(tree[-3], sha, 'a', 0o0100644)
         self.assertTreeEntryEqual(tree['a'], sha, 'a', 0o0100644)
         self.assertTreeEntryEqual(tree / 'a', sha, 'a', 0o0100644)
+        self.assertTreeEntryEqual(tree / 0, sha, 'a', 0o0100644)
 
         sha = '85f120ee4dac60d0719fd51731e4199aa5a37df6'
         assert 'b' in tree
@@ -73,6 +75,7 @@ class TreeTest(utils.BareRepoTestCase):
         self.assertTreeEntryEqual(tree[-2], sha, 'b', 0o0100644)
         self.assertTreeEntryEqual(tree['b'], sha, 'b', 0o0100644)
         self.assertTreeEntryEqual(tree / 'b', sha, 'b', 0o0100644)
+        self.assertTreeEntryEqual(tree / 1, sha, 'b', 0o0100644)
 
         sha = '297efb891a47de80be0cfe9c639e4b8c9b450989'
         self.assertTreeEntryEqual(tree['c/d'], sha, 'd', 0o0100644)
@@ -84,9 +87,6 @@ class TreeTest(utils.BareRepoTestCase):
         self.assertRaisesWithArg(KeyError, 'ab/cd', lambda: tree / 'ab/cd')
         self.assertRaisesWithArg(KeyError, 'ab', lambda: tree / 'c' / 'ab')
         self.assertRaisesWithArg(TypeError, 'Only for trees', lambda: tree / 'a' / 'cd')
-
-        self.assertRaisesWithArg(TypeError, 'Only for trees', lambda: (tree / 'c' / 'd').tree)
-        self.assertRaisesWithArg(TypeError, 'Only for blobs', lambda: (tree / 'c').blob)
 
     def test_equality(self):
         tree_a = self.repo['18e2d2e9db075f9eb43bcb2daa65a2867d29a15e']
@@ -117,7 +117,7 @@ class TreeTest(utils.BareRepoTestCase):
         self.assertTreeEntryEqual(subtree[0], sha, 'd', 0o0100644)
 
         subtree_entry = (tree / 'c')
-        assert subtree_entry.tree == self.repo[subtree_entry.id]
+        assert subtree_entry.obj == self.repo[subtree_entry.id]
 
     def test_new_tree(self):
         repo = self.repo
@@ -159,9 +159,9 @@ class TreeTest(utils.BareRepoTestCase):
         assert y.type == 'blob'
         assert z.type == 'tree'
 
-        assert x.blob == repo[x.id]
-        assert y.blob == repo[y.id]
-        assert z.tree == repo[z.id]
+        assert x.obj == repo[x.id]
+        assert y.obj == repo[y.id]
+        assert z.obj == repo[z.id]
 
 
     def test_modify_tree(self):

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -83,7 +83,10 @@ class TreeTest(utils.BareRepoTestCase):
         self.assertRaisesWithArg(KeyError, 'ab/cd', lambda: tree['ab/cd'])
         self.assertRaisesWithArg(KeyError, 'ab/cd', lambda: tree / 'ab/cd')
         self.assertRaisesWithArg(KeyError, 'ab', lambda: tree / 'c' / 'ab')
-        self.assertRaisesWithArg(TypeError, 'Only supported for trees', lambda: tree / 'a' / 'cd')
+        self.assertRaisesWithArg(TypeError, 'Only for trees', lambda: tree / 'a' / 'cd')
+
+        self.assertRaisesWithArg(TypeError, 'Only for trees', lambda: (tree / 'c' / 'd').tree)
+        self.assertRaisesWithArg(TypeError, 'Only for blobs', lambda: (tree / 'c').blob)
 
     def test_equality(self):
         tree_a = self.repo['18e2d2e9db075f9eb43bcb2daa65a2867d29a15e']
@@ -113,6 +116,8 @@ class TreeTest(utils.BareRepoTestCase):
         sha = '297efb891a47de80be0cfe9c639e4b8c9b450989'
         self.assertTreeEntryEqual(subtree[0], sha, 'd', 0o0100644)
 
+        subtree_entry = (tree / 'c')
+        assert subtree_entry.tree == self.repo[subtree_entry.id]
 
     def test_new_tree(self):
         repo = self.repo
@@ -153,6 +158,10 @@ class TreeTest(utils.BareRepoTestCase):
         assert x.type == 'blob'
         assert y.type == 'blob'
         assert z.type == 'tree'
+
+        assert x.blob == repo[x.id]
+        assert y.blob == repo[y.id]
+        assert z.tree == repo[z.id]
 
 
     def test_modify_tree(self):


### PR DESCRIPTION
Navigating tree objects is pretty crude via Pygit2 at the moment, requiring a lot of boilerplate lookups.

This change incorporates the same `/` operator approach as [Pathlib](https://docs.python.org/3/library/pathlib.html#operators) and [GitPython](https://gitpython.readthedocs.io/en/stable/tutorial.html?highlight=existing%20repository#the-tree-object):

* `my_tree / 'path'` resolves to a TreeEntry (same as `my_tree['path']` currently)
* If a TreeEntry is of type `tree`, then:
  * `my_tree_entry / 'path'` resolves to a child TreeEntry
  * `my_tree_entry['path']` and `my_tree_entry[0]` similarly
  * `'path' in my_tree_entry` returns a boolean.
* this enables `my_tree / 'path' / 'path'` navigation

_Ideally_ I'd suggest that maybe Tree should probably be a subclass of TreeEntry so it kinda magically works how the user expects, but that would require quite a few changes.