### PR TITLE
Do not throw exception when Config.__init__() failed

### DIFF
--- a/pygit2/config.py
+++ b/pygit2/config.py
@@ -96,7 +96,10 @@ class Config(object):
         return config
 
     def __del__(self):
-        C.git_config_free(self._config)
+        try:
+            C.git_config_free(self._config)
+        except AttributeError:
+            pass
 
     def _get(self, key):
         assert_string(key, "key")


### PR DESCRIPTION
Config.__init__() does not always set self._config, which can cause
trouble during __del__(). This avoids seemingly spurious and not
really helpful exceptions.
Fixes #916