### PR TITLE
diff: add support for patchid.

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -565,6 +565,22 @@ Diff_len(Diff *self)
     return (Py_ssize_t)git_diff_num_deltas(self->diff);
 }
 
+PyDoc_STRVAR(Diff_patchid__doc__,
+    "Corresponding patchid.");
+
+PyObject *
+Diff_patchid__get__(Diff *self)
+{
+    git_oid oid;
+    int err;
+
+    err = git_diff_patchid(&oid, self->diff, NULL);
+    if (err < 0)
+        return Error_set(err);
+    return git_oid_to_python(&oid);
+}
+
+
 PyDoc_STRVAR(Diff_deltas__doc__, "Iterate over the diff deltas.");
 
 PyObject *
@@ -1024,6 +1040,7 @@ PyGetSetDef Diff_getsetters[] = {
     GETTER(Diff, deltas),
     GETTER(Diff, patch),
     GETTER(Diff, stats),
+    GETTER(Diff, patchid),
     {NULL}
 };
 

--- a/src/diff.h
+++ b/src/diff.h
@@ -35,6 +35,7 @@
 
 PyObject* Diff_changes(Diff *self);
 PyObject* Diff_patch(Diff *self);
+PyObject* Diff_patchid(Diff *self);
 
 PyObject* wrap_diff(git_diff *diff, Repository *repo);
 PyObject* wrap_diff_delta(const git_diff_delta *delta);

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -63,6 +63,8 @@ index 297efb8..0000000
 -c/d contents
 """
 
+PATCHID = 'f31412498a17e6c3fbc635f2c5f9aa3ef4c1a9b7'
+
 PATCH_BINARY = """diff --git a/binary_file b/binary_file
 index 86e5c10..b835d73 100644
 Binary files a/binary_file and b/binary_file differ
@@ -278,6 +280,13 @@ class DiffTest(utils.BareRepoTestCase):
         delta = patch.delta
         assert delta.old_file.id.hex == '7f129fd57e31e935c6d60a0c794efe4e6927664b'
         assert delta.new_file.id.hex == 'af431f20fc541ed6d5afede3e2dc7160f6f01f16'
+
+    def test_diff_patchid(self):
+        commit_a = self.repo[COMMIT_SHA1_1]
+        commit_b = self.repo[COMMIT_SHA1_2]
+        diff = commit_a.tree.diff_to_tree(commit_b.tree)
+        assert diff.patch == PATCH
+        assert diff.patchid.hex == PATCHID
 
     def test_hunk_content(self):
         commit_a = self.repo[COMMIT_SHA1_1]


### PR DESCRIPTION
Add binding for git patchid as mentioned in issue #877 
For the test to pass, it must be built against `fb439c975` in libgit2 where support for patchid has been improved.
