### PR TITLE
Move _pygit2 to pygit2._pygit2

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -139,7 +139,7 @@ library:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "pygit2/__init__.py", line 29, in <module>
-       from _pygit2 import *
+       from ._pygit2 import *
    ImportError: libgit2.so.0: cannot open shared object file: No such file or directory
 
 This happens for instance in Ubuntu, the libgit2 library is installed within
@@ -229,7 +229,7 @@ everytime. Verify yourself if curious:
 
 .. code-block:: sh
 
-   $ readelf --dynamic lib/python2.7/site-packages/pygit2-0.27.0-py2.7-linux-x86_64.egg/_pygit2.so | grep PATH
+   $ readelf --dynamic lib/python2.7/site-packages/pygit2-0.27.0-py2.7-linux-x86_64.egg/pygit2/_pygit2.so | grep PATH
     0x000000000000001d (RUNPATH)            Library runpath: [/tmp/venv/lib]
 
 

--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -27,7 +27,7 @@
 import functools
 
 # Low level API
-from _pygit2 import *
+from ._pygit2 import *
 
 # High level API
 from .blame import Blame, BlameHunk

--- a/pygit2/blame.py
+++ b/pygit2/blame.py
@@ -26,7 +26,7 @@
 # Import from pygit2
 from .ffi import ffi, C
 from .utils import GenericIterator
-from _pygit2 import Signature, Oid
+from ._pygit2 import Signature, Oid
 
 
 def wrap_signature(csig):

--- a/pygit2/errors.py
+++ b/pygit2/errors.py
@@ -25,7 +25,7 @@
 
 # Import from pygit2
 from .ffi import ffi, C
-from _pygit2 import GitError
+from ._pygit2 import GitError
 
 
 value_errors = set([C.GIT_EEXISTS, C.GIT_EINVALIDSPEC, C.GIT_EAMBIGUOUS])

--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -26,7 +26,7 @@
 import weakref
 
 # Import from pygit2
-from _pygit2 import Oid, Tree, Diff
+from ._pygit2 import Oid, Tree, Diff
 from .errors import check_error
 from .ffi import ffi, C
 from .utils import to_bytes, to_str

--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -24,7 +24,7 @@
 # Boston, MA 02110-1301, USA.
 
 # Import from pygit2
-from _pygit2 import Oid
+from ._pygit2 import Oid
 from .errors import check_error, Passthrough
 from .ffi import ffi, C
 from .refspec import Refspec

--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -30,14 +30,14 @@ import tarfile
 from time import time
 
 # Import from pygit2
-from _pygit2 import Repository as _Repository, init_file_backend
-from _pygit2 import Oid, GIT_OID_HEXSZ, GIT_OID_MINPREFIXLEN
-from _pygit2 import GIT_CHECKOUT_SAFE, GIT_CHECKOUT_RECREATE_MISSING, GIT_DIFF_NORMAL
-from _pygit2 import GIT_FILEMODE_LINK
-from _pygit2 import GIT_BRANCH_LOCAL, GIT_BRANCH_REMOTE, GIT_BRANCH_ALL
-from _pygit2 import GIT_REF_SYMBOLIC
-from _pygit2 import Reference, Tree, Commit, Blob
-from _pygit2 import InvalidSpecError
+from ._pygit2 import Repository as _Repository, init_file_backend
+from ._pygit2 import Oid, GIT_OID_HEXSZ, GIT_OID_MINPREFIXLEN
+from ._pygit2 import GIT_CHECKOUT_SAFE, GIT_CHECKOUT_RECREATE_MISSING, GIT_DIFF_NORMAL
+from ._pygit2 import GIT_FILEMODE_LINK
+from ._pygit2 import GIT_BRANCH_LOCAL, GIT_BRANCH_REMOTE, GIT_BRANCH_ALL
+from ._pygit2 import GIT_REF_SYMBOLIC
+from ._pygit2 import Reference, Tree, Commit, Blob
+from ._pygit2 import InvalidSpecError
 
 from .config import Config
 from .errors import check_error

--- a/pygit2/settings.py
+++ b/pygit2/settings.py
@@ -29,8 +29,8 @@ Settings mapping.
 
 from ssl import get_default_verify_paths
 
-import _pygit2
-from _pygit2 import option
+from . import _pygit2
+from ._pygit2 import option
 from .errors import GitError
 
 

--- a/pygit2/submodule.py
+++ b/pygit2/submodule.py
@@ -23,7 +23,7 @@
 # the Free Software Foundation, 51 Franklin Street, Fifth Floor,
 # Boston, MA 02110-1301, USA.
 
-from _pygit2 import Oid
+from ._pygit2 import Oid
 from .errors import check_error
 from .ffi import ffi, C
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ if os.name == 'nt':
     cmdclass['build'] = BuildWithDLLs
 
 ext_modules = [
-    Extension('_pygit2', pygit2_exts, libraries=['git2'],
+    Extension('pygit2._pygit2', pygit2_exts, libraries=['git2'],
               include_dirs=[libgit2_include],
               library_dirs=[libgit2_lib]),
 ]

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ class BuildWithDLLs(build):
         elif compiler_type == 'mingw32':
             libgit2_dlls.append('libgit2.dll')
         look_dirs = [libgit2_bin] + getenv("PATH", "").split(pathsep)
-        target = abspath(self.build_lib)
+        target = abspath(os.path.join(self.build_lib, "pygit2"))
         for bin in libgit2_dlls:
             for look in look_dirs:
                 f = os.path.join(look, bin)


### PR DESCRIPTION
This resolve issues with binary top-level modules affecting [delocate](https://github.com/matthew-brett/delocate) on macOS (which helps with macOS wheel creation). Specifically, https://github.com/matthew-brett/delocate/issues/12#issuecomment-246536098

Change is that it moves (eg) `site-packages/_pygit2.cpython-37m-darwin.so` to `site-packages/pygit2/_pygit2.cpython-37m-darwin.so`, meaning the `_pygit2` internal api is available via `import pygit2._pygit2` cf `import _pygit2`

The impact this has building macOS wheels:
(fyi `delocate-listdeps` shows the libraries and what depends _on them_ indented)

Before:
```console
$ delocate-listdeps -d dist/pygit2-1.0.3-cp37-cp37m-macosx_10_15_x86_64.whl
/Users/rcoup/code/pygit2/venv/lib/libgit2.0.99.0.dylib:
    _pygit2.cpython-37m-darwin.so
    pygit2/_libgit2.abi3.so
$ delocate-wheel dist/pygit2-1.0.3-cp37-cp37m-macosx_10_15_x86_64.whl
$ delocate-listdeps -d dist/pygit2-1.0.3-cp37-cp37m-macosx_10_15_x86_64.whl
/Users/rcoup/code/pygit2/venv/lib/libgit2.0.99.0.dylib:
    _pygit2.cpython-37m-darwin.so
@loader_path/.dylibs/libgit2.0.99.0.dylib:
    pygit2/_libgit2.abi3.so
$ zipinfo -1 dist/*.whl | grep -P "\.dylib|\.so"
_pygit2.cpython-37m-darwin.so
pygit2/_libgit2.abi3.so
pygit2/.dylibs/libgit2.0.99.0.dylib
```

* libgit2 gets bundled into the wheel but `_pygit2.*.so` is still referencing the `$LIBGIT2` path (everything should be prefixed `@loader_path/.dylibs/`)
* if you actually install this wheel with `$LIBGIT2/lib/libgit2.dylib` in position too (eg via: `import pygit2; pygit2.config.Config()`), then you get a segfault 
* cause of that seems to be that we end up loading libgit2 twice, once the copy baked into the wheel, and once from the original `$LIBGIT2/lib` location.
```
$ python
>>> import pygit2
>>> import os; os.getpid()

$ lsof -p 21632 | grep -P "libgit2\..*\.dylib"
Python  21632 rcoup  txt    REG    1,4   1004300          8737655297 /Users/rcoup/code/pygit2/venv/lib/libgit2.0.99.0.dylib
Python  21632 rcoup  txt    REG    1,4   1004300          8737685087 /Users/rcoup/code/pygit2/venv/lib/python3.7/site-packages/pygit2/.dylibs/libgit2.0.99.0.dylib
```

By moving the `_pygit2` module into the top-level python package, delocate correctly links it to the baked libgit2.

After:
```console
$ delocate-listdeps -d dist/pygit2-1.0.3-cp37-cp37m-macosx_10_15_x86_64.whl
/Users/rcoup/code/pygit2/venv/lib/libgit2.0.99.0.dylib:
    pygit2/_pygit2.cpython-37m-darwin.so
    pygit2/_libgit2.abi3.so
$ delocate-wheel dist/pygit2-1.0.3-cp37-cp37m-macosx_10_15_x86_64.whl
$ delocate-listdeps -d dist/pygit2-1.0.3-cp37-cp37m-macosx_10_15_x86_64.whl
@loader_path/.dylibs/libgit2.0.99.0.dylib:
    pygit2/_pygit2.cpython-37m-darwin.so
    pygit2/_libgit2.abi3.so
$ zipinfo -1 dist/*.whl | grep -P "\.dylib|\.so"
pygit2/_libgit2.abi3.so
pygit2/_pygit2.cpython-37m-darwin.so
pygit2/.dylibs/libgit2.0.99.0.dylib
```

_Delocate_ could fix the issue, but the comments in that ticket imply there are additional concerns there, and I can't see any particular need for the internal `_pygit2` to be a top-level package.
