### PR TITLE
Allow using tuples as well as lists for StrArray

### DIFF
--- a/pygit2/utils.py
+++ b/pygit2/utils.py
@@ -86,7 +86,7 @@ class StrArray:
             self.array = ffi.NULL
             return
 
-        if not isinstance(l, list):
+        if not isinstance(l, (list, tuple)):
             raise TypeError("Value must be a list")
 
         strings = [None] * len(l)


### PR DESCRIPTION
In `StrArray`, allow using tuples instead of lists for creating the array.