### PR TITLE
Add repr, str, == and != support to IndexEntry.

### DIFF
--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -353,6 +353,22 @@ class IndexEntry:
         """The id of the referenced object as a hex string"""
         return self.id.hex
 
+    def __str__(self):
+        return "<path={} id={} mode={}>".format(self.path, self.hex, self.mode)
+
+    def __repr__(self):
+        t = type(self)
+        return "<{}.{} path={} id={} mode={}>".format(
+            t.__module__, t.__qualname__, self.path, self.hex, self.mode
+        )
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        if not isinstance(other, IndexEntry):
+            return NotImplemented
+        return self.path == other.path and self.id == other.id and self.mode == other.mode
+
     def _to_c(self):
         """Convert this entry into the C structure
 
@@ -440,3 +456,6 @@ class ConflictIterator:
         theirs = IndexEntry._from_c(ctheirs[0])
 
         return ancestor, ours, theirs
+
+    def __iter__(self):
+        return self

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -31,7 +31,7 @@ from pathlib import Path
 import pytest
 
 import pygit2
-from pygit2 import Repository, Index
+from pygit2 import Repository, Index, Oid
 from . import utils
 
 
@@ -241,6 +241,28 @@ def test_create_entry_aspath(testrepo):
     entry = pygit2.IndexEntry(Path('README.md'), hello_entry.id, hello_entry.mode)
     index.add(entry)
     index.write_tree()
+
+def test_entry_eq(testrepo):
+    index = testrepo.index
+    hello_entry = index['hello.txt']
+    entry = pygit2.IndexEntry(hello_entry.path, hello_entry.id, hello_entry.mode)
+    assert hello_entry == entry
+
+    entry = pygit2.IndexEntry("README.md", hello_entry.id, hello_entry.mode)
+    assert hello_entry != entry
+    oid = Oid(hex='0907563af06c7464d62a70cdd135a6ba7d2b41d8')
+    entry = pygit2.IndexEntry(hello_entry.path, oid, hello_entry.mode)
+    assert hello_entry != entry
+    entry = pygit2.IndexEntry(hello_entry.path, hello_entry.id, pygit2.GIT_FILEMODE_BLOB_EXECUTABLE)
+    assert hello_entry != entry
+
+def test_entry_repr(testrepo):
+    index = testrepo.index
+    hello_entry = index['hello.txt']
+    assert (repr(hello_entry) ==
+            "<pygit2.index.IndexEntry path=hello.txt id=a520c24d85fbfc815d385957eed41406ca5a860b mode=33188>")
+    assert (str(hello_entry) ==
+            "<path=hello.txt id=a520c24d85fbfc815d385957eed41406ca5a860b mode=33188>")
 
 
 def test_create_empty():


### PR DESCRIPTION
IndexEntry is a simple datatype which can be usefully displayed or
compated to any other IndexEntry.
Not done for larger types Index or ConflictCollection since
its not clear if, for instance, two Indexes can be == if they have
different paths.

Added `ConflictIterator.__iter__` - this is required by the iterator
protocol. See
https://docs.python.org/3/library/stdtypes.html#iterator-types