### PR TITLE
Add `Index.remove_all()` method

### DIFF
--- a/pygit2/decl/index.h
+++ b/pygit2/decl/index.h
@@ -48,6 +48,11 @@ int git_index_add_all(
 	unsigned int flags,
 	git_index_matched_path_cb callback,
 	void *payload);
+int git_index_remove_all(
+	git_index *index,
+	const git_strarray *pathspec,
+	git_index_matched_path_cb callback,
+	void *payload);
 int git_index_has_conflicts(const git_index *index);
 void git_index_conflict_iterator_free(
 	git_index_conflict_iterator *iterator);

--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -174,6 +174,13 @@ class Index(object):
         err = C.git_index_remove(self._index, to_bytes(path), level)
         check_error(err, True)
 
+    def remove_all(self, pathspecs):
+        """Remove all index entries matching pathspecs.
+        """
+        with StrArray(pathspecs) as arr:
+            err = C.git_index_remove_all(self._index, arr, ffi.NULL, ffi.NULL)
+            check_error(err, True)
+
     def add_all(self, pathspecs=[]):
         """Add or update index entries matching files in the working directory.
 

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -177,6 +177,15 @@ class IndexTest(utils.RepoTestCase):
         index.remove('hello.txt')
         assert 'hello.txt' not in index
 
+    def test_remove_all(self):
+        index = self.repo.index
+        print([i.path for i in index])
+        assert 'hello.txt' in index
+        index.remove_all(['*.txt'])
+        assert 'hello.txt' not in index
+
+        index.remove_all(['not-existing'])  # this doesn't error
+
     def test_change_attributes(self):
         index = self.repo.index
         entry = index['hello.txt']


### PR DESCRIPTION
Matches `Index.add_all()`, calls [`git_index_remove_all()`](https://libgit2.org/libgit2/#HEAD/group/index/git_index_remove_all) underneath:

```
myindex.remove_all(["*.txt", "foo.bar"])
```