### PR TITLE
macOS Wheels

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,119 @@
+---
+name: macOS
+
+on:
+  push: {}
+
+jobs:
+  build:
+    name: py-${{ matrix.py.ver }} libgit2-${{ matrix.libgit2}}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        libgit2: ['maint/v0.99']
+        py:
+          - ver: '3.6'
+            release: '3.6.8'  # last Python.org binary release
+          - ver: '3.7'
+            release: '3.7.7'
+          - ver: '3.8'
+            release: '3.8.2'
+    env:
+      HOMEBREW_CACHE: ${{ github.workspace }}/.cache/brew
+      CCACHE_DIR: ${{ github.workspace }}/.cache/ccache
+      CCACHE_COMPRESS: 1
+      PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
+    steps:
+      - name: checkout pygit2
+        uses: actions/checkout@v2
+        with:
+          path: pygit2
+
+      - name: checkout libgit2
+        uses: actions/checkout@v2
+        with:
+          repository: libgit2/libgit2
+          path: libgit2
+          ref: ${{ matrix.libgit2 }}
+
+      - id: cache
+        uses: actions/cache@v1.1.0
+        with:
+          path: .cache
+          key: cache-libgit2.${{ matrix.libgit2 }}-py.${{ matrix.py.release }}
+          restore-keys: |
+            cache-
+
+      - name: setup python
+        run: |
+          mkdir -p .cache/python/ .cache/pip/
+          PKG="python-${{ matrix.py.release }}-macosx10.9.pkg"
+          URL="https://www.python.org/ftp/python/${{ matrix.py.release }}/$PKG"
+          wget --no-verbose -P .cache/python -N "$URL"
+          sudo installer -pkg ".cache/python/$PKG" -target /
+          export PATH=/Library/Frameworks/Python.framework/Versions/${{ matrix.py.ver }}/bin:$PATH
+          echo "::add-path::/Library/Frameworks/Python.framework/Versions/${{ matrix.py.ver }}/bin"
+          which python3
+          python3 -VV
+          test "$(python3 -V)" = "Python ${{ matrix.py.release }}"
+
+      - name: setup
+        run: |
+          mkdir -p .cache/brew/ .cache/ccache/
+          brew install ccache pkg-config
+          python3 -m venv venv/
+          echo "::add-path::${{ github.workspace }}/venv/bin:/usr/local/opt/ccache/libexec"
+          venv/bin/pip3 install delocate pytest
+
+      - name: build libgit2
+        id: libgit2
+        working-directory: libgit2
+        env:
+          PKG_CONFIG_PATH: /dev/null
+        run: |
+          mkdir env/
+          cmake . \
+          -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/libgit2/env \
+          -DBUILD_EXAMPLES=NO \
+          -DBUILD_CLAR=NO \
+          -DUSE_SSH=NO
+          cmake --build . --target install
+          VERSION=$(PKG_CONFIG_PATH=$(pwd) pkg-config --modversion libgit2)
+          echo "::set-output name=version::$VERSION"
+
+      - name: build pygit2
+        id: pygit2
+        working-directory: pygit2
+        env:
+          LIBGIT2: "${{ github.workspace }}/libgit2/env"
+          LDFLAGS: "-Wl,-rpath,'${{ github.workspace }}/libgit2/env/lib'"
+        run: |
+          python3 setup.py bdist_wheel
+          delocate-listdeps dist/pygit2-*macosx*.whl
+          delocate-wheel -v -w dist/fixed-wheels/ dist/pygit2-*macosx*.whl
+          WHEEL=$(basename dist/fixed-wheels/*.whl)
+          echo "::set-output name=wheel::$WHEEL"
+          delocate-listdeps dist/fixed-wheels/$WHEEL
+
+      - name: pygit2 tests
+        working-directory: pygit2
+        run: |
+          mv pygit2 pygit2~
+          mv ../libgit2/env ../libgit2/env~
+          pip3 install dist/fixed-wheels/pygit2-*.whl
+          mkdir -p testresults/
+          pytest -v test/ --junitxml=testresults/testresults.xml
+
+      - name: save test results
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: "test-results-py_${{ matrix.py.ver }}-libgit2_${{ steps.libgit2.outputs.version }}"
+          path: pygit2/testresults/
+
+      - name: save wheel
+        uses: actions/upload-artifact@v1
+        with:
+          name: "macOS-wheel-py_${{ matrix.py.ver }}-libgit2_${{ steps.libgit2.outputs.version }}"
+          path: pygit2/dist/fixed-wheels/

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,9 @@ implements Git plumbing.  Pygit2 works with Python 3.5 - 3.8 and PyPy 3.5
 .. image:: https://ci.appveyor.com/api/projects/status/edmwc0dctk5nacx0/branch/master?svg=true
    :target: https://ci.appveyor.com/project/jdavid/pygit2/branch/master
 
+.. image:: https://github.com/libgit2/pygit2/workflows/macOS/badge.svg
+   :target: https://github.com/libgit2/pygit2/actions?query=workflow%3AmacOS
+
 Links
 =====================================
 

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -680,7 +680,7 @@ class WorktreeTestCase(utils.RepoTestCase):
             # Confirm the name attribute matches the specified name
             assert worktree.name == worktree_name
             # Confirm the path attribute points to the correct path
-            assert os.path.realpath(worktree.path) == worktree_dir
+            assert os.path.realpath(worktree.path) == os.path.realpath(worktree_dir)
             # The "gitdir" in a worktree should be a file with a reference to
             # the actual gitdir. Let's make sure that the path exists and is a
             # file.


### PR DESCRIPTION
Add macOS wheels into CI, using Github Actions macOS support.

* Built against Python 3.6, 3.7, 3.8 using the Python.org distributions, which means wheels are compatible with macOS 10.9+.
* Wheels run through [delocate](https://github.com/matthew-brett/delocate/) to embed libgit2
* Unit tests run/pass against the wheels
* Caches things fairly heavily, so total rebuild time is normally 2-3mins.
* Wheels are saved as artifacts, and are downloadable for 90 days.

### Libgit2

Builds against `maint/v0.99` to match appveyor & travis, but it's configured as a matrix so can easily test against releases/branches/etc if appropriate. Not sure if we should be doing a "release" build `-DCMAKE_BUILD_TYPE=Release` (or `RelWithDebugInfo`), but it matches the other environments atm.

### Python 3.5

This was in the plan, but I think the Python.org 3.5.4 release was built using an old version of GCC instead of Clang, and it's not in the CI environment by default. I can dig further, or switch to the build of Py3.5 used by GH Actions (which is macOS 10.13+ only), or we just leave it out.

### PyPi

Haven't set it up to push to PyPi on release tags, but that's easily done using eg: [gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) once secrets are configured.
