### PR TITLE
repository: add .is_shallow to detect shallow clones

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -264,6 +264,19 @@ Repository_is_bare__get__(Repository *self)
 }
 
 
+PyDoc_STRVAR(Repository_is_shallow__doc__,
+  "Check if a repository is a shallow repository.");
+
+PyObject *
+Repository_is_shallow__get__(Repository *self)
+{
+    if (git_repository_is_shallow(self->repo) > 0)
+        Py_RETURN_TRUE;
+
+    Py_RETURN_FALSE;
+}
+
+
 PyDoc_STRVAR(Repository_git_object_lookup_prefix__doc__,
   "git_object_lookup_prefix(oid) -> Object\n"
   "\n"
@@ -2130,6 +2143,7 @@ PyGetSetDef Repository_getseters[] = {
     GETTER(Repository, head_is_unborn),
     GETTER(Repository, is_empty),
     GETTER(Repository, is_bare),
+    GETTER(Repository, is_shallow),
     GETSET(Repository, workdir),
     GETTER(Repository, default_signature),
     GETTER(Repository, odb),

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -633,3 +633,12 @@ def test_open_extended(tmp_path):
         assert repo.is_bare
         assert repo.path == orig_repo.path
         assert not repo.workdir
+
+def test_is_shallow(testrepo):
+    assert not testrepo.is_shallow
+
+    # create a dummy shallow file
+    with open(os.path.join(testrepo.path, 'shallow'), 'wt') as f:
+        f.write('abcdef0123456789abcdef0123456789abcdef00\n')
+
+    assert testrepo.is_shallow


### PR DESCRIPTION
Add support for [`git_repository_is_shallow()`](https://libgit2.org/libgit2/#HEAD/group/repository/git_repository_is_shallow) to Pygit2 to indicate whether a repository is a [shallow clone](https://github.com/git/git/blob/master/Documentation/technical/shallow.txt) or not.

libgit2 currently [doesn't support shallow clones](https://github.com/libgit2/libgit2/issues/3058) beyond detecting there's a non-empty `.git/shallow` file but it's helpful nonetheless.