### PR TITLE
ci/appveyor: build Python 3.10 wheel for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,10 @@ environment:
     PYTHON: 'C:\Python39\python.exe'
   - GENERATOR: 'Visual Studio 14 Win64'
     PYTHON: 'C:\Python39-x64\python.exe'
+  - GENERATOR: 'Visual Studio 14'
+    PYTHON: 'C:\Python310\python.exe'
+  - GENERATOR: 'Visual Studio 14 Win64'
+    PYTHON: 'C:\Python310-x64\python.exe'
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Appveyor now has a support for the Python 3.10: https://github.com/appveyor/ci/issues/3741#issuecomment-958837889