### PR TITLE
build: requires libgit2 1.2.x

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -32,8 +32,8 @@
 #include <Python.h>
 #include <git2.h>
 
-#if !(LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR == 1)
-#error You need a compatible libgit2 version (1.1.x)
+#if !(LIBGIT2_VER_MAJOR == 1 && (LIBGIT2_VER_MINOR == 1 || LIBGIT2_VER_MINOR == 2))
+#error You need a compatible libgit2 version (1.1.x or 1.2.x)
 #endif
 
 /*


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/84518

```
  src/types.h:36:2: error: You need a compatible libgit2 version (1.1.x)
  #error You need a compatible libgit2 version (1.1.x)
   ^
```