### PR TITLE
note: lazily get all information about notes.

### DIFF
--- a/src/note.h
+++ b/src/note.h
@@ -32,6 +32,7 @@
 #include <Python.h>
 #include <git2.h>
 
-PyObject* wrap_note(Repository* repo, git_oid* annotated_id, const char* ref);
+PyObject* wrap_note(Repository* repo, git_oid* note_id,
+                    git_oid* annotated_id, const char* ref);
 
 #endif

--- a/src/repository.c
+++ b/src/repository.c
@@ -1666,7 +1666,7 @@ Repository_lookup_note(Repository *self, PyObject* args)
     if (err < 0)
         return Error_set(err);
 
-    return (PyObject*) wrap_note(self, &annotated_id, ref);
+    return (PyObject*) wrap_note(self, NULL, &annotated_id, ref);
 }
 
 PyDoc_STRVAR(Repository_reset__doc__,

--- a/src/types.h
+++ b/src/types.h
@@ -109,6 +109,8 @@ typedef struct {
     Repository *repo;
     git_note *note;
     PyObject* annotated_id;
+    PyObject* id;
+    const char *ref;
 } Note;
 
 typedef struct {


### PR DESCRIPTION
Listing notes with below snippet of code could take a lot longer
than the equivalent git command: "git notes list".
```
import pygit2
repo = pygit2.Repository(".")
for note in repo.notes():
       print(note.id, note.annotated_id)
```

To avoid this, lazily call git_note_read() only when more information
about the note is needed or when the note id is not provided.