### PR TITLE
Use chain.from_iterable in test_diff.py

### DIFF
--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -187,8 +187,8 @@ def test_diff_empty_tree(barerepo):
     diff = commit_a.tree.diff_to_tree()
 
     def get_context_for_lines(diff):
-        hunks = chain(*map(lambda x: x.hunks, [p for p in diff]))
-        lines = chain(*map(lambda x: x.lines, hunks))
+        hunks = chain.from_iterable(map(lambda x: x.hunks, diff))
+        lines = chain.from_iterable(map(lambda x: x.lines, hunks))
         return map(lambda x: x.origin, lines)
 
     entries = [p.delta.new_file.path for p in diff]


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.