### PR TITLE
Fix abort with nested Tree iteration

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -119,6 +119,8 @@ Tree_iter(Tree *self)
 {
     TreeIter *iter;
 
+    if (Object__load(self) == NULL) { return NULL; } // Lazy load
+
     iter = PyObject_New(TreeIter, &TreeIterType);
     if (iter) {
         Py_INCREF(self);

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -167,6 +167,17 @@ class TreeTest(utils.BareRepoTestCase):
         for tree_entry in tree:
             assert tree_entry == tree[tree_entry.name]
 
+    def test_iterate_tree_nested(self):
+        """
+        Testing that we're able to iterate of a Tree object and then iterate
+        trees we receive as a result.
+        """
+        tree = self.repo[TREE_SHA]
+        for tree_entry in tree:
+            if isinstance(tree_entry, pygit2.Tree):
+                for tree_entry2 in tree_entry:
+                    pass
+
     def test_deep_contains(self):
         tree = self.repo[TREE_SHA]
         assert 'a' in tree


### PR DESCRIPTION
When doing nested iteration of a Tree, Python crashes with an Abort from a libgit2 assert in `git_tree_entry_byindex()`.

Code to reproduce:
```
for obj in some_tree:
    if isinstance(obj, pygit2.Tree):
        for obj2 in obj:
            pass
```

Fix is to ensure `Tree`s are fully-loaded via `Object__load()` before creating a `TreeIter`, otherwise `self->owner->tree` in `TreeIter_iternext()` can resolve to `NULL`.

