### PR TITLE
[WIP] OdbBackend: Python subclassing

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -145,7 +145,7 @@ git_error_for_exc()
             return GIT_ENOTFOUND;
         }
         if (PyErr_GivenExceptionMatches(err, PyExc_ValueError)) {
-            return GIT_EINVALID;
+            return GIT_EAMBIGUOUS;
         }
         /* TODO: others? */
         return GIT_EUSER;

--- a/src/error.c
+++ b/src/error.c
@@ -135,3 +135,20 @@ Error_type_error(const char *format, PyObject *value)
     PyErr_Format(PyExc_TypeError, format, Py_TYPE(value)->tp_name);
     return NULL;
 }
+
+int
+git_error_for_exc()
+{
+    PyObject *err;
+    if ((err = PyErr_Occurred()) != NULL) {
+        if (PyErr_GivenExceptionMatches(err, PyExc_KeyError)) {
+            return GIT_ENOTFOUND;
+        }
+        if (PyErr_GivenExceptionMatches(err, PyExc_ValueError)) {
+            return GIT_EINVALID;
+        }
+        /* TODO: others? */
+        return GIT_EUSER;
+    }
+    return 0;
+}

--- a/src/error.h
+++ b/src/error.h
@@ -38,5 +38,6 @@ PyObject* Error_set_exc(PyObject* exception);
 PyObject* Error_set_str(int err, const char *str);
 PyObject* Error_set_oid(int err, const git_oid *oid, size_t len);
 PyObject* Error_type_error(const char *format, PyObject *value);
+int git_error_for_exc();
 
 #endif

--- a/src/odb.c
+++ b/src/odb.c
@@ -158,7 +158,7 @@ Odb_read_raw(git_odb *odb, const git_oid *oid, size_t len)
     int err;
 
     err = git_odb_read_prefix(&obj, odb, oid, (unsigned int)len);
-    if (err < 0) {
+    if (err < 0 && err != GIT_EUSER) {
         Error_set_oid(err, oid, len);
         return NULL;
     }
@@ -288,7 +288,7 @@ Odb_add_backend(Odb *self, PyObject *args)
     }
 
     err = git_odb_add_backend(self->odb, backend->odb_backend, priority);
-    if (err > 0)
+    if (err != 0)
         return Error_set(err);
 
     Py_RETURN_NONE;

--- a/src/odb.c
+++ b/src/odb.c
@@ -240,6 +240,31 @@ Odb_write(Odb *self, PyObject *args)
     return git_oid_to_python(&oid);
 }
 
+PyDoc_STRVAR(Odb_exists__doc__,
+    "exists(oid) -> bool\n"
+    "\n"
+    "Returns true if the given oid can be found in this odb.");
+
+PyObject *
+Odb_exists(Odb *self, PyObject *py_hex)
+{
+    git_oid oid;
+    size_t len;
+    int result;
+
+    len = py_oid_to_git_oid(py_hex, &oid);
+    if (len == 0)
+        return NULL;
+
+    result = git_odb_exists(self->odb, &oid);
+    if (result < 0)
+        return Error_set(result);
+    else if (result == 0)
+        Py_RETURN_FALSE;
+    else
+        Py_RETURN_TRUE;
+}
+
 
 PyDoc_STRVAR(Odb_add_backend__doc__,
     "add_backend(backend, priority)\n"
@@ -274,6 +299,7 @@ PyMethodDef Odb_methods[] = {
     METHOD(Odb, add_disk_alternate, METH_O),
     METHOD(Odb, read, METH_O),
     METHOD(Odb, write, METH_VARARGS),
+    METHOD(Odb, exists, METH_O),
     METHOD(Odb, add_backend, METH_VARARGS),
     {NULL}
 };

--- a/src/odb_backend.c
+++ b/src/odb_backend.c
@@ -649,6 +649,14 @@ OdbBackend_refresh(OdbBackend *self)
     return Py_None;
 }
 
+/*
+ * TODO:
+ * - write
+ * - writepack
+ * - writestream
+ * - readstream
+ * - freshen
+ */
 PyMethodDef OdbBackend_methods[] = {
     METHOD(OdbBackend, read, METH_O),
     METHOD(OdbBackend, read_prefix, METH_O),

--- a/src/odb_backend.c
+++ b/src/odb_backend.c
@@ -36,6 +36,310 @@
 #include <git2/sys/alloc.h>
 #include <git2/sys/odb_backend.h>
 
+/*
+ * pygit2_odb_backend is a container for the state associated with a custom
+ * implementation of git_odb_backend. It holds a list of callable references
+ * which represent the Python class's implementations of each git_odb_backend
+ * function. The git_odb_backend field's function pointers are assigned to the
+ * pygit2_odb_backend_* functions, which handle translating between the libgit2
+ * ABI and the Python ABI.
+ */
+struct pygit2_odb_backend
+{
+    git_odb_backend backend;
+    PyObject *OdbBackend;
+    PyObject *read,
+             *read_prefix,
+             *read_header,
+             *write,
+             *writestream,
+             *readstream,
+             *exists,
+             *exists_prefix,
+             *refresh,
+             *foreach, /* __iter__ */
+             *writepack,
+             *freshen;
+};
+
+static int
+pygit2_odb_backend_read(void **ptr, size_t *sz,
+        git_object_t *type, git_odb_backend *_be, const git_oid *oid)
+{
+    int err;
+    PyObject *args, *py_oid, *result;
+    struct pygit2_odb_backend *be = (struct pygit2_odb_backend *)_be;
+
+    py_oid = git_oid_to_python(oid);
+    args = Py_BuildValue("(O)", py_oid);
+    result = PyObject_CallObject(be->read, args);
+    Py_DECREF(py_oid);
+
+    if ((err = git_error_for_exc()) != 0) {
+        return err;
+    }
+
+    if (result == NULL)
+        return GIT_EUSER;
+
+    const char *bytes;
+    if (!PyArg_ParseTuple(result, "ny#", type, &bytes, sz) || !bytes)
+        return GIT_EUSER;
+
+    /* XXX: This assumes the default libgit2 allocator is in use and will
+     * probably segfault and/or destroy the universe otherwise */
+    *ptr = malloc(*sz);
+    if (!*ptr)
+        return GIT_EUSER;
+
+    memcpy(*ptr, bytes, *sz);
+    return 0;
+}
+
+static int
+pygit2_odb_backend_read_prefix(git_oid *oid_out, void **ptr, size_t *sz,
+        git_object_t *type, git_odb_backend *_be,
+        const git_oid *short_oid, size_t len)
+{
+    int err;
+    PyObject *args, *py_oid, *py_oid_out, *result;
+    struct pygit2_odb_backend *be = (struct pygit2_odb_backend *)_be;
+
+    py_oid = git_oid_to_python(short_oid);
+    args = Py_BuildValue("(O)", py_oid);
+    result = PyObject_CallObject(be->read_prefix, args);
+    Py_DECREF(py_oid);
+
+    if ((err = git_error_for_exc()) != 0) {
+        return err;
+    }
+
+    if (result == NULL)
+        return GIT_EUSER;
+
+    const char *bytes;
+    if (!PyArg_ParseTuple(result, "Ony#",
+                &py_oid_out, type, &bytes, sz) || !bytes)
+        return GIT_EUSER;
+
+    /* XXX: This assumes the default libgit2 allocator is in use and will
+     * probably segfault and/or destroy the universe otherwise */
+    *ptr = malloc(*sz);
+    if (!*ptr)
+        return GIT_EUSER;
+
+    memcpy(*ptr, bytes, *sz);
+    py_oid_to_git_oid(py_oid_out, oid_out);
+    return 0;
+}
+
+static int
+pygit2_odb_backend_read_header(size_t *len, git_object_t *type,
+        git_odb_backend *_be, const git_oid *oid)
+{
+    int err;
+    PyObject *args, *py_oid, *result;
+    struct pygit2_odb_backend *be = (struct pygit2_odb_backend *)_be;
+
+    py_oid = git_oid_to_python(oid);
+    args = Py_BuildValue("(O)", py_oid);
+    result = PyObject_CallObject(be->read_header, args);
+    Py_DECREF(py_oid);
+
+    if ((err = git_error_for_exc()) != 0) {
+        return err;
+    }
+
+    if (result == NULL)
+        return GIT_EUSER;
+
+    if (!PyArg_ParseTuple(result, "nn", type, len))
+        return GIT_EUSER;
+
+    return 0;
+}
+
+static int
+pygit2_odb_backend_write(git_odb_backend *_be, const git_oid *oid,
+        const void *data, size_t sz, git_object_t typ)
+{
+    int err;
+    PyObject *args, *py_oid, *result;
+    struct pygit2_odb_backend *be = (struct pygit2_odb_backend *)_be;
+
+    py_oid = git_oid_to_python(oid);
+    args = Py_BuildValue("(Oy#n)", py_oid, data, sz, typ);
+    result = PyObject_CallObject(be->write, args);
+    Py_DECREF(py_oid);
+
+    if ((err = git_error_for_exc()) != 0) {
+        return err;
+    }
+
+    if (result == NULL)
+        return GIT_EUSER;
+
+    return 0;
+}
+
+static int
+pygit2_odb_backend_exists(git_odb_backend *_be, const git_oid *oid)
+{
+    int err;
+    PyObject *args, *py_oid, *result;
+    struct pygit2_odb_backend *be = (struct pygit2_odb_backend *)_be;
+
+    py_oid = git_oid_to_python(oid);
+    args = Py_BuildValue("(O)", py_oid);
+    result = PyObject_CallObject(be->exists, args);
+    Py_DECREF(py_oid);
+
+    if ((err = git_error_for_exc()) != 0) {
+        return err;
+    }
+
+    if (!result)
+        return GIT_EUSER;
+
+    return PyObject_IsTrue(result);
+}
+
+static void
+pygit2_odb_backend_free(git_odb_backend *_be)
+{
+    struct pygit2_odb_backend *be = (struct pygit2_odb_backend *)_be;
+    Py_DECREF(be->OdbBackend);
+}
+
+int
+OdbBackend_init(OdbBackend *self, PyObject *args, PyObject *kwds)
+{
+    if (args && PyTuple_Size(args) > 0) {
+        PyErr_SetString(PyExc_TypeError,
+                        "OdbBackend takes no arguments");
+        return -1;
+    }
+
+    if (kwds && PyDict_Size(kwds) > 0) {
+        PyErr_SetString(PyExc_TypeError,
+                        "OdbBackend takes no keyword arguments");
+        return -1;
+    }
+
+    struct pygit2_odb_backend *be = calloc(1, sizeof(struct pygit2_odb_backend));
+    be->backend.version = GIT_ODB_BACKEND_VERSION;
+    be->OdbBackend = (PyObject *)self;
+
+    be->read = PyObject_GetAttrString((PyObject *)self, "read");
+    if (be->read) {
+        be->backend.read = pygit2_odb_backend_read;
+        Py_INCREF(be->read);
+    }
+
+    be->read_prefix = PyObject_GetAttrString(
+            (PyObject *)self, "read_prefix");
+    if (be->read_prefix) {
+        be->backend.read_prefix = pygit2_odb_backend_read_prefix;
+        Py_INCREF(be->read_prefix);
+    }
+
+    be->read_header = PyObject_GetAttrString(
+            (PyObject *)self, "read_header");
+    if (be->read_header) {
+        be->backend.read_header = pygit2_odb_backend_read_header;
+        Py_INCREF(be->read_header);
+    }
+
+    be->write = PyObject_GetAttrString(
+            (PyObject *)self, "write");
+    if (be->write) {
+        be->backend.write = pygit2_odb_backend_write;
+        Py_INCREF(be->write);
+    }
+
+    /* TODO: Stream-based read/write
+    be->writestream = PyObject_GetAttrString(
+            (PyObject *)self, "writestream");
+    if (be->writestream) {
+        be->backend.writestream = pygit2_odb_backend_writestream;
+        Py_INCREF(be->writestream);
+    }
+
+    be->readstream = PyObject_GetAttrString(
+            (PyObject *)self, "readstream");
+    if (be->readstream) {
+        be->backend.readstream = pygit2_odb_backend_readstream;
+        Py_INCREF(be->readstream);
+    }
+    */
+
+    be->exists = PyObject_GetAttrString(
+            (PyObject *)self, "exists");
+    if (be->exists) {
+        be->backend.exists = pygit2_odb_backend_exists;
+        Py_INCREF(be->exists);
+    }
+
+    /*
+    be->exists_prefix = PyObject_GetAttrString(
+            (PyObject *)self, "exists_prefix");
+    if (be->exists_prefix) {
+        be->backend.exists_prefix = pygit2_odb_backend_exists_prefix;
+        Py_INCREF(be->exists_prefix);
+    }
+
+    be->refresh = PyObject_GetAttrString(
+            (PyObject *)self, "refresh");
+    if (be->refresh) {
+        be->backend.refresh = pygit2_odb_backend_refresh;
+        Py_INCREF(be->refresh);
+    }
+
+    be->writepack = PyObject_GetAttrString(
+            (PyObject *)self, "writepack");
+    if (be->writepack) {
+        be->backend.writepack = pygit2_odb_backend_writepack;
+        Py_INCREF(be->writepack);
+    }
+
+    be->freshen = PyObject_GetAttrString(
+            (PyObject *)self, "freshen");
+    if (be->freshen) {
+        be->backend.freshen = pygit2_odb_backend_freshen;
+        Py_INCREF(be->freshen);
+    }
+    */
+
+    Py_INCREF((PyObject *)self);
+    be->backend.free = pygit2_odb_backend_free;
+
+    self->odb_backend = (git_odb_backend *)be;
+    return 0;
+}
+
+void
+OdbBackend_dealloc(OdbBackend *self)
+{
+    if (self->odb_backend && self->odb_backend->read == pygit2_odb_backend_read) {
+        struct pygit2_odb_backend *be = (struct pygit2_odb_backend *)self->odb_backend;
+        Py_CLEAR(be->read);
+        Py_CLEAR(be->read_prefix);
+        Py_CLEAR(be->read_header);
+        Py_CLEAR(be->write);
+        Py_CLEAR(be->writestream);
+        Py_CLEAR(be->readstream);
+        Py_CLEAR(be->exists);
+        Py_CLEAR(be->exists_prefix);
+        Py_CLEAR(be->refresh);
+        Py_CLEAR(be->foreach);
+        Py_CLEAR(be->writepack);
+        Py_CLEAR(be->freshen);
+        free(be);
+    }
+
+    Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
 static int
 OdbBackend_build_as_iter(const git_oid *oid, void *accum)
 {
@@ -77,7 +381,7 @@ exit:
 }
 
 PyDoc_STRVAR(OdbBackend_read__doc__,
-    "read(oid) -> (type, data, size)\n"
+    "read(oid) -> (type, data)\n"
     "\n"
     "Read raw object data from this odb backend.\n");
 
@@ -115,8 +419,113 @@ OdbBackend_read(OdbBackend *self, PyObject *py_hex)
     return tuple;
 }
 
+PyDoc_STRVAR(OdbBackend_read_prefix__doc__,
+    "read_prefix(oid) -> (oid, type, data)\n"
+    "\n"
+    "Read raw object data from this odb backend based on an oid prefix.\n");
+
+PyObject *
+OdbBackend_read_prefix(OdbBackend *self, PyObject *py_hex)
+{
+    int err;
+    git_oid oid, oid_out;
+    git_object_t type;
+    size_t len, sz;
+    void *data;
+    PyObject *tuple, *py_oid_out;
+
+    if (self->odb_backend->read_prefix == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    len = py_oid_to_git_oid(py_hex, &oid);
+    if (len == 0)
+        return NULL;
+
+    err = self->odb_backend->read_prefix(&oid_out,
+            &data, &sz, &type, self->odb_backend, &oid, len);
+    if (err != 0) {
+        Error_set_oid(err, &oid, len);
+        return NULL;
+    }
+
+    py_oid_out = git_oid_to_python(&oid_out);
+    tuple = Py_BuildValue("(ny#o)", type, data, sz, py_oid_out);
+
+    /* XXX: This assumes the default libgit2 allocator is in use and will
+     * probably segfault and/or destroy the universe otherwise */
+    free(data);
+
+    return tuple;
+}
+
+PyDoc_STRVAR(OdbBackend_read_header__doc__,
+    "read_header(oid) -> (type, len)\n"
+    "\n"
+    "Read raw object header from this odb backend.");
+
+PyObject *
+OdbBackend_read_header(OdbBackend *self, PyObject *py_hex)
+{
+    int err;
+    size_t len;
+    git_object_t type;
+    git_oid oid;
+
+    if (self->odb_backend->read_header == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    len = py_oid_to_git_oid(py_hex, &oid);
+    if (len == 0)
+        return NULL;
+
+    err = self->odb_backend->read_header(&len, &type, self->odb_backend, &oid);
+    if (err != 0) {
+        Error_set_oid(err, &oid, len);
+        return NULL;
+    }
+
+    return Py_BuildValue("(ni)", type, len);
+}
+
+PyDoc_STRVAR(OdbBackend_exists__doc__,
+    "exists(oid) -> bool\n"
+    "\n"
+    "Returns true if the given oid can be found in this odb.");
+
+PyObject *
+OdbBackend_exists(OdbBackend *self, PyObject *py_hex)
+{
+    int result;
+    size_t len;
+    git_oid oid;
+
+    if (self->odb_backend->exists == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    len = py_oid_to_git_oid(py_hex, &oid);
+    if (len == 0)
+        return NULL;
+
+    result = self->odb_backend->exists(self->odb_backend, &oid);
+    if (result < 0)
+        return Error_set(result);
+    else if (result == 0)
+        Py_RETURN_FALSE;
+    else
+        Py_RETURN_TRUE;
+}
+
 PyMethodDef OdbBackend_methods[] = {
     METHOD(OdbBackend, read, METH_O),
+    METHOD(OdbBackend, read_prefix, METH_O),
+    METHOD(OdbBackend, read_header, METH_O),
+    METHOD(OdbBackend, exists, METH_O),
     {NULL}
 };
 
@@ -127,7 +536,7 @@ PyTypeObject OdbBackendType = {
     "_pygit2.OdbBackend",                      /* tp_name           */
     sizeof(OdbBackend),                        /* tp_basicsize      */
     0,                                         /* tp_itemsize       */
-    0,                                         /* tp_dealloc        */
+    (destructor)OdbBackend_dealloc,            /* tp_dealloc        */
     0,                                         /* tp_print          */
     0,                                         /* tp_getattr        */
     0,                                         /* tp_setattr        */
@@ -158,7 +567,7 @@ PyTypeObject OdbBackendType = {
     0,                                         /* tp_descr_get      */
     0,                                         /* tp_descr_set      */
     0,                                         /* tp_dictoffset     */
-    0,                                         /* tp_init           */
+    (initproc)OdbBackend_init,                 /* tp_init           */
     0,                                         /* tp_alloc          */
     0,                                         /* tp_new            */
 };
@@ -166,12 +575,12 @@ PyTypeObject OdbBackendType = {
 PyObject *
 wrap_odb_backend(git_odb_backend *c_odb_backend)
 {
-    OdbBackend *py_odb_backend = PyObject_New(OdbBackend, &OdbBackendType);
+    OdbBackend *pygit2_odb_backend = PyObject_New(OdbBackend, &OdbBackendType);
 
-    if (py_odb_backend)
-        py_odb_backend->odb_backend = c_odb_backend;
+    if (pygit2_odb_backend)
+        pygit2_odb_backend->odb_backend = c_odb_backend;
 
-    return (PyObject *)py_odb_backend;
+    return (PyObject *)pygit2_odb_backend;
 }
 
 PyDoc_STRVAR(OdbBackendPack__doc__, "Object database backend for packfiles.");

--- a/src/odb_backend.c
+++ b/src/odb_backend.c
@@ -301,66 +301,66 @@ OdbBackend_init(OdbBackend *self, PyObject *args, PyObject *kwds)
     be->backend.version = GIT_ODB_BACKEND_VERSION;
     be->OdbBackend = (PyObject *)self;
 
-    be->read = PyObject_GetAttrString((PyObject *)self, "read");
-    if (be->read) {
+    if (PyObject_HasAttrString((PyObject *)self, "read")) {
+        be->read = PyObject_GetAttrString((PyObject *)self, "read");
         be->backend.read = pygit2_odb_backend_read;
         Py_INCREF(be->read);
     }
 
-    be->read_prefix = PyObject_GetAttrString(
-            (PyObject *)self, "read_prefix");
-    if (be->read_prefix) {
+    if (PyObject_HasAttrString((PyObject *)self, "read_prefix")) {
+        be->read_prefix = PyObject_GetAttrString(
+                (PyObject *)self, "read_prefix");
         be->backend.read_prefix = pygit2_odb_backend_read_prefix;
         Py_INCREF(be->read_prefix);
     }
 
-    be->read_header = PyObject_GetAttrString(
-            (PyObject *)self, "read_header");
-    if (be->read_header) {
+    if (PyObject_HasAttrString((PyObject *)self, "read_header")) {
+        be->read_header = PyObject_GetAttrString(
+                (PyObject *)self, "read_header");
         be->backend.read_header = pygit2_odb_backend_read_header;
         Py_INCREF(be->read_header);
     }
 
-    be->write = PyObject_GetAttrString(
-            (PyObject *)self, "write");
-    if (be->write) {
+    if (PyObject_HasAttrString((PyObject *)self, "write")) {
+        be->write = PyObject_GetAttrString(
+                (PyObject *)self, "write");
         be->backend.write = pygit2_odb_backend_write;
         Py_INCREF(be->write);
     }
 
     /* TODO: Stream-based read/write
-    be->writestream = PyObject_GetAttrString(
-            (PyObject *)self, "writestream");
-    if (be->writestream) {
+    if (PyObject_HasAttrString((PyObject *)self, "writestream")) {
+        be->writestream = PyObject_GetAttrString(
+                (PyObject *)self, "writestream");
         be->backend.writestream = pygit2_odb_backend_writestream;
         Py_INCREF(be->writestream);
     }
 
-    be->readstream = PyObject_GetAttrString(
-            (PyObject *)self, "readstream");
-    if (be->readstream) {
+    if (PyObject_HasAttrString((PyObject *)self, "readstream")) {
+        be->readstream = PyObject_GetAttrString(
+                (PyObject *)self, "readstream");
         be->backend.readstream = pygit2_odb_backend_readstream;
         Py_INCREF(be->readstream);
     }
     */
 
-    be->exists = PyObject_GetAttrString(
-            (PyObject *)self, "exists");
-    if (be->exists) {
+    if (PyObject_HasAttrString((PyObject *)self, "exists")) {
+        be->exists = PyObject_GetAttrString(
+                (PyObject *)self, "exists");
         be->backend.exists = pygit2_odb_backend_exists;
         Py_INCREF(be->exists);
     }
 
-    be->exists_prefix = PyObject_GetAttrString(
-            (PyObject *)self, "exists_prefix");
-    if (be->exists_prefix) {
+    if (PyObject_HasAttrString((PyObject *)self, "exists_prefix")) {
+        be->exists_prefix = PyObject_GetAttrString(
+                (PyObject *)self, "exists_prefix");
         be->backend.exists_prefix = pygit2_odb_backend_exists_prefix;
         Py_INCREF(be->exists_prefix);
     }
 
-    be->refresh = PyObject_GetAttrString(
-            (PyObject *)self, "refresh");
-    if (be->refresh) {
+    if (PyObject_HasAttrString((PyObject *)self, "refresh")) {
+        be->refresh = PyObject_GetAttrString(
+                (PyObject *)self, "refresh");
         be->backend.refresh = pygit2_odb_backend_refresh;
         Py_INCREF(be->refresh);
     }
@@ -369,17 +369,17 @@ OdbBackend_init(OdbBackend *self, PyObject *args, PyObject *kwds)
         be->backend.foreach = pygit2_odb_backend_foreach;
     }
 
-    /*
-    be->writepack = PyObject_GetAttrString(
-            (PyObject *)self, "writepack");
-    if (be->writepack) {
+    /* TODO:
+    if (PyObject_HasAttrString((PyObject *)self, "writepack")) {
+        be->writepack = PyObject_GetAttrString(
+                (PyObject *)self, "writepack");
         be->backend.writepack = pygit2_odb_backend_writepack;
         Py_INCREF(be->writepack);
     }
 
-    be->freshen = PyObject_GetAttrString(
-            (PyObject *)self, "freshen");
-    if (be->freshen) {
+    if (PyObject_HasAttrString((PyObject *)self, "freshen")) {
+        be->freshen = PyObject_GetAttrString(
+                (PyObject *)self, "freshen");
         be->backend.freshen = pygit2_odb_backend_freshen;
         Py_INCREF(be->freshen);
     }
@@ -525,7 +525,7 @@ OdbBackend_read_prefix(OdbBackend *self, PyObject *py_hex)
     }
 
     py_oid_out = git_oid_to_python(&oid_out);
-    tuple = Py_BuildValue("(ny#o)", type, data, sz, py_oid_out);
+    tuple = Py_BuildValue("(ny#O)", type, data, sz, py_oid_out);
 
     /* XXX: This assumes the default libgit2 allocator is in use and will
      * probably segfault and/or destroy the universe otherwise */

--- a/src/odb_backend.c
+++ b/src/odb_backend.c
@@ -85,9 +85,7 @@ pygit2_odb_backend_read(void **ptr, size_t *sz,
     if (!PyArg_ParseTuple(result, "ny#", type, &bytes, sz) || !bytes)
         return GIT_EUSER;
 
-    /* XXX: This assumes the default libgit2 allocator is in use and will
-     * probably segfault and/or destroy the universe otherwise */
-    *ptr = malloc(*sz);
+    *ptr = git_odb_backend_data_alloc(_be, *sz);
     if (!*ptr)
         return GIT_EUSER;
 
@@ -121,9 +119,7 @@ pygit2_odb_backend_read_prefix(git_oid *oid_out, void **ptr, size_t *sz,
                 &py_oid_out, type, &bytes, sz) || !bytes)
         return GIT_EUSER;
 
-    /* XXX: This assumes the default libgit2 allocator is in use and will
-     * probably segfault and/or destroy the universe otherwise */
-    *ptr = malloc(*sz);
+    *ptr = git_odb_backend_data_alloc(_be, *sz);
     if (!*ptr)
         return GIT_EUSER;
 
@@ -486,9 +482,7 @@ OdbBackend_read(OdbBackend *self, PyObject *py_hex)
 
     tuple = Py_BuildValue("(ny#)", type, data, sz);
 
-    /* XXX: This assumes the default libgit2 allocator is in use and will
-     * probably segfault and/or destroy the universe otherwise */
-    free(data);
+    git_odb_backend_data_free(self->odb_backend, data);
 
     return tuple;
 }
@@ -527,9 +521,7 @@ OdbBackend_read_prefix(OdbBackend *self, PyObject *py_hex)
     py_oid_out = git_oid_to_python(&oid_out);
     tuple = Py_BuildValue("(ny#O)", type, data, sz, py_oid_out);
 
-    /* XXX: This assumes the default libgit2 allocator is in use and will
-     * probably segfault and/or destroy the universe otherwise */
-    free(data);
+    git_odb_backend_data_free(self->odb_backend, data);
 
     return tuple;
 }

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -312,7 +312,7 @@ moduleinit(PyObject* m)
     INIT_TYPE(OdbType, NULL, PyType_GenericNew)
     ADD_TYPE(m, Odb)
 
-    INIT_TYPE(OdbBackendType, NULL, NULL)
+    INIT_TYPE(OdbBackendType, NULL, PyType_GenericNew)
     ADD_TYPE(m, OdbBackend)
     INIT_TYPE(OdbBackendPackType, &OdbBackendType, PyType_GenericNew)
     ADD_TYPE(m, OdbBackendPack)

--- a/test/test_odb.py
+++ b/test/test_odb.py
@@ -101,29 +101,3 @@ class OdbTest(utils.BareRepoTestCase):
 
         oid = self.odb.write(GIT_OBJ_BLOB, data)
         assert type(oid) == Oid
-
-
-class OdbBackendTest(utils.BareRepoTestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.ref_odb = self.repo.odb
-        self.obj_path = os.path.join(os.path.dirname(__file__),
-                'data', 'testrepo.git', 'objects')
-
-    def tearDown(self):
-        del self.ref_odb
-        gc.collect()
-        super().tearDown()
-
-    def test_pack(self):
-        pack = OdbBackendPack(self.obj_path)
-        assert len(list(pack)) > 0
-        for obj in pack:
-            assert obj in self.ref_odb
-
-    def test_loose(self):
-        pack = OdbBackendLoose(self.obj_path, 5, False)
-        assert len(list(pack)) > 0
-        for obj in pack:
-            assert obj in self.ref_odb

--- a/test/test_odb_backend.py
+++ b/test/test_odb_backend.py
@@ -1,0 +1,128 @@
+# Copyright 2010-2019 The pygit2 contributors
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2,
+# as published by the Free Software Foundation.
+#
+# In addition to the permissions in the GNU General Public License,
+# the authors give you unlimited permission to link the compiled
+# version of this file into combinations with other programs,
+# and to distribute those combinations without any restriction
+# coming from the use of this file.  (The General Public License
+# restrictions do apply in other respects; for example, they cover
+# modification of the file, and distribution when not linked into
+# a combined executable.)
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+
+"""Tests for Odb backends."""
+
+# Import from the Standard Library
+import binascii
+import gc
+import os
+import unittest
+
+import pytest
+
+# Import from pygit2
+from pygit2 import Odb, OdbBackend, OdbBackendPack, OdbBackendLoose, Oid
+from pygit2 import GIT_OBJ_ANY, GIT_OBJ_BLOB
+
+from . import utils
+
+BLOB_HEX = 'af431f20fc541ed6d5afede3e2dc7160f6f01f16'
+BLOB_RAW = binascii.unhexlify(BLOB_HEX.encode('ascii'))
+BLOB_OID = Oid(raw=BLOB_RAW)
+
+class OdbBackendTest(utils.BareRepoTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.ref_odb = self.repo.odb
+        self.obj_path = os.path.join(os.path.dirname(__file__),
+                'data', 'testrepo.git', 'objects')
+
+    def tearDown(self):
+        del self.ref_odb
+        gc.collect()
+        super().tearDown()
+
+    def test_pack(self):
+        pack = OdbBackendPack(self.obj_path)
+        assert len(list(pack)) > 0
+        for obj in pack:
+            assert obj in self.ref_odb
+
+    def test_loose(self):
+        pack = OdbBackendLoose(self.obj_path, 5, False)
+        assert len(list(pack)) > 0
+        for obj in pack:
+            assert obj in self.ref_odb
+
+class ProxyBackend(OdbBackend):
+    def __init__(self, source):
+        super().__init__()
+        self.source = source
+
+    def read(self, oid):
+        return self.source.read(oid)
+
+    def read_prefix(self, oid):
+        return self.source.read_prefix(oid)
+
+    def read_header(self, oid):
+        typ, data = self.source.read(oid)
+        return typ, len(data)
+
+    def exists(self, oid):
+        return self.source.exists(oid)
+
+    def exists_prefix(self, oid):
+        return self.source.exists_prefix(oid)
+
+    def __iter__(self):
+        return iter(self.source)
+
+class CustomBackendTest(utils.BareRepoTestCase):
+    def setUp(self):
+        super().setUp()
+        self.obj_path = os.path.join(os.path.dirname(__file__),
+                'data', 'testrepo.git', 'objects')
+        self.odb = ProxyBackend(OdbBackendPack(self.obj_path))
+
+    def test_iterable(self):
+        assert BLOB_HEX in [str(o) for o in self.odb]
+
+    def test_read(self):
+        with pytest.raises(TypeError): self.odb.read(123)
+        self.assertRaisesWithArg(KeyError, '1' * 40, self.odb.read, '1' * 40)
+
+        ab = self.odb.read(BLOB_OID)
+        a = self.odb.read(BLOB_HEX)
+        assert ab == a
+        assert (GIT_OBJ_BLOB, b'a contents\n') == a
+
+    def test_read_prefix(self):
+        a_hex_prefix = BLOB_HEX[:4]
+        a3 = self.odb.read_prefix(a_hex_prefix)
+        assert (GIT_OBJ_BLOB, b'a contents\n', BLOB_OID) == a3
+
+    def test_exists(self):
+        with pytest.raises(TypeError): self.odb.exists(123)
+
+        assert self.odb.exists('1' * 40) == False
+        assert self.odb.exists(BLOB_HEX) == True
+
+    def test_exists_prefix(self):
+        a_hex_prefix = BLOB_HEX[:4]
+        a3 = self.odb.exists_prefix(a_hex_prefix)
+        assert BLOB_HEX == a3.hex


### PR DESCRIPTION
The basic approach here is to have backends created from C (loose, pack) circumvent the OdbBackend_init function. However, backends created from Python will not. We then use this backend to pull out the functions implemented in Python and rig them up through shim functions to the libgit2 git_odb_backend.

TODO:

- [x] read
- [x] read_prefix
- [x] read_header
- [x] write
- [x] exists
- [x] exists_prefix
- [x] refresh
- [x] foreach
- [x] Unit tests

Separate patch?

- [ ] writestream
- [ ] readstream
- [ ] freshen
- [ ] writepack
- [ ] Custom refdbs
- [ ] Create Repository with custom Odb and Refdb