### PR TITLE
Added Repository.merge_base_many and Repository.merge_base_octopus

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -192,3 +192,4 @@ Authors::
   chengyuhang
   earl
   odidev
+  Filip Rindler

--- a/docs/merge.rst
+++ b/docs/merge.rst
@@ -55,3 +55,17 @@ in-memory Index representing the result of the merge.
 
 .. automethod:: pygit2.Repository.merge_commits
 .. automethod:: pygit2.Repository.merge_trees
+
+
+N-way merges
+============
+
+The following methods perform the calculation for a base to an n-way merge.
+
+.. automethod:: pygit2.Repository.merge_base_many
+.. automethod:: pygit2.Repository.merge_base_octopus
+
+With this base at hand one can do repeated invokations of
+:py:meth:`.Repository.merge_commits` and :py:meth:`.Repository.merge_trees`
+to perform the actual merge into one tree (and deal with conflicts along the
+way).

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -220,3 +220,37 @@ def test_merge_options():
         | C.GIT_MERGE_FILE_IGNORE_WHITESPACE
         | C.GIT_MERGE_FILE_DIFF_PATIENCE
     )
+
+
+def test_merge_many(mergerepo):
+    branch_head_hex = '03490f16b15a09913edb3a067a3dc67fbb8d41f1'
+    branch_id = mergerepo.get(branch_head_hex).id
+    ancestor_id = mergerepo.merge_base_many([mergerepo.head.target, branch_id])
+
+    merge_index = mergerepo.merge_trees(ancestor_id, mergerepo.head.target, branch_head_hex)
+    assert merge_index.conflicts is None
+    merge_commits_tree = merge_index.write_tree(mergerepo)
+
+    mergerepo.merge(branch_id)
+    index = mergerepo.index
+    assert index.conflicts is None
+    merge_tree = index.write_tree()
+
+    assert merge_tree == merge_commits_tree
+
+
+def test_merge_octopus(mergerepo):
+    branch_head_hex = '03490f16b15a09913edb3a067a3dc67fbb8d41f1'
+    branch_id = mergerepo.get(branch_head_hex).id
+    ancestor_id = mergerepo.merge_base_octopus([mergerepo.head.target, branch_id])
+
+    merge_index = mergerepo.merge_trees(ancestor_id, mergerepo.head.target, branch_head_hex)
+    assert merge_index.conflicts is None
+    merge_commits_tree = merge_index.write_tree(mergerepo)
+
+    mergerepo.merge(branch_id)
+    index = mergerepo.index
+    assert index.conflicts is None
+    merge_tree = index.write_tree()
+
+    assert merge_tree == merge_commits_tree


### PR DESCRIPTION
This provides an interface to git_merge_base_many and git_merge_base_octopus. One can then repeatedly merge things using merge_trees.