### PR TITLE
Obj reached not through tree caused Segmentation fault on raw_name access

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -175,6 +175,9 @@ PyDoc_STRVAR(Object_raw_name__doc__, "Name (bytes).");
 PyObject *
 Object_raw_name__get__(Object *self)
 {
+    if (self->entry == NULL)
+        Py_RETURN_NONE;
+
     return PyBytes_FromString(git_tree_entry_name(self->entry));
 }
 


### PR DESCRIPTION
While tab completing in the repl on the . of a blob object accessed not through the tree I caused a segfault.
I found out the repl calls inspect.getmemebers on the object which again tries to access raw_name.
I took the check from .name property and applied to to .raw_name

This is on python 3.8.2

Before fix
```python
>>> import os, pygit2, inspect
>>> r = pygit2.Repository("/home/user/repos/pygit2")
>>> b = r.get("855c845e538b")
>>> inspect.getmembers(b)
Segmentation fault (core dumped)
```
After fix
```python
>>> import os, pygit2, inspect
>>> r = pygit2.Repository("/home/user/repos/pygit2")
>>> b = r.get("855c845e538b")
>>> inspect.getmembers(b)
[('__class__', <class '_pygit2.Blob'>), 

# ...

('short_id', '855c845'), ('size', 444379), ('type', 3), ('type_str', 'blob')]

```
