### PR TITLE
Fix build, change git_attr_t to git_attr_value_t

### DIFF
--- a/pygit2/decl/attr.h
+++ b/pygit2/decl/attr.h
@@ -8,7 +8,7 @@ typedef enum {
 	GIT_ATTR_TRUE_T,
 	GIT_ATTR_FALSE_T,
 	GIT_ATTR_VALUE_T,
-} git_attr_t;
+} git_attr_value_t;
 
 int git_attr_get(
 	const char **value_out,
@@ -17,4 +17,4 @@ int git_attr_get(
 	const char *path,
 	const char *name);
 
-git_attr_t git_attr_value(const char *attr);
+git_attr_value_t git_attr_value(const char *attr);


### PR DESCRIPTION
When using libgit2 built from source, the build breaks due to a change
from git_attr_t to git_attr_value_t.  Update our headerfile
accordingly.