### PR TITLE
Use returned buffer size of git_buf

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -190,7 +190,7 @@ Branch_remote_name__get__(Branch *self)
     if (err < GIT_OK)
         return Error_set(err);
 
-    py_name = to_unicode(name.ptr, NULL, NULL);
+    py_name = to_unicode_n(name.ptr, name.size, NULL, NULL);
     git_buf_dispose(&name);
 
     return py_name;
@@ -268,7 +268,7 @@ Branch_upstream_name__get__(Branch *self)
     if (err < GIT_OK)
         return Error_set(err);
 
-    py_name = to_unicode(name.ptr, NULL, NULL);
+    py_name = to_unicode_n(name.ptr, name.size, NULL, NULL);
     git_buf_dispose(&name);
 
     return py_name;

--- a/src/diff.c
+++ b/src/diff.c
@@ -633,7 +633,7 @@ Diff_patch__get__(Diff *self)
         git_patch_free(patch);
     }
 
-    py_patch = to_unicode(buf.ptr, NULL, NULL);
+    py_patch = to_unicode_n(buf.ptr, buf.size, NULL, NULL);
     git_buf_dispose(&buf);
 
 cleanup:
@@ -831,7 +831,7 @@ DiffStats_format(DiffStats *self, PyObject *args, PyObject *kwds)
     if (err < 0)
         return Error_set(err);
 
-    str = to_unicode(buf.ptr, NULL, NULL);
+    str = to_unicode_n(buf.ptr, buf.size, NULL, NULL);
     git_buf_dispose(&buf);
 
     return str;

--- a/src/options.c
+++ b/src/options.c
@@ -45,7 +45,7 @@ get_search_path(long level)
     if (err < 0)
         return Error_set(err);
 
-    py_path = to_unicode(buf.ptr, NULL, NULL);
+    py_path = to_unicode_n(buf.ptr, buf.size, NULL, NULL);
     git_buf_dispose(&buf);
 
     if (!py_path)

--- a/src/patch.c
+++ b/src/patch.c
@@ -207,7 +207,7 @@ Patch_text__get__(Patch *self)
     if (err < 0)
         return Error_set(err);
 
-    text = to_unicode(buf.ptr, NULL, NULL);
+    text = to_unicode_n(buf.ptr, buf.size, NULL, NULL);
     git_buf_dispose(&buf);
     return text;
 }


### PR DESCRIPTION
The returned string may contain a '\0' character. Although not common, it
can happen e.g. in the diff output. Instead of truncating the output on the
null character, use the returned size from git_buf.

Fixes #1043