### PR TITLE
fetch wheel from macos11.pkg for Python3.10

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,7 +57,8 @@ jobs:
 
     - name: Setup python
       run: |
-        PKG="python-${{ matrix.py.release }}-macosx10.9.pkg"
+        [[ ${{ matrix.py.ver }} == "3.10" ]] && MACOS_VERSION="macos11" || MACOS_VERSION="macosx10.9"
+        PKG="python-${{ matrix.py.release }}-$MACOS_VERSION.pkg"
         URL="https://www.python.org/ftp/python/${{ matrix.py.release }}/$PKG"
         wget --no-verbose -N "$URL"
         sudo installer -pkg $PKG -target /


### PR DESCRIPTION
I still haven't been able to build wheel in macos yet. `bdist_wheel` builds platform-based wheel locally but it builds universal wheel on the CI.

See: https://github.com/skshetry/pygit2/runs/3816156599?check_suite_focus=true#step:4:579

Any help on this would be appreciated. Thanks. 