### PR TITLE
Expand revparse support

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -208,7 +208,7 @@ PyTypeObject BlobType = {
     0,                                         /* tp_getattr        */
     0,                                         /* tp_setattr        */
     0,                                         /* tp_compare        */
-    0,                                         /* tp_repr           */
+    (reprfunc)Object_repr,                     /* tp_repr           */
     0,                                         /* tp_as_number      */
     0,                                         /* tp_as_sequence    */
     0,                                         /* tp_as_mapping     */

--- a/src/commit.c
+++ b/src/commit.c
@@ -286,7 +286,7 @@ PyTypeObject CommitType = {
     0,                                         /* tp_getattr        */
     0,                                         /* tp_setattr        */
     0,                                         /* tp_compare        */
-    0,                                         /* tp_repr           */
+    (reprfunc)Object_repr,                     /* tp_repr           */
     0,                                         /* tp_as_number      */
     0,                                         /* tp_as_sequence    */
     0,                                         /* tp_as_mapping     */

--- a/src/object.c
+++ b/src/object.c
@@ -259,6 +259,14 @@ Object_hash(Object *self)
 }
 
 PyObject *
+Object_repr(Object *self)
+{
+    return PyUnicode_FromFormat("<pygit2.Object{%s:%S}>",
+        git_object_type2string(Object__type(self)),
+        Object_hex__get__(self));
+}
+
+PyObject *
 Object_richcompare(PyObject *o1, PyObject *o2, int op)
 {
     PyObject *res;
@@ -325,7 +333,7 @@ PyTypeObject ObjectType = {
     0,                                         /* tp_getattr        */
     0,                                         /* tp_setattr        */
     0,                                         /* tp_compare        */
-    0,                                         /* tp_repr           */
+    (reprfunc)Object_repr,                     /* tp_repr           */
     0,                                         /* tp_as_number      */
     0,                                         /* tp_as_sequence    */
     0,                                         /* tp_as_mapping     */

--- a/src/object.h
+++ b/src/object.h
@@ -40,6 +40,7 @@ PyObject* Object_get_oid(Object *self);
 PyObject* Object_get_hex(Object *self);
 PyObject* Object_get_type(Object *self);
 PyObject* Object_read_raw(Object *self);
+PyObject* Object_repr(Object *self);
 PyObject* wrap_object(git_object *c_object, Repository *repo, const git_tree_entry *entry);
 
 #endif

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -67,6 +67,7 @@ extern PyTypeObject RefdbType;
 extern PyTypeObject RefdbBackendType;
 extern PyTypeObject RefdbFsBackendType;
 extern PyTypeObject ReferenceType;
+extern PyTypeObject RevSpecType;
 extern PyTypeObject RefLogIterType;
 extern PyTypeObject RefLogEntryType;
 extern PyTypeObject BranchType;
@@ -423,6 +424,14 @@ PyInit__pygit2(void)
     ADD_CONSTANT_INT(m, GIT_REF_OID)
     ADD_CONSTANT_INT(m, GIT_REF_SYMBOLIC)
     ADD_CONSTANT_INT(m, GIT_REF_LISTALL)
+
+    /*
+     * RevSpec
+     */
+    INIT_TYPE(RevSpecType, NULL, NULL)
+    ADD_CONSTANT_INT(m, GIT_REVPARSE_SINGLE)
+    ADD_CONSTANT_INT(m, GIT_REVPARSE_RANGE)
+    ADD_CONSTANT_INT(m, GIT_REVPARSE_MERGE_BASE)
 
     /*
      * Worktree

--- a/src/revspec.c
+++ b/src/revspec.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2010-2020 The pygit2 contributors
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * In addition to the permissions in the GNU General Public License,
+ * the authors give you unlimited permission to link the compiled
+ * version of this file into combinations with other programs,
+ * and to distribute those combinations without any restriction
+ * coming from the use of this file.  (The General Public License
+ * restrictions do apply in other respects; for example, they cover
+ * modification of the file, and distribution when not linked into
+ * a combined executable.)
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "error.h"
+#include "object.h"
+#include "types.h"
+#include "utils.h"
+
+extern PyTypeObject RevSpecType;
+
+PyObject*
+wrap_revspec(git_revspec *revspec, Repository *repo)
+{
+    RevSpec *py_revspec;
+
+    py_revspec = PyObject_New(RevSpec, &RevSpecType);
+    if (py_revspec) {
+        py_revspec->flags = revspec->flags;
+
+        if (revspec->from != NULL) {
+            py_revspec->from = wrap_object(revspec->from, repo, NULL);
+        } else {
+            py_revspec->from = NULL;
+        }
+
+        if (revspec->to != NULL) {
+            py_revspec->to = wrap_object(revspec->to, repo, NULL);
+        } else {
+            py_revspec->to = NULL;
+        }
+    }
+
+    return (PyObject*) py_revspec;
+}
+
+PyDoc_STRVAR(RevSpec_from_object__doc__, "From revision");
+
+PyObject *
+RevSpec_from_object__get__(RevSpec *self)
+{
+    if (self->from == NULL)
+        Py_RETURN_NONE;
+
+    Py_INCREF(self->from);
+    return self->from;
+}
+
+PyDoc_STRVAR(RevSpec_to_object__doc__, "To revision");
+
+PyObject *
+RevSpec_to_object__get__(RevSpec *self)
+{
+    if (self->to == NULL)
+        Py_RETURN_NONE;
+
+    Py_INCREF(self->to);
+    return self->to;
+}
+
+PyDoc_STRVAR(RevSpec_flags__doc__,
+    "A combination of GIT_REVPARSE_ flags which indicate the\n"
+    "intended behavior of the spec passed to Repository.revparse()");
+
+PyObject *
+RevSpec_flags__get__(RevSpec *self)
+{
+    return PyLong_FromLong(self->flags);
+}
+
+static PyObject *
+RevSpec_repr(RevSpec *self)
+{
+    return PyUnicode_FromFormat("<pygit2.RevSpec{from=%S,to=%S}>",
+                                (self->from != NULL) ? self->from : Py_None,
+                                (self->to != NULL) ? self->to : Py_None);
+}
+
+static void
+RevSpec_dealloc(RevSpec *self)
+{
+    Py_XDECREF(self->from);
+    Py_XDECREF(self->to);
+    PyObject_Del(self);
+}
+
+PyGetSetDef RevSpec_getsetters[] = {
+    GETTER(RevSpec, from_object),
+    GETTER(RevSpec, to_object),
+    GETTER(RevSpec, flags),
+    {NULL}
+};
+
+PyDoc_STRVAR(RevSpec__doc__, "RevSpec object, output from Repository.revparse().");
+
+PyTypeObject RevSpecType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "_pygit2.RevSpec",                         /* tp_name           */
+    sizeof(RevSpec),                           /* tp_basicsize      */
+    0,                                         /* tp_itemsize       */
+    (destructor)RevSpec_dealloc,               /* tp_dealloc        */
+    0,                                         /* tp_print          */
+    0,                                         /* tp_getattr        */
+    0,                                         /* tp_setattr        */
+    0,                                         /* tp_compare        */
+    (reprfunc)RevSpec_repr,                    /* tp_repr           */
+    0,                                         /* tp_as_number      */
+    0,                                         /* tp_as_sequence    */
+    0,                                         /* tp_as_mapping     */
+    0,                                         /* tp_hash           */
+    0,                                         /* tp_call           */
+    0,                                         /* tp_str            */
+    0,                                         /* tp_getattro       */
+    0,                                         /* tp_setattro       */
+    0,                                         /* tp_as_buffer      */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,  /* tp_flags          */
+    RevSpec__doc__,                            /* tp_doc            */
+    0,                                         /* tp_traverse       */
+    0,                                         /* tp_clear          */
+    0,                                         /* tp_richcompare    */
+    0,                                         /* tp_weaklistoffset */
+    0,                                         /* tp_iter           */
+    0,                                         /* tp_iternext       */
+    0,                                         /* tp_methods        */
+    0,                                         /* tp_members        */
+    RevSpec_getsetters,                        /* tp_getset         */
+    0,                                         /* tp_base           */
+    0,                                         /* tp_dict           */
+    0,                                         /* tp_descr_get      */
+    0,                                         /* tp_descr_set      */
+    0,                                         /* tp_dictoffset     */
+    0,                                         /* tp_init           */
+    0,                                         /* tp_alloc          */
+    0,                                         /* tp_new            */
+};

--- a/src/revspec.h
+++ b/src/revspec.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2020 The pygit2 contributors
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2,
+ * as published by the Free Software Foundation.
+ *
+ * In addition to the permissions in the GNU General Public License,
+ * the authors give you unlimited permission to link the compiled
+ * version of this file into combinations with other programs,
+ * and to distribute those combinations without any restriction
+ * coming from the use of this file.  (The General Public License
+ * restrictions do apply in other respects; for example, they cover
+ * modification of the file, and distribution when not linked into
+ * a combined executable.)
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDE_pygit2_revspec_h
+#define INCLUDE_pygit2_revspec_h
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <git2.h>
+#include "types.h"
+
+PyObject* wrap_revspec(git_revspec *revspec, Repository *repo);
+
+#endif

--- a/src/tree.c
+++ b/src/tree.c
@@ -455,7 +455,7 @@ PyTypeObject TreeType = {
     0,                                         /* tp_getattr        */
     0,                                         /* tp_setattr        */
     0,                                         /* tp_compare        */
-    0,                                         /* tp_repr           */
+    (reprfunc)Object_repr,                     /* tp_repr           */
     &Tree_as_number,                           /* tp_as_number      */
     &Tree_as_sequence,                         /* tp_as_sequence    */
     &Tree_as_mapping,                          /* tp_as_mapping     */

--- a/src/types.h
+++ b/src/types.h
@@ -236,6 +236,13 @@ typedef struct {
     size_t size;
 } RefLogIter;
 
+/* git_revspec */
+typedef struct {
+    PyObject_HEAD
+    PyObject *from;
+    PyObject *to;
+    unsigned int flags;
+} RevSpec;
 
 /* git_signature */
 typedef struct {

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -128,3 +128,9 @@ def test_short_id(testrepo):
         test_obj(tree, "tree#"+tree.id.hex)
         for entry in tree:
             test_obj(testrepo[entry.hex], "entry="+entry.name+"#"+entry.hex)
+
+
+def test_repr(testrepo):
+    commit_id = testrepo.lookup_reference('refs/heads/master').target
+    commit_a = testrepo[commit_id]
+    assert repr(commit_a) == "<pygit2.Object{commit:%s}>" % commit_id

--- a/test/test_revparse.py
+++ b/test/test_revparse.py
@@ -43,6 +43,20 @@ def test_revparse_single(testrepo):
     assert o.hex == '5470a671a80ac3789f1a6a8cefbcf43ce7af0563'
 
 
+def test_revparse_ext(testrepo):
+    o, r = testrepo.revparse_ext('master')
+    assert o.hex == HEAD_SHA
+    assert r == testrepo.references['refs/heads/master']
+
+    o, r = testrepo.revparse_ext('HEAD^')
+    assert o.hex == PARENT_SHA
+    assert r is None
+
+    o, r = testrepo.revparse_ext('i18n')
+    assert o.hex.startswith('5470a67')
+    assert r == testrepo.references['refs/heads/i18n']
+
+
 def test_revparse_1(testrepo):
     s = testrepo.revparse('master')
     assert s.from_object.hex == HEAD_SHA

--- a/test/test_revparse.py
+++ b/test/test_revparse.py
@@ -1,0 +1,78 @@
+# Copyright 2020 The pygit2 contributors
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2,
+# as published by the Free Software Foundation.
+#
+# In addition to the permissions in the GNU General Public License,
+# the authors give you unlimited permission to link the compiled
+# version of this file into combinations with other programs,
+# and to distribute those combinations without any restriction
+# coming from the use of this file.  (The General Public License
+# restrictions do apply in other respects; for example, they cover
+# modification of the file, and distribution when not linked into
+# a combined executable.)
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+
+"""Tests for revision parsing."""
+
+from pygit2 import GIT_REVPARSE_SINGLE, GIT_REVPARSE_RANGE, GIT_REVPARSE_MERGE_BASE, InvalidSpecError
+from pytest import raises
+
+HEAD_SHA = '2be5719152d4f82c7302b1c0932d8e5f0a4a0e98'
+PARENT_SHA = '5ebeeebb320790caf276b9fc8b24546d63316533'  # HEAD^
+
+
+def test_revparse_single(testrepo):
+    o = testrepo.revparse_single('HEAD')
+    assert o.hex == HEAD_SHA
+
+    o = testrepo.revparse_single('HEAD^')
+    assert o.hex == PARENT_SHA
+
+    o = testrepo.revparse_single('@{-1}')
+    assert o.hex == '5470a671a80ac3789f1a6a8cefbcf43ce7af0563'
+
+
+def test_revparse_1(testrepo):
+    s = testrepo.revparse('master')
+    assert s.from_object.hex == HEAD_SHA
+    assert s.to_object is None
+    assert s.flags == GIT_REVPARSE_SINGLE
+
+
+def test_revparse_range_1(testrepo):
+    s = testrepo.revparse('HEAD^1..acecd5e')
+    assert s.from_object.hex == PARENT_SHA
+    assert s.to_object.hex.startswith('acecd5e')
+    assert s.flags == GIT_REVPARSE_RANGE
+
+
+def test_revparse_range_2(testrepo):
+    s = testrepo.revparse('HEAD...i18n')
+    assert s.from_object.hex.startswith('2be5719')
+    assert s.to_object.hex.startswith('5470a67')
+    assert s.flags == GIT_REVPARSE_RANGE | GIT_REVPARSE_MERGE_BASE
+    assert testrepo.merge_base(s.from_object.id, s.to_object.id) is not None
+
+
+def test_revparse_range_errors(testrepo):
+    with raises(KeyError):
+        testrepo.revparse('nope..2be571915')
+
+    with raises(InvalidSpecError):
+        testrepo.revparse('master............2be571915')
+
+
+def test_revparse_repr(testrepo):
+    s = testrepo.revparse('HEAD...i18n')
+    assert repr(s) == "<pygit2.RevSpec{from=<pygit2.Object{commit:2be5719152d4f82c7302b1c0932d8e5f0a4a0e98}>,to=<pygit2.Object{commit:5470a671a80ac3789f1a6a8cefbcf43ce7af0563}>}>"


### PR DESCRIPTION
Expands revision parsing support:

1. adds `Repository.revparse_with_reference()` which maps to [`git_revparse_ext()`](https://libgit2.org/libgit2/#HEAD/group/revparse/git_revparse_ext) — takes the same arguments as `revparse_single()` but returns a 2-tuple `(Object, Reference)` where the revspec is a reference eg: `master`.
  a. ❓ Not sure on naming? `find_revision()`?
  b. ❓ Should we deprecate `Repository.revparse_single()` in favour of this rather than having two methods?
  c. ❓ Or merge them via something like `revparse_single(revspec, with_reference=True)`

2. adds `Repository.revparse()` which maps to [`git_revparse()`](https://libgit2.org/libgit2/#HEAD/group/revparse/git_revparse) — does range requests (eg: `HEAD^1...new@{yesterday}`). Returns a `RevSpec` object which has `.from_object`, `.to_object`, and `.intents` properties.

3. Adds a crude `repr()` implementation for Object-ish classes. eg: `<pygit2.Object{commit:5ebeeebb320790caf276b9fc8b24546d63316533}>`. I kinda feel we should be adding useful `repr()` methods to all classes going forward, otherwise debugging or exploration via a Python shell is unnecessarily slow.