### PR TITLE
Fix garbled mirror configuration in recipe for `git clone --mirror`

### DIFF
--- a/docs/recipes/git-clone-mirror.rst
+++ b/docs/recipes/git-clone-mirror.rst
@@ -16,7 +16,7 @@ option for push in the remote.
         # Create the remote with a mirroring url
         remote = repo.remotes.create(name, url, "+refs/*:refs/*")
         # And set the configuration option to true for the push command
-        mirror_var = "remote.{}.mirror".format(name)
+        mirror_var = "remote.{}.mirror".format(name.decode())
         repo.config[mirror_var] = True
         # Return the remote, which pygit2 will use to perform the clone
         return remote


### PR DESCRIPTION
The documentation contains a recipe for how to emulate `git clone --mirror`. In
the example code, the init_remote callback constructs the mirror configuration
passing `name` to str.format. However, the callback receives the `name` (and
`url`) as bytes, so str.format would return something like this:

    "remote.b'origin'.mirror"

This commit fixes the code example by decoding `name` when used with str.format.

The invocation of `repo.remotes.create` in the same example works fine as is,
because that function invokes `to_bytes` on its arguments, and `to_bytes` is a
noop when passed bytes.
