### PR TITLE
Fixes #962: First create a git_patch to get delta->flags correctly

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -505,6 +505,17 @@ PyTypeObject DiffIterType = {
 PyObject *
 diff_get_delta_byindex(git_diff *diff, size_t idx)
 {
+    git_patch *patch = NULL;
+    int err;
+
+    /* create a git_patch in order to store delta->flags */
+    err = git_patch_from_diff(&patch, diff, idx);
+    if (err < 0) {
+        PyErr_SetObject(PyExc_IndexError, PyLong_FromSize_t(idx));
+        return NULL;
+    }
+    git_patch_free(patch);
+
     const git_diff_delta *delta = git_diff_get_delta(diff, idx);
     if (delta == NULL) {
         PyErr_SetObject(PyExc_IndexError, PyLong_FromSize_t(idx));

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -319,9 +319,7 @@ def test_deltas(barerepo):
         assert delta.nfiles == patch_delta.nfiles
         assert delta.old_file.id == patch_delta.old_file.id
         assert delta.new_file.id == patch_delta.new_file.id
-
-        # As explained in the libgit2 documentation, flags are not set
-        #assert delta.flags == patch_delta.flags
+        assert delta.flags == patch_delta.flags
 
 def test_diff_parse(barerepo):
     diff = pygit2.Diff.parse_diff(PATCH)


### PR DESCRIPTION
diff_get_delta_byindex() may result incorrect value of delta->flags 
as described in the comment of git_diff_get_delta() (git2/diff.h)

```
Note that the flags on the delta related to whether it has binary
content or not may not be set if there are no attributes set for the
file and there has been no reason to load the file data at this point.
For now, if you need those flags to be up to date, your only option is
to either use `git_diff_foreach` or create a `git_patch`.
```

this pull request fixes #962 