### PR TITLE
Accept Pathlike objects (eg. pathlib.Path) in Py3.6+

### DIFF
--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -78,7 +78,7 @@ class Index(object):
 
     def __getitem__(self, key):
         centry = ffi.NULL
-        if isinstance(key, str):
+        if isinstance(key, str) or hasattr(key, '__fspath__'):
             centry = C.git_index_get_bypath(self._index, to_bytes(key), 0)
         elif isinstance(key, int):
             if key >= 0:
@@ -200,13 +200,13 @@ class Index(object):
         Index without checking for the existence of the path or id.
         """
 
-        if isinstance(path_or_entry, str):
-            path = path_or_entry
-            err = C.git_index_add_bypath(self._index, to_bytes(path))
-        elif isinstance(path_or_entry, IndexEntry):
+        if isinstance(path_or_entry, IndexEntry):
             entry = path_or_entry
             centry, str_ref = entry._to_c()
             err = C.git_index_add(self._index, centry)
+        elif isinstance(path_or_entry, str) or hasattr(path_or_entry, '__fspath__'):
+            path = path_or_entry
+            err = C.git_index_add_bypath(self._index, to_bytes(path))
         else:
             raise AttributeError('argument must be string or IndexEntry')
 

--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -1280,6 +1280,9 @@ class References(object):
 
 class Repository(BaseRepository):
     def __init__(self, path, *args, **kwargs):
+        if hasattr(path, "__fspath__"):
+            path = path.__fspath__()
+
         if not isinstance(path, str):
             path = path.decode('utf-8')
 

--- a/pygit2/utils.py
+++ b/pygit2/utils.py
@@ -23,6 +23,8 @@
 # the Free Software Foundation, 51 Franklin Street, Fifth Floor,
 # Boston, MA 02110-1301, USA.
 
+import os
+
 # Import from pygit2
 from .ffi import ffi
 
@@ -31,6 +33,9 @@ def to_bytes(s, encoding='utf-8', errors='strict'):
     if s == ffi.NULL or s is None:
         return ffi.NULL
 
+    if hasattr(s, '__fspath__'):
+        s = os.fspath(s)
+
     if isinstance(s, bytes):
         return s
 
@@ -38,6 +43,9 @@ def to_bytes(s, encoding='utf-8', errors='strict'):
 
 
 def to_str(s):
+    if hasattr(s, '__fspath__'):
+        s = os.fspath(s)
+
     if type(s) is str:
         return s
 
@@ -76,10 +84,11 @@ class StrArray(object):
 
         strings = [None] * len(l)
         for i in range(len(l)):
-            if not isinstance(l[i], str):
-                raise TypeError("Value must be a string")
+            li = l[i]
+            if not isinstance(li, str) and not hasattr(li, '__fspath__'):
+                raise TypeError("Value must be a string or PathLike object")
 
-            strings[i] = ffi.new('char []', to_bytes(l[i]))
+            strings[i] = ffi.new('char []', to_bytes(li))
 
         self._arr = ffi.new('char *[]', strings)
         self._strings = strings

--- a/src/repository.c
+++ b/src/repository.c
@@ -724,13 +724,18 @@ PyObject *
 Repository_create_blob_fromworkdir(Repository *self, PyObject *args)
 {
     git_oid oid;
-    const char* path;
+    PyBytesObject *py_path = NULL;
+    const char* path = NULL;
     int err;
 
-    if (!PyArg_ParseTuple(args, "s", &path))
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_FSConverter, &py_path))
         return NULL;
 
+    if (py_path != NULL)
+        path = PyBytes_AS_STRING(py_path);
+
     err = git_blob_create_fromworkdir(&oid, self->repo, path);
+    Py_XDECREF(py_path);
     if (err < 0)
         return Error_set(err);
 
@@ -747,13 +752,18 @@ PyObject *
 Repository_create_blob_fromdisk(Repository *self, PyObject *args)
 {
     git_oid oid;
-    const char* path;
+    PyBytesObject *py_path = NULL;
+    const char* path = NULL;
     int err;
 
-    if (!PyArg_ParseTuple(args, "s", &path))
+    if (!PyArg_ParseTuple(args, "O&", PyUnicode_FSConverter, &py_path))
         return NULL;
 
+    if (py_path != NULL)
+      path = PyBytes_AS_STRING(py_path);
+
     err = git_blob_create_fromdisk(&oid, self->repo, path);
+    Py_XDECREF(py_path);
     if (err < 0)
         return Error_set(err);
 
@@ -1757,20 +1767,25 @@ PyObject *
 Repository_add_worktree(Repository *self, PyObject *args)
 {
     char *c_name;
-    char *c_path;
+    PyBytesObject *py_path = NULL;
+    char *c_path = NULL;
     Reference *py_reference = NULL;
     git_worktree *wt;
     git_worktree_add_options add_opts = GIT_WORKTREE_ADD_OPTIONS_INIT;
-    
+
     int err;
 
-    if (!PyArg_ParseTuple(args, "ss|O!", &c_name, &c_path, &ReferenceType, &py_reference))
+    if (!PyArg_ParseTuple(args, "sO&|O!", &c_name, PyUnicode_FSConverter, &py_path, &ReferenceType, &py_reference))
         return NULL;
+
+    if (py_path != NULL)
+        c_path = PyBytes_AS_STRING(py_path);
 
     if(py_reference != NULL)
         add_opts.ref = py_reference->reference;
-    
+
     err = git_worktree_add(&wt, self->repo, c_name, c_path, &add_opts);
+    Py_XDECREF(py_path);
     if (err < 0)
         return Error_set(err);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -39,6 +39,10 @@
 #  define PYGIT2_FN_UNUSED
 #endif
 
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 6 && (!defined(PYPY_VERSION) || PYPY_VERSION_NUM >= 0x07030000)
+#define HAS_FSPATH_SUPPORT
+#endif
+
 #define to_path(x) to_unicode(x, Py_FileSystemDefaultEncoding, "strict")
 #define to_encoding(x) PyUnicode_DecodeASCII(x, strlen(x), "strict")
 

--- a/test/test_attributes.py
+++ b/test/test_attributes.py
@@ -24,7 +24,9 @@
 # Boston, MA 02110-1301, USA.
 
 # Standard Library
+import unittest
 from os.path import join
+from pathlib import Path
 
 # pygit2
 from . import utils
@@ -49,3 +51,10 @@ class RepositorySignatureTest(utils.RepoTestCase):
         assert self.repo.get_attr('file.py', 'text')
         assert not self.repo.get_attr('file.jpg', 'text')
         assert "lf" == self.repo.get_attr('file.sh', 'eol')
+
+    @unittest.skipIf(not utils.has_fspath, "Requires PEP-519 (FSPath) support")
+    def test_no_attr_aspath(self):
+        with open(join(self.repo.workdir, '.gitattributes'), 'w+') as f:
+            print('*.py  text\n', file=f)
+
+        assert self.repo.get_attr(Path('file.py'), 'text')

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -26,6 +26,8 @@
 """Tests for Blob objects."""
 
 import io
+import unittest
+from pathlib import Path
 
 import pytest
 
@@ -126,6 +128,13 @@ class BlobTest(utils.RepoTestCase):
         assert len(BLOB_FILE_CONTENT) == blob.size
         assert BLOB_FILE_CONTENT == blob.read_raw()
 
+    @unittest.skipIf(not utils.has_fspath, "Requires PEP-519 (FSPath) support")
+    def test_create_blob_fromworkdir_aspath(self):
+
+        blob_oid = self.repo.create_blob_fromworkdir(Path("bye.txt"))
+        blob = self.repo[blob_oid]
+
+        assert isinstance(blob, pygit2.Blob)
 
     def test_create_blob_outside_workdir(self):
         with pytest.raises(KeyError):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -24,6 +24,8 @@
 # Boston, MA 02110-1301, USA.
 
 import os
+import unittest
+from pathlib import Path
 
 import pytest
 
@@ -88,6 +90,17 @@ class ConfigTest(utils.RepoTestCase):
         assert config.get_bool('this.that')
         assert 'something.other.here' in config
         assert not config.get_bool('something.other.here')
+
+    @unittest.skipIf(not utils.has_fspath, "Requires PEP-519 (FSPath) support")
+    def test_add_aspath(self):
+        config = Config()
+
+        new_file = open(CONFIG_FILENAME, "w")
+        new_file.write("[this]\n\tthat = true\n")
+        new_file.close()
+
+        config.add_file(Path(CONFIG_FILENAME), 0)
+        assert 'this.that' in config
 
     def test_read(self):
         config = self.repo.config

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -26,6 +26,7 @@
 """Tests for credentials"""
 
 import unittest
+from pathlib import Path
 
 import pytest
 
@@ -62,6 +63,16 @@ class CredentialCreateTest(utils.NoRepoTestCase):
         username = "git"
         pubkey = "id_rsa.pub"
         privkey = "id_rsa"
+        passphrase = "bad wolf"
+
+        cred = Keypair(username, pubkey, privkey, passphrase)
+        assert (username, pubkey, privkey, passphrase) == cred.credential_tuple
+
+    @unittest.skipIf(not utils.has_fspath, "Requires PEP-519 (FSPath) support")
+    def test_ssh_key_aspath(self):
+        username = "git"
+        pubkey = Path("id_rsa.pub")
+        privkey = Path("id_rsa")
         passphrase = "bad wolf"
 
         cred = Keypair(username, pubkey, privkey, passphrase)

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -26,6 +26,8 @@
 """Tests for Index files."""
 
 import os
+import unittest
+from pathlib import Path
 
 import pytest
 
@@ -70,6 +72,14 @@ class IndexTest(utils.RepoTestCase):
         assert len(index) == 3
         assert index['bye.txt'].hex == sha
 
+    @unittest.skipIf(not utils.has_fspath, "Requires PEP-519 (FSPath) support")
+    def test_add_aspath(self):
+        index = self.repo.index
+
+        assert 'bye.txt' not in index
+        index.add(Path('bye.txt'))
+        assert 'bye.txt' in index
+
     def test_add_all(self):
         self.test_clear()
 
@@ -105,6 +115,17 @@ class IndexTest(utils.RepoTestCase):
 
         assert index['bye.txt'].hex == sha_bye
         assert index['hello.txt'].hex == sha_hello
+
+    @unittest.skipIf(not utils.has_fspath, "Requires PEP-519 (FSPath) support")
+    def test_add_all_aspath(self):
+        self.test_clear()
+
+        index = self.repo.index
+
+        index.add_all([Path('bye.txt'), Path('hello.txt')])
+
+        assert 'bye.txt' in index
+        assert 'hello.txt' in index
 
     def test_clear(self):
         index = self.repo.index
@@ -181,6 +202,20 @@ class IndexTest(utils.RepoTestCase):
 
         index.remove_all(['not-existing'])  # this doesn't error
 
+    @unittest.skipIf(not utils.has_fspath, "Requires PEP-519 (FSPath) support")
+    def test_remove_aspath(self):
+        index = self.repo.index
+        assert 'hello.txt' in index
+        index.remove(Path('hello.txt'))
+        assert 'hello.txt' not in index
+
+    @unittest.skipIf(not utils.has_fspath, "Requires PEP-519 (FSPath) support")
+    def test_remove_all_aspath(self):
+        index = self.repo.index
+        assert 'hello.txt' in index
+        index.remove_all([Path('hello.txt')])
+        assert 'hello.txt' not in index
+
     def test_change_attributes(self):
         index = self.repo.index
         entry = index['hello.txt']
@@ -210,6 +245,15 @@ class IndexEntryTest(utils.RepoTestCase):
         index.add(entry)
         tree_id = index.write_tree()
         assert '60e769e57ae1d6a2ab75d8d253139e6260e1f912' == str(tree_id)
+
+    @unittest.skipIf(not utils.has_fspath, "Requires PEP-519 (FSPath) support")
+    def test_create_entry_aspath(self):
+        index = self.repo.index
+        hello_entry = index[Path('hello.txt')]
+        entry = pygit2.IndexEntry(Path('README.md'), hello_entry.id, hello_entry.mode)
+        index.add(entry)
+        index.write_tree()
+
 
 class StandaloneIndexTest(utils.RepoTestCase):
 

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -27,6 +27,7 @@
 
 import os
 import unittest
+from pathlib import Path
 
 from . import utils
 
@@ -36,10 +37,16 @@ SUBM_PATH = 'submodule'
 SUBM_URL = 'https://github.com/libgit2/pygit2'
 SUBM_HEAD_SHA = '819cbff552e46ac4b8d10925cc422a30aa04e78e'
 
+
 class SubmoduleTest(utils.SubmoduleRepoTestCase):
 
     def test_lookup_submodule(self):
         s = self.repo.lookup_submodule(SUBM_PATH)
+        assert s is not None
+
+    @unittest.skipIf(not utils.has_fspath, "Requires PEP-519 (FSPath) support")
+    def test_lookup_submodule_aspath(self):
+        s = self.repo.lookup_submodule(Path(SUBM_PATH))
         assert s is not None
 
     def test_listall_submodules(self):

--- a/test/utils.py
+++ b/test/utils.py
@@ -29,6 +29,7 @@ import os
 import shutil
 import socket
 import stat
+import sys
 import tarfile
 import tempfile
 import unittest
@@ -50,6 +51,14 @@ def no_network():
             _no_network = False
 
     return _no_network
+
+
+is_pypy = '__pypy__' in sys.builtin_module_names
+
+if is_pypy:
+    has_fspath = sys.pypy_version_info >= (7, 3)
+else:
+    has_fspath = sys.version_info >= (3, 6)
 
 
 def force_rm_handle(remove_path, path, excinfo):


### PR DESCRIPTION
PEP-519 (Py3.6+ / PyPy 7.3+) adds a [file system path protocol[(https://www.python.org/dev/peps/pep-0519/) via `Object.__fspath__()`, and is supported by `pathlib`/`os`/`open()`/etc. This PR adds support for accepting `pathlib.Path` objects natively in Pygit2.

* Where we take paths in Python, check `hasattr(value, '__fspath__')` to provide Py3.5 compatibility, then call it to get a str/bytes representation.
* In C, use [`PyUnicode_FSConverter`](https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FSConverter) when parsing function arguments (it handles Pathlike objects), or [`PyOS_FSPath()`](https://docs.python.org/3/c-api/sys.html#c.PyOS_FSPath) when available (ie. not Py3.5).
* Implementation-wise, this approach is basically called for all string arguments, but since `os.fspath()`/`PyOS_FSPath()` return a str/bytes argument unchanged, behaviour-wise it's the same. Cleaning this up might sit with #895?

Adds a pile of `*_aspath()` tests under Py3.6+ to wherever we seem to accept paths. I'm sure I've missed some but we can sort that along the way.
