### PR TITLE
Introduce Refdb type

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libgit2: ['maint/v0.99']
+        libgit2: ['master']
         py:
           - ver: '3.6'
             release: '3.6.8'  # last Python.org binary release

--- a/.travis.sh
+++ b/.travis.sh
@@ -9,7 +9,7 @@ fi
 
 cd ~
 
-git clone --depth=1 -b "maint/v${LIBGIT2_VERSION}" https://github.com/libgit2/libgit2.git
+git clone --depth=1 -b "${LIBGIT2_VERSION}" https://github.com/libgit2/libgit2.git
 cd libgit2/
 
 mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     LIBGIT2: ~/libgit2/_install/
     LD_LIBRARY_PATH: ${LIBGIT2}/lib:${LD_LIBRARY_PATH}
-    LIBGIT2_VERSION: "0.99"
+    LIBGIT2_VERSION: "master"
 
 
 jobs:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ build_script:
 # Clone, build and install libgit2
 - cmd: |
     set LIBGIT2=%APPVEYOR_BUILD_FOLDER%\venv
-    git clone --depth=1 -b maint/v0.99 https://github.com/libgit2/libgit2.git libgit2
+    git clone --depth=1 -b master https://github.com/libgit2/libgit2.git libgit2
     cd libgit2
     cmake . -DBUILD_CLAR=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="%LIBGIT2%" -G "%GENERATOR%"
     cmake --build . --target install

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -2,7 +2,41 @@
 Backends
 **********************************************************************
 
-There is some support for custom backends, but undocumented. See
-`<https://github.com/libgit2/pygit2/pull/690/commits>`_
+The use of custom backends for the git object database (odb) and reference
+database (refdb) are supported by pygit2.
 
-Documentation contributions are very welcome.
+.. contents:: Contents
+   :local:
+
+The OdbBackend class
+===================================
+
+The OdbBackend class is subclassable and can be used to build a custom object
+database.
+
+.. autoclass:: pygit2.OdbBackend
+   :members:
+
+Built-in OdbBackend implementations
+===================================
+
+.. autoclass:: pygit2.OdbBackendLoose
+   :members:
+
+.. autoclass:: pygit2.OdbBackendPack
+   :members:
+
+The RefdbBackend class
+===================================
+
+The RefdbBackend class is subclassable and can be used to build a custom
+reference database.
+
+.. autoclass:: pygit2.RefdbBackend
+   :members:
+
+Built-in RefdbBackend implementations
+=====================================
+
+.. autoclass:: pygit2.RefdbFsBackend
+   :members:

--- a/docs/repository.rst
+++ b/docs/repository.rst
@@ -56,10 +56,14 @@ Below there are some general attributes and methods:
    :members: ahead_behind, apply, create_reference, default_signature,
              descendant_of, describe, free, is_bare, is_empty, odb, path,
              path_is_ignored, reset, revert_commit, state_cleanup, workdir,
-             write_archive
+             write_archive, set_odb, set_refdb
 
    The Repository constructor only takes one argument, the path of the
-   repository to open.
+   repository to open. Alternatively, constructing a repository with no
+   arguments will create a repository with no backends. You can use this path
+   to create repositories with custom backends. Note that most operations on
+   the repository are considered invalid and may lead to undefined behavior if
+   attempted before providing an odb and refdb via set_odb and set_refdb.
 
    Example::
 
@@ -73,5 +77,8 @@ The Odb class
 .. autoclass:: pygit2.Odb
    :members:
 
-.. autoclass:: pygit2.OdbBackend
+The Refdb class
+===================================
+
+.. autoclass:: pygit2.Refdb
    :members:

--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -50,8 +50,8 @@ from .submodule import Submodule
 
 
 class BaseRepository(_Repository):
-    def __init__(self, backend, *args, **kwargs):
-        super().__init__(backend, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._common_init()
 
     def _common_init(self):
@@ -1279,15 +1279,18 @@ class References(object):
 
 
 class Repository(BaseRepository):
-    def __init__(self, path, *args, **kwargs):
-        if hasattr(path, "__fspath__"):
-            path = path.__fspath__()
-
-        if not isinstance(path, str):
-            path = path.decode('utf-8')
-
-        path_backend = init_file_backend(path)
-        super().__init__(backend=path_backend, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        if len(args) != 0:
+            path = args[0]
+            args = args[1:]
+            if hasattr(path, "__fspath__"):
+                path = path.__fspath__()
+            if not isinstance(path, str):
+                path = path.decode('utf-8')
+            path_backend = init_file_backend(path)
+            super().__init__(path_backend, *args, **kwargs)
+        else:
+            super().__init__(*args, **kwargs)
 
     @classmethod
     def _from_c(cls, ptr, owned):

--- a/src/odb_backend.c
+++ b/src/odb_backend.c
@@ -772,8 +772,8 @@ PyTypeObject OdbBackendPackType = {
 };
 
 PyDoc_STRVAR(OdbBackendLoose__doc__,
-        "OdbBackendLoose(objects_dir, compression_level,\n"
-        "    do_fsync, dir_mode=0, file_mode=0)\n"
+        "OdbBackendLoose(objects_dir, compression_level,"
+        " do_fsync, dir_mode=0, file_mode=0)\n"
         "\n"
         "Object database backend for loose objects.\n"
         "\n"

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -64,6 +64,8 @@ extern PyTypeObject BlobType;
 extern PyTypeObject TagType;
 extern PyTypeObject WalkerType;
 extern PyTypeObject RefdbType;
+extern PyTypeObject RefdbBackendType;
+extern PyTypeObject RefdbFsBackendType;
 extern PyTypeObject ReferenceType;
 extern PyTypeObject RefLogIterType;
 extern PyTypeObject RefLogEntryType;
@@ -400,6 +402,11 @@ PyInit__pygit2(void)
     /* Refdb */
     INIT_TYPE(RefdbType, NULL, PyType_GenericNew)
     ADD_TYPE(m, Refdb)
+
+    INIT_TYPE(RefdbBackendType, NULL, PyType_GenericNew)
+    ADD_TYPE(m, RefdbBackend)
+    INIT_TYPE(RefdbFsBackendType, &RefdbBackendType, PyType_GenericNew)
+    ADD_TYPE(m, RefdbFsBackend)
 
     /*
      * References

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -63,6 +63,7 @@ extern PyTypeObject TreeIterType;
 extern PyTypeObject BlobType;
 extern PyTypeObject TagType;
 extern PyTypeObject WalkerType;
+extern PyTypeObject RefdbType;
 extern PyTypeObject ReferenceType;
 extern PyTypeObject RefLogIterType;
 extern PyTypeObject RefLogEntryType;
@@ -395,6 +396,10 @@ PyInit__pygit2(void)
     ADD_CONSTANT_INT(m, GIT_RESET_SOFT)
     ADD_CONSTANT_INT(m, GIT_RESET_MIXED)
     ADD_CONSTANT_INT(m, GIT_RESET_HARD)
+
+    /* Refdb */
+    INIT_TYPE(RefdbType, NULL, PyType_GenericNew)
+    ADD_TYPE(m, Refdb)
 
     /*
      * References

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -399,7 +399,7 @@ PyInit__pygit2(void)
     /*
      * References
      */
-    INIT_TYPE(ReferenceType, NULL, NULL)
+    INIT_TYPE(ReferenceType, NULL, PyType_GenericNew)
     INIT_TYPE(RefLogEntryType, NULL, NULL)
     INIT_TYPE(RefLogIterType, NULL, NULL)
     INIT_TYPE(NoteType, NULL, NULL)

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -32,6 +32,7 @@
 #include "types.h"
 #include "utils.h"
 #include <git2/refdb.h>
+#include <git2/sys/refdb_backend.h>
 
 extern PyTypeObject RepositoryType;
 extern PyTypeObject RefdbType;
@@ -55,6 +56,21 @@ PyObject *
 Refdb_compress(Refdb *self)
 {
     int err = git_refdb_compress(self->refdb);
+    if (err != 0)
+        return Error_set(err);
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(Refdb_set_backend__doc__,
+        "set_backend(backend: RefdbBackend)\n"
+        "\n"
+        "Sets a custom RefdbBackend for this Refdb.");
+
+PyObject *
+Refdb_set_backend(Refdb *self, RefdbBackend *backend)
+{
+    int err;
+    err = git_refdb_set_backend(self->refdb, backend->refdb_backend);
     if (err != 0)
         return Error_set(err);
     Py_RETURN_NONE;
@@ -111,6 +127,7 @@ Refdb_open(PyObject *self, Repository *repo)
 
 PyMethodDef Refdb_methods[] = {
     METHOD(Refdb, compress, METH_NOARGS),
+    METHOD(Refdb, set_backend, METH_O),
     {"new", (PyCFunction) Refdb_new,
       METH_O | METH_STATIC, Refdb_new__doc__},
     {"open", (PyCFunction) Refdb_open,

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2010-2019 The pygit2 contributors
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * In addition to the permissions in the GNU General Public License,
+ * the authors give you unlimited permission to link the compiled
+ * version of this file into combinations with other programs,
+ * and to distribute those combinations without any restriction
+ * coming from the use of this file.  (The General Public License
+ * restrictions do apply in other respects; for example, they cover
+ * modification of the file, and distribution when not linked into
+ * a combined executable.)
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "error.h"
+#include "refdb.h"
+#include "types.h"
+#include "utils.h"
+#include <git2/refdb.h>
+
+extern PyTypeObject RepositoryType;
+extern PyTypeObject RefdbType;
+
+void
+Refdb_dealloc(Refdb *self)
+{
+    git_refdb_free(self->refdb);
+
+    Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
+PyDoc_STRVAR(Refdb_compress__doc__,
+    "compress()\n"
+    "\n"
+     "Suggests that the given refdb compress or optimize its references.\n"
+     "This mechanism is implementation specific.  For on-disk reference\n"
+     "databases, for example, this may pack all loose references.");
+
+PyObject *
+Refdb_compress(Refdb *self)
+{
+    int err = git_refdb_compress(self->refdb);
+    if (err != 0)
+        return Error_set(err);
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(Refdb_new__doc__, "Refdb.new(repo: Repository) -> Refdb\n"
+        "Creates a new refdb with no backend.");
+
+PyObject *
+Refdb_new(PyObject *self, Repository *repo)
+{
+    if (!PyObject_IsInstance((PyObject *)repo, (PyObject *)&RepositoryType)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Refdb.new expects an object of type "
+                        "pygit2.Repository");
+        return NULL;
+    }
+
+    git_refdb *refdb;
+    int err = git_refdb_new(&refdb, repo->repo);
+    if (err) {
+        Error_set(err);
+        return NULL;
+    }
+
+    return wrap_refdb(refdb);
+}
+
+PyDoc_STRVAR(Refdb_open__doc__,
+    "open(repo: Repository) -> Refdb\n"
+    "\n"
+     "Create a new reference database and automatically add\n"
+     "the default backends, assuming the repository dir as the folder.");
+
+PyObject *
+Refdb_open(PyObject *self, Repository *repo)
+{
+    if (!PyObject_IsInstance((PyObject *)repo, (PyObject *)&RepositoryType)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Refdb.open expects an object of type "
+                        "pygit2.Repository");
+        return NULL;
+    }
+
+    git_refdb *refdb;
+    int err = git_refdb_open(&refdb, repo->repo);
+    if (err) {
+        Error_set(err);
+        return NULL;
+    }
+
+    return wrap_refdb(refdb);
+}
+
+PyMethodDef Refdb_methods[] = {
+    METHOD(Refdb, compress, METH_NOARGS),
+    {"new", (PyCFunction) Refdb_new,
+      METH_O | METH_STATIC, Refdb_new__doc__},
+    {"open", (PyCFunction) Refdb_open,
+      METH_O | METH_STATIC, Refdb_open__doc__},
+    {NULL}
+};
+
+PyDoc_STRVAR(Refdb__doc__, "Reference database.");
+
+PyTypeObject RefdbType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "_pygit2.Refdb",                           /* tp_name           */
+    sizeof(Refdb),                             /* tp_basicsize      */
+    0,                                         /* tp_itemsize       */
+    (destructor)Refdb_dealloc,                 /* tp_dealloc        */
+    0,                                         /* tp_print          */
+    0,                                         /* tp_getattr        */
+    0,                                         /* tp_setattr        */
+    0,                                         /* tp_compare        */
+    0,                                         /* tp_repr           */
+    0,                                         /* tp_as_number      */
+    0,                                         /* tp_as_sequence    */
+    0,                                         /* tp_as_mapping     */
+    0,                                         /* tp_hash           */
+    0,                                         /* tp_call           */
+    0,                                         /* tp_str            */
+    0,                                         /* tp_getattro       */
+    0,                                         /* tp_setattro       */
+    0,                                         /* tp_as_buffer      */
+    Py_TPFLAGS_DEFAULT,                        /* tp_flags          */
+    Refdb__doc__,                              /* tp_doc            */
+    0,                                         /* tp_traverse       */
+    0,                                         /* tp_clear          */
+    0,                                         /* tp_richcompare    */
+    0,                                         /* tp_weaklistoffset */
+    0,                                         /* tp_iter           */
+    0,                                         /* tp_iternext       */
+    Refdb_methods,                             /* tp_methods        */
+    0,                                         /* tp_members        */
+    0,                                         /* tp_getset         */
+    0,                                         /* tp_base           */
+    0,                                         /* tp_dict           */
+    0,                                         /* tp_descr_get      */
+    0,                                         /* tp_descr_set      */
+    0,                                         /* tp_dictoffset     */
+    0,                                         /* tp_init           */
+    0,                                         /* tp_alloc          */
+    0,                                         /* tp_new            */
+};
+
+PyObject *
+wrap_refdb(git_refdb *c_refdb)
+{
+    Refdb *py_refdb = PyObject_New(Refdb, &RefdbType);
+
+    if (py_refdb)
+        py_refdb->refdb = c_refdb;
+
+    return (PyObject *)py_refdb;
+}

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2019 The pygit2 contributors
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * In addition to the permissions in the GNU General Public License,
+ * the authors give you unlimited permission to link the compiled
+ * version of this file into combinations with other programs,
+ * and to distribute those combinations without any restriction
+ * coming from the use of this file.  (The General Public License
+ * restrictions do apply in other respects; for example, they cover
+ * modification of the file, and distribution when not linked into
+ * a combined executable.)
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDE_pygit2_refdb_h
+#define INCLUDE_pygit2_refdb_h
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <git2.h>
+#include "types.h"
+
+PyObject *wrap_refdb(git_refdb *c_refdb);
+
+#endif

--- a/src/refdb_backend.c
+++ b/src/refdb_backend.c
@@ -198,7 +198,6 @@ pygit2_refdb_backend_lookup(git_reference **out,
 
     *out = result->reference;
 out:
-    Py_DECREF(result);
     return err;
 }
 
@@ -451,25 +450,11 @@ RefdbBackend_init(RefdbBackend *self, PyObject *args, PyObject *kwds)
         be->backend.ensure_log = pygit2_refdb_backend_ensure_log;
     }
 
-    if (PyObject_HasAttrString((PyObject *)self, "reflog_read")) {
-        be->reflog_read = PyObject_GetAttrString((PyObject *)self, "reflog_read");
-        be->backend.reflog_read = pygit2_refdb_backend_reflog_read;
-    }
-
-    if (PyObject_HasAttrString((PyObject *)self, "reflog_write")) {
-        be->reflog_write = PyObject_GetAttrString((PyObject *)self, "reflog_write");
-        be->backend.reflog_write = pygit2_refdb_backend_reflog_write;
-    }
-
-    if (PyObject_HasAttrString((PyObject *)self, "reflog_rename")) {
-        be->reflog_rename = PyObject_GetAttrString((PyObject *)self, "reflog_rename");
-        be->backend.reflog_rename = pygit2_refdb_backend_reflog_rename;
-    }
-
-    if (PyObject_HasAttrString((PyObject *)self, "reflog_delete")) {
-        be->reflog_delete = PyObject_GetAttrString((PyObject *)self, "reflog_delete");
-        be->backend.reflog_delete = pygit2_refdb_backend_reflog_delete;
-    }
+    /* TODO: First-class reflog support */
+    be->backend.reflog_read = pygit2_refdb_backend_reflog_read;
+    be->backend.reflog_write = pygit2_refdb_backend_reflog_write;
+    be->backend.reflog_rename = pygit2_refdb_backend_reflog_rename;
+    be->backend.reflog_delete = pygit2_refdb_backend_reflog_delete;
 
     /* TODO: transactions
     if (PyObject_HasAttrString((PyObject *)self, "lock")) {

--- a/src/refdb_backend.c
+++ b/src/refdb_backend.c
@@ -1,0 +1,914 @@
+/*
+ * Copyright 2010-2019 The pygit2 contributors
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * In addition to the permissions in the GNU General Public License,
+ * the authors give you unlimited permission to link the compiled
+ * version of this file into combinations with other programs,
+ * and to distribute those combinations without any restriction
+ * coming from the use of this file.  (The General Public License
+ * restrictions do apply in other respects; for example, they cover
+ * modification of the file, and distribution when not linked into
+ * a combined executable.)
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <fnmatch.h>
+#include "error.h"
+#include "types.h"
+#include "oid.h"
+#include "reference.h"
+#include "signature.h"
+#include "utils.h"
+#include <git2/refdb.h>
+#include <git2/sys/refdb_backend.h>
+
+extern PyTypeObject ReferenceType;
+extern PyTypeObject RepositoryType;
+extern PyTypeObject SignatureType;
+
+struct pygit2_refdb_backend
+{
+    git_refdb_backend backend;
+    PyObject *RefdbBackend;
+    PyObject *exists,
+             *lookup,
+             *iterator,
+             *write,
+             *rename,
+             *delete,
+             *compress,
+             *has_log,
+             *ensure_log,
+             *reflog_read,
+             *reflog_write,
+             *reflog_rename,
+             *reflog_delete,
+             *lock,
+             *unlock;
+};
+
+struct pygit2_refdb_iterator {
+    struct git_reference_iterator base;
+    PyObject *iterator;
+    char *glob;
+};
+
+static Reference *
+iterator_get_next(struct pygit2_refdb_iterator *iter)
+{
+    Reference *ref;
+    while ((ref = (Reference *)PyIter_Next(iter->iterator)) != NULL) {
+        if (!iter->glob) {
+            return ref;
+        }
+        const char *name = git_reference_name(ref->reference);
+        if (fnmatch(iter->glob, name, 0) != FNM_NOMATCH) {
+            return ref;
+        }
+    }
+    return NULL;
+}
+
+static int
+pygit2_refdb_iterator_next(
+        git_reference **out, git_reference_iterator *_iter)
+{
+    struct pygit2_refdb_iterator *iter = (struct pygit2_refdb_iterator *)_iter;
+    Reference *ref = iterator_get_next(iter);
+    if (ref == NULL) {
+        *out = NULL;
+        return GIT_ITEROVER;
+    }
+    if (!PyObject_IsInstance((PyObject *)ref, (PyObject *)&ReferenceType)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "RefdbBackend iterator must yield References");
+        return GIT_EUSER;
+    }
+    *out = ref->reference;
+    return 0;
+}
+
+static int
+pygit2_refdb_iterator_next_name(const char **ref_name,
+		git_reference_iterator *_iter)
+{
+    struct pygit2_refdb_iterator *iter = (struct pygit2_refdb_iterator *)_iter;
+    Reference *ref = iterator_get_next(iter);
+    if (ref == NULL) {
+        *ref_name = NULL;
+        return GIT_ITEROVER;
+    }
+    if (!PyObject_IsInstance((PyObject *)ref, (PyObject *)&ReferenceType)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "RefdbBackend iterator must yield References");
+        return GIT_EUSER;
+    }
+    *ref_name = git_reference_name(ref->reference);
+    return 0;
+}
+
+static void
+pygit2_refdb_iterator_free(git_reference_iterator *_iter)
+{
+    struct pygit2_refdb_iterator *iter = (struct pygit2_refdb_iterator *)_iter;
+    Py_DECREF(iter->iterator);
+    free(iter->glob);
+}
+
+static int
+pygit2_refdb_backend_iterator(git_reference_iterator **iter,
+    struct git_refdb_backend *_be,
+    const char *glob)
+{
+    struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)_be;
+    PyObject *iterator = PyObject_GetIter((PyObject *)be->RefdbBackend);
+    assert(iterator);
+
+    struct pygit2_refdb_iterator *pyiter =
+        calloc(1, sizeof(struct pygit2_refdb_iterator));
+    *iter = (git_reference_iterator *)pyiter;
+    pyiter->iterator = iterator;
+    pyiter->base.next = pygit2_refdb_iterator_next;
+    pyiter->base.next_name = pygit2_refdb_iterator_next_name;
+    pyiter->base.free = pygit2_refdb_iterator_free;
+    pyiter->glob = strdup(glob);
+    return 0;
+}
+
+static int
+pygit2_refdb_backend_exists(int *exists,
+        git_refdb_backend *_be, const char *ref_name)
+{
+    int err;
+    PyObject *args, *result;
+    struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)_be;
+
+    if ((args = Py_BuildValue("(s)", ref_name)) == NULL)
+        return GIT_EUSER;
+    result = PyObject_CallObject(be->exists, args);
+    Py_DECREF(args);
+
+    if ((err = git_error_for_exc()) != 0)
+        goto out;
+
+    *exists = PyObject_IsTrue(result);
+
+out:
+    Py_DECREF(result);
+    return 0;
+}
+
+static int
+pygit2_refdb_backend_lookup(git_reference **out,
+        git_refdb_backend *_be, const char *ref_name)
+{
+    int err;
+    PyObject *args;
+    Reference *result;
+    struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)_be;
+
+    if ((args = Py_BuildValue("(s)", ref_name)) == NULL)
+        return GIT_EUSER;
+    result = (Reference *)PyObject_CallObject(be->lookup, args);
+    Py_DECREF(args);
+
+    if ((err = git_error_for_exc()) != 0)
+        goto out;
+
+    if (!PyObject_IsInstance((PyObject *)result, (PyObject *)&ReferenceType)) {
+        PyErr_SetString(PyExc_TypeError, "Expected object of type pygit2.Reference");
+        err = GIT_EUSER;
+        goto out;
+    }
+
+    *out = result->reference;
+out:
+    Py_DECREF(result);
+    return err;
+}
+
+static int
+pygit2_refdb_backend_write(git_refdb_backend *_be,
+        const git_reference *_ref, int force,
+        const git_signature *_who, const char *message,
+        const git_oid *_old, const char *old_target)
+{
+    int err;
+    PyObject *args = NULL, *ref = NULL, *who = NULL, *old = NULL;
+    struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)_be;
+
+    // XXX: Drops const
+    if ((ref = wrap_reference((git_reference *)_ref, NULL)) == NULL)
+        goto euser;
+    if ((who = build_signature(NULL, _who, "utf-8")) == NULL)
+        goto euser;
+    if ((old = git_oid_to_python(_old)) == NULL)
+        goto euser;
+    if ((args = Py_BuildValue("(NNNsNs)", ref,
+            force ? Py_True : Py_False,
+            who, message, old, old_target)) == NULL)
+        goto euser;
+
+    PyObject_CallObject(be->write, args);
+    err = git_error_for_exc();
+out:
+    Py_DECREF(ref);
+    Py_DECREF(who);
+    Py_DECREF(old);
+    Py_DECREF(args);
+    return err;
+euser:
+    err = GIT_EUSER;
+    goto out;
+}
+
+static int
+pygit2_refdb_backend_rename(git_reference **out, git_refdb_backend *_be,
+        const char *old_name, const char *new_name, int force,
+        const git_signature *_who, const char *message)
+{
+    int err;
+    PyObject *args, *who;
+    struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)_be;
+
+    if ((who = build_signature(NULL, _who, "utf-8")) != NULL)
+        return GIT_EUSER;
+    if ((args = Py_BuildValue("(ssNNs)", old_name, new_name,
+            force ? Py_True : Py_False, who, message)) == NULL) {
+        Py_DECREF(who);
+        return GIT_EUSER;
+    }
+    Reference *ref = (Reference *)PyObject_CallObject(be->rename, args);
+    Py_DECREF(who);
+    Py_DECREF(args);
+
+    if ((err = git_error_for_exc()) != 0)
+        return err;
+
+    if (!PyObject_IsInstance((PyObject *)ref, (PyObject *)&ReferenceType)) {
+        PyErr_SetString(PyExc_TypeError, "Expected object of type pygit2.Reference");
+        return GIT_EUSER;
+    }
+
+    git_reference_dup(out, ref->reference);
+    Py_DECREF(ref);
+    return 0;
+}
+
+static int
+pygit2_refdb_backend_del(git_refdb_backend *_be,
+        const char *ref_name, const git_oid *_old, const char *old_target)
+{
+    PyObject *args, *old;
+    struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)_be;
+    old = git_oid_to_python(_old);
+
+    if ((args = Py_BuildValue("(sOs)", ref_name, old, old_target)) == NULL) {
+        Py_DECREF(old);
+        return GIT_EUSER;
+    }
+    PyObject_CallObject(be->rename, args);
+    Py_DECREF(old);
+    Py_DECREF(args);
+    return git_error_for_exc();
+}
+
+static int
+pygit2_refdb_backend_compress(git_refdb_backend *_be)
+{
+    struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)_be;
+    PyObject_CallObject(be->rename, NULL);
+    return git_error_for_exc();
+}
+
+static int
+pygit2_refdb_backend_has_log(git_refdb_backend *_be, const char *refname)
+{
+    int err;
+    PyObject *args, *result;
+    struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)_be;
+
+    if ((args = Py_BuildValue("(s)", refname)) == NULL) {
+        return GIT_EUSER;
+    }
+    result = PyObject_CallObject(be->has_log, args);
+    Py_DECREF(args);
+
+    if ((err = git_error_for_exc()) != 0) {
+        return err;
+    }
+
+    if (PyObject_IsTrue(result)) {
+        Py_DECREF(result);
+        return 1;
+    }
+
+    Py_DECREF(result);
+    return 0;
+}
+
+static int
+pygit2_refdb_backend_ensure_log(git_refdb_backend *_be, const char *refname)
+{
+    int err;
+    PyObject *args, *result;
+    struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)_be;
+
+    if ((args = Py_BuildValue("(s)", refname)) == NULL) {
+        return GIT_EUSER;
+    }
+    result = PyObject_CallObject(be->ensure_log, args);
+    Py_DECREF(args);
+
+    if ((err = git_error_for_exc()) != 0) {
+        return err;
+    }
+
+    if (PyObject_IsTrue(result)) {
+        Py_DECREF(result);
+        return 1;
+    }
+
+    Py_DECREF(result);
+    return 0;
+}
+
+static int
+pygit2_refdb_backend_reflog_read(git_reflog **out,
+        git_refdb_backend *backend, const char *name)
+{
+    /* TODO: Implement first-class pygit2 reflog support
+     * These stubs are here because libgit2 requires refdb_backend to implement
+     * them. libgit2 doesn't actually use them as of 0.99; it assumes the refdb
+     * backend will update the reflogs itself. */
+    return GIT_EUSER;
+}
+
+static int
+pygit2_refdb_backend_reflog_write(git_refdb_backend *backend, git_reflog *reflog)
+{
+    /* TODO: Implement first-class pygit2 reflog support */
+    return GIT_EUSER;
+}
+
+static int
+pygit2_refdb_backend_reflog_rename(git_refdb_backend *_backend,
+        const char *old_name, const char *new_name)
+{
+    /* TODO: Implement first-class pygit2 reflog support */
+    return GIT_EUSER;
+}
+
+static int
+pygit2_refdb_backend_reflog_delete(git_refdb_backend *backend, const char *name)
+{
+    /* TODO: Implement first-class pygit2 reflog support */
+    return GIT_EUSER;
+}
+
+static void
+pygit2_refdb_backend_free(git_refdb_backend *_be)
+{
+    struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)_be;
+    Py_DECREF(be->RefdbBackend);
+}
+
+int
+RefdbBackend_init(RefdbBackend *self, PyObject *args, PyObject *kwds)
+{
+    if (args && PyTuple_Size(args) > 0) {
+        PyErr_SetString(PyExc_TypeError,
+                        "RefdbBackend takes no arguments");
+        return -1;
+    }
+
+    if (kwds && PyDict_Size(kwds) > 0) {
+        PyErr_SetString(PyExc_TypeError,
+                        "RefdbBackend takes no keyword arguments");
+        return -1;
+    }
+
+    struct pygit2_refdb_backend *be = calloc(1, sizeof(struct pygit2_refdb_backend));
+    git_refdb_init_backend(&be->backend, GIT_REFDB_BACKEND_VERSION);
+    be->RefdbBackend = (PyObject *)self;
+
+    if (PyIter_Check((PyObject *)self)) {
+        be->backend.iterator = pygit2_refdb_backend_iterator;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "exists")) {
+        be->exists = PyObject_GetAttrString((PyObject *)self, "exists");
+        be->backend.exists = pygit2_refdb_backend_exists;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "lookup")) {
+        be->lookup = PyObject_GetAttrString((PyObject *)self, "lookup");
+        be->backend.lookup = pygit2_refdb_backend_lookup;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "write")) {
+        be->write = PyObject_GetAttrString((PyObject *)self, "write");
+        be->backend.write = pygit2_refdb_backend_write;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "rename")) {
+        be->rename = PyObject_GetAttrString((PyObject *)self, "rename");
+        be->backend.rename = pygit2_refdb_backend_rename;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "delete")) {
+        be->delete = PyObject_GetAttrString((PyObject *)self, "delete");
+        be->backend.del = pygit2_refdb_backend_del;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "compress")) {
+        be->compress = PyObject_GetAttrString((PyObject *)self, "compress");
+        be->backend.compress = pygit2_refdb_backend_compress;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "has_log")) {
+        be->has_log = PyObject_GetAttrString((PyObject *)self, "has_log");
+        be->backend.has_log = pygit2_refdb_backend_has_log;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "ensure_log")) {
+        be->ensure_log = PyObject_GetAttrString((PyObject *)self, "ensure_log");
+        be->backend.ensure_log = pygit2_refdb_backend_ensure_log;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "reflog_read")) {
+        be->reflog_read = PyObject_GetAttrString((PyObject *)self, "reflog_read");
+        be->backend.reflog_read = pygit2_refdb_backend_reflog_read;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "reflog_write")) {
+        be->reflog_write = PyObject_GetAttrString((PyObject *)self, "reflog_write");
+        be->backend.reflog_write = pygit2_refdb_backend_reflog_write;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "reflog_rename")) {
+        be->reflog_rename = PyObject_GetAttrString((PyObject *)self, "reflog_rename");
+        be->backend.reflog_rename = pygit2_refdb_backend_reflog_rename;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "reflog_delete")) {
+        be->reflog_delete = PyObject_GetAttrString((PyObject *)self, "reflog_delete");
+        be->backend.reflog_delete = pygit2_refdb_backend_reflog_delete;
+    }
+
+    /* TODO: transactions
+    if (PyObject_HasAttrString((PyObject *)self, "lock")) {
+        be->lock = PyObject_GetAttrString((PyObject *)self, "lock");
+        be->backend.lock = pygit2_refdb_backend_lock;
+    }
+
+    if (PyObject_HasAttrString((PyObject *)self, "unlock")) {
+        be->unlock = PyObject_GetAttrString((PyObject *)self, "unlock");
+        be->backend.unlock = pygit2_refdb_backend_unlock;
+    }
+    */
+
+    Py_INCREF((PyObject *)self);
+    be->backend.free = pygit2_refdb_backend_free;
+
+    self->refdb_backend = (git_refdb_backend *)be;
+    return 0;
+}
+
+void
+RefdbBackend_dealloc(RefdbBackend *self)
+{
+    if (self->refdb_backend && self->refdb_backend->free == pygit2_refdb_backend_free) {
+        struct pygit2_refdb_backend *be = (struct pygit2_refdb_backend *)self->refdb_backend;
+        Py_CLEAR(be->exists);
+        Py_CLEAR(be->lookup);
+        Py_CLEAR(be->iterator);
+        Py_CLEAR(be->write);
+        Py_CLEAR(be->rename);
+        Py_CLEAR(be->delete);
+        Py_CLEAR(be->compress);
+        Py_CLEAR(be->has_log);
+        Py_CLEAR(be->ensure_log);
+        Py_CLEAR(be->reflog_read);
+        Py_CLEAR(be->reflog_write);
+        Py_CLEAR(be->reflog_rename);
+        Py_CLEAR(be->reflog_delete);
+        Py_CLEAR(be->lock);
+        Py_CLEAR(be->unlock);
+        free(be);
+    }
+    Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
+PyDoc_STRVAR(RefdbBackend_exists__doc__,
+    "exists(refname: str)\n"
+    "\n"
+    "Returns True if a ref by this name exists, or False otherwise.");
+
+PyObject *
+RefdbBackend_exists(RefdbBackend *self, PyObject *py_str)
+{
+    int err, exists;
+    const char *ref_name;
+    if (self->refdb_backend->exists == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    if (!PyUnicode_Check(py_str)) {
+        PyErr_SetString(PyExc_TypeError,
+                "RefdbBackend.exists takes a string argument");
+        return NULL;
+    }
+    ref_name = PyUnicode_AsUTF8(py_str);
+
+    err = self->refdb_backend->exists(&exists, self->refdb_backend, ref_name);
+    if (err != 0)
+        return Error_set(err);
+
+    if (exists)
+        Py_RETURN_TRUE;
+    else
+        Py_RETURN_FALSE;
+}
+
+PyDoc_STRVAR(RefdbBackend_lookup__doc__,
+    "lookup(refname: str) -> Reference\n"
+    "\n"
+    "Looks up a reference and returns it, or None if not found.");
+
+PyObject *
+RefdbBackend_lookup(RefdbBackend *self, PyObject *py_str)
+{
+    int err;
+    git_reference *ref;
+    const char *ref_name;
+    if (self->refdb_backend->lookup == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    if (!PyUnicode_Check(py_str)) {
+        PyErr_SetString(PyExc_TypeError,
+                "RefdbBackend.lookup takes a string argument");
+        return NULL;
+    }
+    ref_name = PyUnicode_AsUTF8(py_str);
+
+    err = self->refdb_backend->lookup(&ref, self->refdb_backend, ref_name);
+
+    if (err == GIT_ENOTFOUND) {
+        Py_RETURN_NONE;
+    } else if (err != 0) {
+        return Error_set(err);
+    }
+
+    return wrap_reference(ref, NULL);
+}
+
+PyDoc_STRVAR(RefdbBackend_write__doc__,
+    "write(ref: Reference, force: bool, who: Signature, message: str, \n"
+    "   old: oid, old_target: str)\n"
+    "\n"
+    "Writes a new reference to the reference database.");
+// TODO: Better docs? libgit2 is scant on documentation for this, too.
+
+PyObject *
+RefdbBackend_write(RefdbBackend *self, PyObject *args)
+{
+    int err;
+    Reference *ref;
+    int force;
+    Signature *who;
+    char *message, *old_target;
+    PyObject *py_old;
+    git_oid old;
+    if (self->refdb_backend->write == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    if (!PyArg_ParseTuple(args, "O!pO!sOs", &ReferenceType, &ref,
+                &force, &SignatureType, &who, &message, &py_old, &old_target))
+        return NULL;
+
+    py_oid_to_git_oid(py_old, &old);
+
+    err = self->refdb_backend->write(self->refdb_backend,
+            ref->reference, force, who->signature, message, &old, old_target);
+    if (err != 0) {
+        return Error_set(err);
+    }
+
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(RefdbBackend_rename__doc__,
+    "rename(old_name: str, new_name: str, force: bool, who: Signature, message: str)\n"
+    "   -> Reference\n"
+    "\n"
+    "Renames a reference.");
+
+PyObject *
+RefdbBackend_rename(RefdbBackend *self, PyObject *args)
+{
+    int err;
+    int force;
+    Signature *who;
+    char *old_name, *new_name, *message;
+    git_reference *out;
+
+    if (self->refdb_backend->rename == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    if (!PyArg_ParseTuple(args, "sspO!s", &old_name, &new_name,
+                &force, &SignatureType, &who, &message))
+        return NULL;
+
+    err = self->refdb_backend->rename(&out, self->refdb_backend,
+            old_name, new_name, force, who->signature, message);
+    if (err != 0)
+        return Error_set(err);
+
+    return (PyObject *)wrap_reference(out, NULL);
+}
+
+PyDoc_STRVAR(RefdbBackend_delete__doc__,
+    "delete(ref_name: str, old_id: Oid, old_target: str)\n"
+    "\n"
+    "Deletes a reference.");
+
+PyObject *
+RefdbBackend_delete(RefdbBackend *self, PyObject *args)
+{
+    int err;
+    PyObject *py_old_id;
+    git_oid old_id;
+    char *ref_name, *old_target;
+
+    if (self->refdb_backend->del == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    if (!PyArg_ParseTuple(args, "sOz", &ref_name, &py_old_id, &old_target))
+        return NULL;
+
+    if (py_old_id != Py_None) {
+        py_oid_to_git_oid(py_old_id, &old_id);
+        err = self->refdb_backend->del(self->refdb_backend,
+                ref_name, &old_id, old_target);
+        Py_DECREF(py_old_id);
+    } else {
+        err = self->refdb_backend->del(self->refdb_backend,
+                ref_name, NULL, old_target);
+    }
+
+    if (err != 0)
+        return Error_set(err);
+
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(RefdbBackend_compress__doc__,
+    "delete(ref_name: str, old_id: Oid, old_target: str)\n"
+    "\n"
+    "Suggests that the implementation compress or optimize its references.\n"
+    "This behavior is implementation-specific.");
+
+PyObject *
+RefdbBackend_compress(RefdbBackend *self)
+{
+    int err;
+    if (self->refdb_backend->compress == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    err = self->refdb_backend->compress(self->refdb_backend);
+    if (err != 0)
+        return Error_set(err);
+
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(RefdbBackend_has_log__doc__,
+    "has_log(ref_name: str)\n"
+    "\n"
+    "Returns True if a ref log is available for this reference.\n"
+    "It may be empty even if it exists.");
+
+PyObject *
+RefdbBackend_has_log(RefdbBackend *self, PyObject *_ref_name)
+{
+    int err;
+    const char *ref_name;
+    if (self->refdb_backend->has_log == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    if (!PyUnicode_Check(_ref_name)) {
+        PyErr_SetString(PyExc_TypeError,
+                "RefdbBackend.has_log takes a string argument");
+        return NULL;
+    }
+    ref_name = PyUnicode_AsUTF8(_ref_name);
+
+    err = self->refdb_backend->has_log(self->refdb_backend, ref_name);
+    if (err < 0) {
+        return Error_set(err);
+    }
+
+    if (err == 0) {
+        Py_RETURN_TRUE;
+    } else {
+        Py_RETURN_FALSE;
+    }
+}
+
+PyDoc_STRVAR(RefdbBackend_ensure_log__doc__,
+    "ensure_log(ref_name: str)\n"
+    "\n"
+    "Ensure that a particular reference will have a reflog which will be\n"
+    "appended to on writes.");
+
+PyObject *
+RefdbBackend_ensure_log(RefdbBackend *self, PyObject *_ref_name)
+{
+    int err;
+    const char *ref_name;
+    if (self->refdb_backend->ensure_log == NULL) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
+    if (!PyUnicode_Check(_ref_name)) {
+        PyErr_SetString(PyExc_TypeError,
+                "RefdbBackend.ensure_log takes a string argument");
+        return NULL;
+    }
+    ref_name = PyUnicode_AsUTF8(_ref_name);
+
+    err = self->refdb_backend->ensure_log(self->refdb_backend, ref_name);
+    if (err < 0) {
+        return Error_set(err);
+    }
+
+    if (err == 0) {
+        Py_RETURN_TRUE;
+    } else {
+        Py_RETURN_FALSE;
+    }
+}
+
+PyMethodDef RefdbBackend_methods[] = {
+    METHOD(RefdbBackend, exists, METH_O),
+    METHOD(RefdbBackend, lookup, METH_O),
+    METHOD(RefdbBackend, write, METH_VARARGS),
+    METHOD(RefdbBackend, rename, METH_VARARGS),
+    METHOD(RefdbBackend, delete, METH_VARARGS),
+    METHOD(RefdbBackend, compress, METH_NOARGS),
+    METHOD(RefdbBackend, has_log, METH_O),
+    METHOD(RefdbBackend, ensure_log, METH_O),
+    {NULL}
+};
+
+PyDoc_STRVAR(RefdbBackend__doc__, "Reference database backend.");
+
+PyTypeObject RefdbBackendType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "_pygit2.RefdbBackend",                    /* tp_name           */
+    sizeof(RefdbBackend),                      /* tp_basicsize      */
+    0,                                         /* tp_itemsize       */
+    (destructor)RefdbBackend_dealloc,          /* tp_dealloc        */
+    0,                                         /* tp_print          */
+    0,                                         /* tp_getattr        */
+    0,                                         /* tp_setattr        */
+    0,                                         /* tp_compare        */
+    0,                                         /* tp_repr           */
+    0,                                         /* tp_as_number      */
+    0,                                         /* tp_as_sequence    */
+    0,                                         /* tp_as_mapping     */
+    0,                                         /* tp_hash           */
+    0,                                         /* tp_call           */
+    0,                                         /* tp_str            */
+    0,                                         /* tp_getattro       */
+    0,                                         /* tp_setattro       */
+    0,                                         /* tp_as_buffer      */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,  /* tp_flags          */
+    RefdbBackend__doc__,                       /* tp_doc            */
+    0,                                         /* tp_traverse       */
+    0,                                         /* tp_clear          */
+    0,                                         /* tp_richcompare    */
+    0,                                         /* tp_weaklistoffset */
+    0 /* TODO: Wrap git_reference_iterator */, /* tp_iter           */
+    0,                                         /* tp_iternext       */
+    RefdbBackend_methods,                      /* tp_methods        */
+    0,                                         /* tp_members        */
+    0,                                         /* tp_getset         */
+    0,                                         /* tp_base           */
+    0,                                         /* tp_dict           */
+    0,                                         /* tp_descr_get      */
+    0,                                         /* tp_descr_set      */
+    0,                                         /* tp_dictoffset     */
+    (initproc)RefdbBackend_init,               /* tp_init           */
+    0,                                         /* tp_alloc          */
+    0,                                         /* tp_new            */
+};
+
+PyObject *
+wrap_refdb_backend(git_refdb_backend *c_refdb_backend)
+{
+    RefdbBackend *pygit2_refdb_backend = PyObject_New(RefdbBackend, &RefdbBackendType);
+
+    if (pygit2_refdb_backend)
+        pygit2_refdb_backend->refdb_backend = c_refdb_backend;
+
+    return (PyObject *)pygit2_refdb_backend;
+}
+
+PyDoc_STRVAR(RefdbFsBackend__doc__,
+        "RefdbFsBackend(repo: Repository)\n"
+        "\n"
+        "Reference database filesystem backend. The path to the repository\n"
+        "is used as the basis of the reference database.");
+
+int
+RefdbFsBackend_init(RefdbFsBackend *self, PyObject *args, PyObject *kwds)
+{
+    if (kwds && PyDict_Size(kwds) > 0) {
+        PyErr_SetString(PyExc_TypeError, "RefdbFsBackend takes no keyword arguments");
+        return -1;
+    }
+
+    Repository *repo = NULL;
+    if (!PyArg_ParseTuple(args, "O!", &RepositoryType, &repo))
+        return -1;
+
+    int err = git_refdb_backend_fs(&self->super.refdb_backend, repo->repo);
+    if (err) {
+        Error_set(err);
+        return -1;
+    }
+
+    return 0;
+}
+
+PyTypeObject RefdbFsBackendType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "_pygit2.RefdbFsBackend",                  /* tp_name           */
+    sizeof(RefdbFsBackend),                    /* tp_basicsize      */
+    0,                                         /* tp_itemsize       */
+    0,                                         /* tp_dealloc        */
+    0,                                         /* tp_print          */
+    0,                                         /* tp_getattr        */
+    0,                                         /* tp_setattr        */
+    0,                                         /* tp_compare        */
+    0,                                         /* tp_repr           */
+    0,                                         /* tp_as_number      */
+    0,                                         /* tp_as_sequence    */
+    0,                                         /* tp_as_mapping     */
+    0,                                         /* tp_hash           */
+    0,                                         /* tp_call           */
+    0,                                         /* tp_str            */
+    0,                                         /* tp_getattro       */
+    0,                                         /* tp_setattro       */
+    0,                                         /* tp_as_buffer      */
+    Py_TPFLAGS_DEFAULT,                        /* tp_flags          */
+    RefdbFsBackend__doc__,                     /* tp_doc            */
+    0,                                         /* tp_traverse       */
+    0,                                         /* tp_clear          */
+    0,                                         /* tp_richcompare    */
+    0,                                         /* tp_weaklistoffset */
+    0,                                         /* tp_iter           */
+    0,                                         /* tp_iternext       */
+    0,                                         /* tp_methods        */
+    0,                                         /* tp_members        */
+    0,                                         /* tp_getset         */
+    &RefdbBackendType,                         /* tp_base           */
+    0,                                         /* tp_dict           */
+    0,                                         /* tp_descr_get      */
+    0,                                         /* tp_descr_set      */
+    0,                                         /* tp_dictoffset     */
+    (initproc)RefdbFsBackend_init,             /* tp_init           */
+    0,                                         /* tp_alloc          */
+    0,                                         /* tp_new            */
+};

--- a/src/refdb_backend.c
+++ b/src/refdb_backend.c
@@ -27,13 +27,13 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include <fnmatch.h>
 #include "error.h"
 #include "types.h"
 #include "oid.h"
 #include "reference.h"
 #include "signature.h"
 #include "utils.h"
+#include "wildmatch.h"
 #include <git2/refdb.h>
 #include <git2/sys/refdb_backend.h>
 
@@ -77,7 +77,7 @@ iterator_get_next(struct pygit2_refdb_iterator *iter)
             return ref;
         }
         const char *name = git_reference_name(ref->reference);
-        if (fnmatch(iter->glob, name, 0) != FNM_NOMATCH) {
+        if (wildmatch(iter->glob, name, 0) != WM_NOMATCH) {
             return ref;
         }
     }

--- a/src/refdb_backend.c
+++ b/src/refdb_backend.c
@@ -582,8 +582,8 @@ RefdbBackend_lookup(RefdbBackend *self, PyObject *py_str)
 }
 
 PyDoc_STRVAR(RefdbBackend_write__doc__,
-    "write(ref: Reference, force: bool, who: Signature, message: str, \n"
-    "   old: oid, old_target: str)\n"
+    "write(ref: Reference, force: bool, who: Signature, message: str, "
+    "old: oid, old_target: str)\n"
     "\n"
     "Writes a new reference to the reference database.");
 // TODO: Better docs? libgit2 is scant on documentation for this, too.

--- a/src/refdb_backend.h
+++ b/src/refdb_backend.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2019 The pygit2 contributors
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * In addition to the permissions in the GNU General Public License,
+ * the authors give you unlimited permission to link the compiled
+ * version of this file into combinations with other programs,
+ * and to distribute those combinations without any restriction
+ * coming from the use of this file.  (The General Public License
+ * restrictions do apply in other respects; for example, they cover
+ * modification of the file, and distribution when not linked into
+ * a combined executable.)
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDE_pygit2_refdb_backend_h
+#define INCLUDE_pygit2_refdb_backend_h
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <git2.h>
+#include "types.h"
+
+PyObject *wrap_refdb_backend(git_refdb_backend *c_refdb_backend);
+
+#endif

--- a/src/reference.c
+++ b/src/reference.c
@@ -633,8 +633,8 @@ wrap_reference(git_reference * c_reference, Repository *repo)
     py_reference = PyObject_New(Reference, &ReferenceType);
     if (py_reference) {
         py_reference->reference = c_reference;
+        py_reference->repo = repo;
         if (repo) {
-            py_reference->repo = repo;
             Py_INCREF(repo);
         }
     }

--- a/src/repository.c
+++ b/src/repository.c
@@ -35,6 +35,7 @@
 #include "object.h"
 #include "oid.h"
 #include "note.h"
+#include "refdb.h"
 #include "repository.h"
 #include "diff.h"
 #include "branch.h"
@@ -1586,6 +1587,21 @@ Repository_odb__get__(Repository *self)
     return wrap_odb(odb);
 }
 
+PyDoc_STRVAR(Repository_refdb__doc__, "Return the reference database for this repository");
+
+PyObject *
+Repository_refdb__get__(Repository *self)
+{
+    git_refdb *refdb;
+    int err;
+
+    err = git_repository_refdb(&refdb, self->repo);
+    if (err < 0)
+        return Error_set(err);
+
+    return wrap_refdb(refdb);
+}
+
 PyDoc_STRVAR(Repository__pointer__doc__, "Get the repo's pointer. For internal use only.");
 PyObject *
 Repository__pointer__get__(Repository *self)
@@ -1929,6 +1945,7 @@ PyGetSetDef Repository_getseters[] = {
     GETSET(Repository, workdir),
     GETTER(Repository, default_signature),
     GETTER(Repository, odb),
+    GETTER(Repository, refdb),
     GETTER(Repository, _pointer),
     {NULL}
 };

--- a/src/repository.c
+++ b/src/repository.c
@@ -1907,6 +1907,38 @@ Repository_apply(Repository *self, PyObject *py_diff)
     Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(Repository_set_odb__doc__,
+  "set_odb(odb: Odb)\n"
+  "\n"
+  "Sets the object database for this repository.\n"
+  "This is a low-level function, most users won't need it.\n");
+
+PyObject *
+Repository_set_odb(Repository *self, Odb *odb)
+{
+    int err;
+    err = git_repository_set_odb(self->repo, odb->odb);
+    if (err < 0)
+        return Error_set(err);
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(Repository_set_refdb__doc__,
+  "set_refdb(refdb: Refdb)\n"
+  "\n"
+  "Sets the reference database for this repository.\n"
+  "This is a low-level function, most users won't need it.\n");
+
+PyObject *
+Repository_set_refdb(Repository *self, Refdb *refdb)
+{
+    int err;
+    err = git_repository_set_refdb(self->repo, refdb->refdb);
+    if (err < 0)
+        return Error_set(err);
+    Py_RETURN_NONE;
+}
+
 PyMethodDef Repository_methods[] = {
     METHOD(Repository, create_blob, METH_VARARGS),
     METHOD(Repository, create_blob_fromworkdir, METH_VARARGS),
@@ -1950,6 +1982,8 @@ PyMethodDef Repository_methods[] = {
     METHOD(Repository, list_worktrees, METH_VARARGS),
     METHOD(Repository, _from_c, METH_VARARGS),
     METHOD(Repository, _disown, METH_NOARGS),
+    METHOD(Repository, set_odb, METH_O),
+    METHOD(Repository, set_refdb, METH_O),
     {NULL}
 };
 

--- a/src/types.h
+++ b/src/types.h
@@ -79,6 +79,15 @@ typedef struct {
     git_refdb *refdb;
 } Refdb;
 
+typedef struct {
+    PyObject_HEAD
+    git_refdb_backend *refdb_backend;
+} RefdbBackend;
+
+typedef struct {
+    RefdbBackend super;
+} RefdbFsBackend;
+
 
 #define SIMPLE_TYPE(_name, _ptr_type, _ptr_name) \
         typedef struct {\

--- a/src/types.h
+++ b/src/types.h
@@ -74,6 +74,11 @@ typedef struct {
     OdbBackend super;
 } OdbBackendLoose;
 
+typedef struct {
+    PyObject_HEAD
+    git_refdb *refdb;
+} Refdb;
+
 
 #define SIMPLE_TYPE(_name, _ptr_type, _ptr_name) \
         typedef struct {\

--- a/src/wildmatch.c
+++ b/src/wildmatch.c
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ *
+ * Do shell-style pattern matching for ?, \, [], and * characters.
+ * It is 8bit clean.
+ *
+ * Written by Rich $alz, mirror!rs, Wed Nov 26 19:03:17 EST 1986.
+ * Rich $alz is now <rsalz@bbn.com>.
+ *
+ * Modified by Wayne Davison to special-case '/' matching, to make '**'
+ * work differently than '*', and to fix the character-class code.
+ *
+ * Imported from git.git.
+ */
+
+#include <ctype.h>
+#include <string.h>
+#include "wildmatch.h"
+
+#define GIT_SPACE 0x01
+#define GIT_DIGIT 0x02
+#define GIT_ALPHA 0x04
+#define GIT_GLOB_SPECIAL 0x08
+#define GIT_REGEX_SPECIAL 0x10
+#define GIT_PATHSPEC_MAGIC 0x20
+#define GIT_CNTRL 0x40
+#define GIT_PUNCT 0x80
+
+enum {
+	S = GIT_SPACE,
+	A = GIT_ALPHA,
+	D = GIT_DIGIT,
+	G = GIT_GLOB_SPECIAL,	/* *, ?, [, \\ */
+	R = GIT_REGEX_SPECIAL,	/* $, (, ), +, ., ^, {, | */
+	P = GIT_PATHSPEC_MAGIC, /* other non-alnum, except for ] and } */
+	X = GIT_CNTRL,
+	U = GIT_PUNCT,
+	Z = GIT_CNTRL | GIT_SPACE
+};
+
+static const unsigned char sane_ctype[256] = {
+	X, X, X, X, X, X, X, X, X, Z, Z, X, X, Z, X, X,		/*   0.. 15 */
+	X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X,		/*  16.. 31 */
+	S, P, P, P, R, P, P, P, R, R, G, R, P, P, R, P,		/*  32.. 47 */
+	D, D, D, D, D, D, D, D, D, D, P, P, P, P, P, G,		/*  48.. 63 */
+	P, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A,		/*  64.. 79 */
+	A, A, A, A, A, A, A, A, A, A, A, G, G, U, R, P,		/*  80.. 95 */
+	P, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A,		/*  96..111 */
+	A, A, A, A, A, A, A, A, A, A, A, R, R, U, P, X,		/* 112..127 */
+	/* Nothing in the 128.. range */
+};
+
+#define sane_istest(x,mask) ((sane_ctype[(unsigned char)(x)] & (mask)) != 0)
+#define is_glob_special(x) sane_istest(x,GIT_GLOB_SPECIAL)
+
+typedef unsigned char uchar;
+
+/* What character marks an inverted character class? */
+#define NEGATE_CLASS	'!'
+#define NEGATE_CLASS2	'^'
+
+#define CC_EQ(class, len, litmatch) ((len) == sizeof (litmatch)-1 \
+				    && *(class) == *(litmatch) \
+				    && strncmp((char*)class, litmatch, len) == 0)
+
+#if defined STDC_HEADERS || !defined isascii
+# define ISASCII(c) 1
+#else
+# define ISASCII(c) isascii(c)
+#endif
+
+#ifdef isblank
+# define ISBLANK(c) (ISASCII(c) && isblank(c))
+#else
+# define ISBLANK(c) ((c) == ' ' || (c) == '\t')
+#endif
+
+#ifdef isgraph
+# define ISGRAPH(c) (ISASCII(c) && isgraph(c))
+#else
+# define ISGRAPH(c) (ISASCII(c) && isprint(c) && !isspace(c))
+#endif
+
+#define ISPRINT(c) (ISASCII(c) && isprint(c))
+#define ISDIGIT(c) (ISASCII(c) && isdigit(c))
+#define ISALNUM(c) (ISASCII(c) && isalnum(c))
+#define ISALPHA(c) (ISASCII(c) && isalpha(c))
+#define ISCNTRL(c) (ISASCII(c) && iscntrl(c))
+#define ISLOWER(c) (ISASCII(c) && islower(c))
+#define ISPUNCT(c) (ISASCII(c) && ispunct(c))
+#define ISSPACE(c) (ISASCII(c) && isspace(c))
+#define ISUPPER(c) (ISASCII(c) && isupper(c))
+#define ISXDIGIT(c) (ISASCII(c) && isxdigit(c))
+
+/* Match pattern "p" against "text" */
+static int dowild(const uchar *p, const uchar *text, unsigned int flags)
+{
+	uchar p_ch;
+	const uchar *pattern = p;
+
+	for ( ; (p_ch = *p) != '\0'; text++, p++) {
+		int matched, match_slash, negated;
+		uchar t_ch, prev_ch;
+		if ((t_ch = *text) == '\0' && p_ch != '*')
+			return WM_ABORT_ALL;
+		if ((flags & WM_CASEFOLD) && ISUPPER(t_ch))
+			t_ch = tolower(t_ch);
+		if ((flags & WM_CASEFOLD) && ISUPPER(p_ch))
+			p_ch = tolower(p_ch);
+		switch (p_ch) {
+		case '\\':
+			/* Literal match with following character.  Note that the test
+			 * in "default" handles the p[1] == '\0' failure case. */
+			p_ch = *++p;
+			/* FALLTHROUGH */
+		default:
+			if (t_ch != p_ch)
+				return WM_NOMATCH;
+			continue;
+		case '?':
+			/* Match anything but '/'. */
+			if ((flags & WM_PATHNAME) && t_ch == '/')
+				return WM_NOMATCH;
+			continue;
+		case '*':
+			if (*++p == '*') {
+				const uchar *prev_p = p - 2;
+				while (*++p == '*') {}
+				if (!(flags & WM_PATHNAME))
+					/* without WM_PATHNAME, '*' == '**' */
+					match_slash = 1;
+				else if ((prev_p < pattern || *prev_p == '/') &&
+				    (*p == '\0' || *p == '/' ||
+				     (p[0] == '\\' && p[1] == '/'))) {
+					/*
+					 * Assuming we already match 'foo/' and are at
+					 * <star star slash>, just assume it matches
+					 * nothing and go ahead match the rest of the
+					 * pattern with the remaining string. This
+					 * helps make foo/<*><*>/bar (<> because
+					 * otherwise it breaks C comment syntax) match
+					 * both foo/bar and foo/a/bar.
+					 */
+					if (p[0] == '/' &&
+					    dowild(p + 1, text, flags) == WM_MATCH)
+						return WM_MATCH;
+					match_slash = 1;
+				} else /* WM_PATHNAME is set */
+					match_slash = 0;
+			} else
+				/* without WM_PATHNAME, '*' == '**' */
+				match_slash = flags & WM_PATHNAME ? 0 : 1;
+			if (*p == '\0') {
+				/* Trailing "**" matches everything.  Trailing "*" matches
+				 * only if there are no more slash characters. */
+				if (!match_slash) {
+					if (strchr((char*)text, '/') != NULL)
+						return WM_NOMATCH;
+				}
+				return WM_MATCH;
+			} else if (!match_slash && *p == '/') {
+				/*
+				 * _one_ asterisk followed by a slash
+				 * with WM_PATHNAME matches the next
+				 * directory
+				 */
+				const char *slash = strchr((char*)text, '/');
+				if (!slash)
+					return WM_NOMATCH;
+				text = (const uchar*)slash;
+				/* the slash is consumed by the top-level for loop */
+				break;
+			}
+			while (1) {
+				if (t_ch == '\0')
+					break;
+				/*
+				 * Try to advance faster when an asterisk is
+				 * followed by a literal. We know in this case
+				 * that the string before the literal
+				 * must belong to "*".
+				 * If match_slash is false, do not look past
+				 * the first slash as it cannot belong to '*'.
+				 */
+				if (!is_glob_special(*p)) {
+					p_ch = *p;
+					if ((flags & WM_CASEFOLD) && ISUPPER(p_ch))
+						p_ch = tolower(p_ch);
+					while ((t_ch = *text) != '\0' &&
+					       (match_slash || t_ch != '/')) {
+						if ((flags & WM_CASEFOLD) && ISUPPER(t_ch))
+							t_ch = tolower(t_ch);
+						if (t_ch == p_ch)
+							break;
+						text++;
+					}
+					if (t_ch != p_ch)
+						return WM_NOMATCH;
+				}
+				if ((matched = dowild(p, text, flags)) != WM_NOMATCH) {
+					if (!match_slash || matched != WM_ABORT_TO_STARSTAR)
+						return matched;
+				} else if (!match_slash && t_ch == '/')
+					return WM_ABORT_TO_STARSTAR;
+				t_ch = *++text;
+			}
+			return WM_ABORT_ALL;
+		case '[':
+			p_ch = *++p;
+#ifdef NEGATE_CLASS2
+			if (p_ch == NEGATE_CLASS2)
+				p_ch = NEGATE_CLASS;
+#endif
+			/* Assign literal 1/0 because of "matched" comparison. */
+			negated = p_ch == NEGATE_CLASS ? 1 : 0;
+			if (negated) {
+				/* Inverted character class. */
+				p_ch = *++p;
+			}
+			prev_ch = 0;
+			matched = 0;
+			do {
+				if (!p_ch)
+					return WM_ABORT_ALL;
+				if (p_ch == '\\') {
+					p_ch = *++p;
+					if (!p_ch)
+						return WM_ABORT_ALL;
+					if (t_ch == p_ch)
+						matched = 1;
+				} else if (p_ch == '-' && prev_ch && p[1] && p[1] != ']') {
+					p_ch = *++p;
+					if (p_ch == '\\') {
+						p_ch = *++p;
+						if (!p_ch)
+							return WM_ABORT_ALL;
+					}
+					if (t_ch <= p_ch && t_ch >= prev_ch)
+						matched = 1;
+					else if ((flags & WM_CASEFOLD) && ISLOWER(t_ch)) {
+						uchar t_ch_upper = toupper(t_ch);
+						if (t_ch_upper <= p_ch && t_ch_upper >= prev_ch)
+							matched = 1;
+					}
+					p_ch = 0; /* This makes "prev_ch" get set to 0. */
+				} else if (p_ch == '[' && p[1] == ':') {
+					const uchar *s;
+					int i;
+					for (s = p += 2; (p_ch = *p) && p_ch != ']'; p++) {} /*SHARED ITERATOR*/
+					if (!p_ch)
+						return WM_ABORT_ALL;
+					i = (int)(p - s - 1);
+					if (i < 0 || p[-1] != ':') {
+						/* Didn't find ":]", so treat like a normal set. */
+						p = s - 2;
+						p_ch = '[';
+						if (t_ch == p_ch)
+							matched = 1;
+						continue;
+					}
+					if (CC_EQ(s,i, "alnum")) {
+						if (ISALNUM(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "alpha")) {
+						if (ISALPHA(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "blank")) {
+						if (ISBLANK(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "cntrl")) {
+						if (ISCNTRL(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "digit")) {
+						if (ISDIGIT(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "graph")) {
+						if (ISGRAPH(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "lower")) {
+						if (ISLOWER(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "print")) {
+						if (ISPRINT(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "punct")) {
+						if (ISPUNCT(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "space")) {
+						if (ISSPACE(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "upper")) {
+						if (ISUPPER(t_ch))
+							matched = 1;
+						else if ((flags & WM_CASEFOLD) && ISLOWER(t_ch))
+							matched = 1;
+					} else if (CC_EQ(s,i, "xdigit")) {
+						if (ISXDIGIT(t_ch))
+							matched = 1;
+					} else /* malformed [:class:] string */
+						return WM_ABORT_ALL;
+					p_ch = 0; /* This makes "prev_ch" get set to 0. */
+				} else if (t_ch == p_ch)
+					matched = 1;
+			} while (prev_ch = p_ch, (p_ch = *++p) != ']');
+			if (matched == negated ||
+			    ((flags & WM_PATHNAME) && t_ch == '/'))
+				return WM_NOMATCH;
+			continue;
+		}
+	}
+
+	return *text ? WM_NOMATCH : WM_MATCH;
+}
+
+/* Match the "pattern" against the "text" string. */
+int wildmatch(const char *pattern, const char *text, unsigned int flags)
+{
+	return dowild((const uchar*)pattern, (const uchar*)text, flags);
+}

--- a/src/wildmatch.h
+++ b/src/wildmatch.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_wildmatch_h__
+#define INCLUDE_wildmatch_h__
+
+#define WM_CASEFOLD 1
+#define WM_PATHNAME 2
+
+#define WM_NOMATCH 1
+#define WM_MATCH 0
+#define WM_ABORT_ALL -1
+#define WM_ABORT_TO_STARSTAR -2
+
+int wildmatch(const char *pattern, const char *text, unsigned int flags);
+
+#endif

--- a/test/test_refdb_backend.py
+++ b/test/test_refdb_backend.py
@@ -1,0 +1,121 @@
+# Copyright 2010-2020 The pygit2 contributors
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2,
+# as published by the Free Software Foundation.
+#
+# In addition to the permissions in the GNU General Public License,
+# the authors give you unlimited permission to link the compiled
+# version of this file into combinations with other programs,
+# and to distribute those combinations without any restriction
+# coming from the use of this file.  (The General Public License
+# restrictions do apply in other respects; for example, they cover
+# modification of the file, and distribution when not linked into
+# a combined executable.)
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+
+"""Tests for Refdb objects."""
+
+import os
+import unittest
+
+from pygit2 import Refdb, RefdbBackend, RefdbFsBackend, Repository
+from pygit2 import Reference
+
+from . import utils
+
+# Note: the refdb abstraction from libgit2 is meant to provide information
+# which libgit2 transforms into something more useful, and in general YMMV by
+# using the backend directly. So some of these tests are a bit vague or
+# incomplete, to avoid hitting the semi-valid states that refdbs produce by
+# design.
+class ProxyRefdbBackend(RefdbBackend):
+    def __init__(self, source):
+        self.source = source
+
+    def exists(self, ref):
+        print(self, self.source, ref)
+        return self.source.exists(ref)
+
+    def lookup(self, ref):
+        return self.source.lookup(ref)
+
+    def write(self, ref, force, who, message, old, old_target):
+        return self.source.write(ref, force, who, message, old, old_target)
+
+    def rename(self, old_name, new_name, force, who, message):
+        return self.source.rename(old_name, new_name, force, who, message)
+
+    def delete(self, ref_name, old_id, old_target):
+        return self.source.delete(ref_name, old_id, old_target)
+
+    def compress(self):
+        return self.source.compress()
+
+    def has_log(self, ref_name):
+        return self.source.has_log(ref_name)
+
+    def ensure_log(self, ref_name):
+        return self.source.ensure_log(ref_name)
+
+    def __iter__(self):
+        return iter(self.source)
+
+class CustomRefdbBackendTest(utils.RepoTestCase):
+    def setUp(self):
+        super().setUp()
+        self.backend = ProxyRefdbBackend(RefdbFsBackend(self.repo))
+
+    def test_exists(self):
+        assert not self.backend.exists('refs/heads/does-not-exist')
+        assert self.backend.exists('refs/heads/master')
+
+    def test_lookup(self):
+        assert self.backend.lookup('refs/heads/does-not-exist') is None
+        assert self.backend.lookup('refs/heads/master').name == 'refs/heads/master'
+
+    def test_write(self):
+        master = self.backend.lookup('refs/heads/master')
+        commit = self.repo.get(master.target)
+        ref = Reference("refs/heads/test-write", master.target, None)
+        self.backend.write(ref, False, commit.author,
+                "Create test-write", None, None)
+        assert self.backend.lookup("refs/heads/test-write").target == master.target
+
+    def test_rename(self):
+        old_ref = self.backend.lookup('refs/heads/i18n')
+        target = self.repo.get(old_ref.target)
+        who = target.committer
+        self.backend.rename('refs/heads/i18n', 'refs/heads/intl',
+                False, target.committer, target.message)
+        assert self.backend.lookup('refs/heads/intl').target == target.id
+
+    def test_delete(self):
+        old = self.backend.lookup('refs/heads/i18n')
+        self.backend.delete('refs/heads/i18n', old.target, None)
+        assert not self.backend.lookup('refs/heads/i18n')
+
+    def test_compress(self):
+        repo = self.repo
+        packed_refs_file = os.path.join(self.repo_path, '.git', 'packed-refs')
+        assert not os.path.exists(packed_refs_file)
+        self.backend.compress()
+        assert os.path.exists(packed_refs_file)
+
+    def test_has_log(self):
+        assert self.backend.has_log('refs/heads/master')
+        assert not self.backend.has_log('refs/heads/does-not-exist')
+
+    def test_ensure_log(self):
+        assert not self.backend.has_log('refs/heads/new-log')
+        self.backend.ensure_log('refs/heads/new-log')
+        assert self.backend.has_log('refs/heads/new-log')


### PR DESCRIPTION
TODO:

- [x] Wrap git_refdb in Refdb type
- [x] Add Reference constructor(s)
- [x] Create RefdbBackend
- [x] Create repositories with custom refdb/odb
- [x] Create Refdb from scratch
- [x] Tests
- [x] Update `docs/backends.rst`

Future work:

- Iterating over a refdb_backend from Python
- First-class reflog support
- Transactional refdb updates