### PR TITLE
add raw_branch_name to pygit2.Branch

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -149,6 +149,23 @@ Branch_branch_name__get__(Branch *self)
         return Error_set(err);
 }
 
+PyDoc_STRVAR(Branch_raw_branch_name__doc__,
+  "The name of the local or remote branch (bytes).");
+
+PyObject *
+Branch_raw_branch_name__get__(Branch *self)
+{
+    int err;
+    const char *c_name;
+
+    CHECK_REFERENCE(self);
+
+    err = git_branch_name(&c_name, self->reference);
+    if (err == GIT_OK)
+        return PyBytes_FromString(c_name);
+    else
+        return Error_set(err);
+}
 
 PyDoc_STRVAR(Branch_remote_name__doc__,
   "The name of the remote set to be the upstream of this branch.");
@@ -263,6 +280,7 @@ PyMethodDef Branch_methods[] = {
 
 PyGetSetDef Branch_getseters[] = {
     GETTER(Branch, branch_name),
+    GETTER(Branch, raw_branch_name),
     GETTER(Branch, remote_name),
     GETSET(Branch, upstream),
     GETTER(Branch, upstream_name),

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -111,10 +111,12 @@ class BranchesObjectTestCase(utils.RepoTestCase):
         branch = self.repo.branches.get('master')
         assert branch.branch_name == 'master'
         assert branch.name == 'refs/heads/master'
+        assert branch.raw_branch_name == branch.branch_name.encode('utf-8')
 
         branch = self.repo.branches.get('i18n')
         assert branch.branch_name == 'i18n'
         assert branch.name == 'refs/heads/i18n'
+        assert branch.raw_branch_name == branch.branch_name.encode('utf-8')
 
     def test_with_commit(self):
         branches = self.repo.branches.with_commit(EXCLUSIVE_MASTER_COMMIT)


### PR DESCRIPTION
A small change to expose the branch_name as bytes on the Branch class.