### PR TITLE
Removed duplicate element in initializer

### DIFF
--- a/pygit2/errors.py
+++ b/pygit2/errors.py
@@ -30,8 +30,7 @@ from .ffi import ffi, C
 from _pygit2 import GitError
 
 
-value_errors = set([C.GIT_EEXISTS, C.GIT_EINVALIDSPEC, C.GIT_EEXISTS,
-                    C.GIT_EAMBIGUOUS])
+value_errors = set([C.GIT_EEXISTS, C.GIT_EINVALIDSPEC, C.GIT_EAMBIGUOUS])
 
 def check_error(err, io=False):
     if err >= 0:


### PR DESCRIPTION
`C.GIT_EEXISTS` was specified twice in the `Set` initializer, which was unnecessary and would lead to reader confusion.