### PR TITLE
Add `str()` and `repr()` support to `Signature` type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@
 
 - CI: various fixes after migration to libgit2 v1.4
 
-- New ``Signature`` supports ``str()``
+- New ``Signature`` supports ``str()`` and ``repr()``
   `#1135 <https://github.com/libgit2/pygit2/pull/1135>`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@
 
 - CI: various fixes after migration to libgit2 v1.4
 
+- New ``Signature`` supports ``str()``
+  `#1135 <https://github.com/libgit2/pygit2/pull/1135>`_
+
 
 1.9.0 (2022-02-22)
 -------------------------

--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -221,7 +221,7 @@ The author and committer attributes of commit objects are ``Signature``
 objects::
 
     >>> commit.author
-    <pygit2.Signature object at 0x7f75e9b1f5f8>
+    pygit2.Signature('Foo Ibáñez', 'foo@example.com', 1322174594, 60, 'utf-8')
 
 Signatures can be compared for (in)equality.
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -233,6 +233,26 @@ Signature__str__(Signature *self)
     return str;
 }
 
+PyObject *
+Signature__repr__(Signature *self)
+{
+    PyObject *name, *email, *encoding, *str;
+    name = to_unicode(self->signature->name, self->encoding, NULL);
+    email = to_unicode(self->signature->email, self->encoding, NULL);
+    encoding = to_unicode(self->encoding, self->encoding, NULL);
+    str = PyUnicode_FromFormat(
+        "pygit2.Signature(%R, %R, %lld, %ld, %R)",
+        name,
+        email,
+        self->signature->when.time,
+        self->signature->when.offset,
+        encoding);
+    Py_DECREF(name);
+    Py_DECREF(email);
+    Py_DECREF(encoding);
+    return str;
+}
+
 
 PyDoc_STRVAR(Signature__doc__, "Signature.");
 
@@ -246,7 +266,7 @@ PyTypeObject SignatureType = {
     0,                                         /* tp_getattr        */
     0,                                         /* tp_setattr        */
     0,                                         /* tp_compare        */
-    0,                                         /* tp_repr           */
+    Signature__repr__,                         /* tp_repr           */
     0,                                         /* tp_as_number      */
     0,                                         /* tp_as_sequence    */
     0,                                         /* tp_as_mapping     */

--- a/src/signature.c
+++ b/src/signature.c
@@ -221,6 +221,18 @@ Signature_richcompare(PyObject *a, PyObject *b, int op)
 
 }
 
+PyObject *
+Signature__str__(Signature *self)
+{
+    PyObject *name, *email, *str;
+    name = to_unicode(self->signature->name, self->encoding, NULL);
+    email = to_unicode(self->signature->email, self->encoding, NULL);
+    str = PyUnicode_FromFormat("%U <%U>", name, email);
+    Py_DECREF(name);
+    Py_DECREF(email);
+    return str;
+}
+
 
 PyDoc_STRVAR(Signature__doc__, "Signature.");
 
@@ -240,7 +252,7 @@ PyTypeObject SignatureType = {
     0,                                         /* tp_as_mapping     */
     0,                                         /* tp_hash           */
     0,                                         /* tp_call           */
-    0,                                         /* tp_str            */
+    Signature__str__,                          /* tp_str            */
     0,                                         /* tp_getattro       */
     0,                                         /* tp_setattro       */
     0,                                         /* tp_as_buffer      */

--- a/test/test_signature.py
+++ b/test/test_signature.py
@@ -68,3 +68,10 @@ def test_now():
 def test_str():
     signature = Signature('Foo Ibáñez', 'foo@example.com', encoding='utf-8')
     assert str(signature) == 'Foo Ibáñez <foo@example.com>'
+
+def test_repr():
+    signature = Signature(
+        'Foo Ibáñez', 'foo@bar.com', 1322174594, 60, encoding='utf-8')
+    expected_signature = \
+        "pygit2.Signature('Foo Ibáñez', 'foo@bar.com', 1322174594, 60, 'utf-8')"
+    assert repr(signature) == expected_signature

--- a/test/test_signature.py
+++ b/test/test_signature.py
@@ -64,3 +64,7 @@ def test_now():
     assert signature.email == signature.raw_email.decode(encoding)
     assert signature.email.encode(encoding) == signature.raw_email
     assert abs(signature.time - time.time()) < 5
+
+def test_str():
+    signature = Signature('Foo Ibáñez', 'foo@example.com', encoding='utf-8')
+    assert str(signature) == 'Foo Ibáñez <foo@example.com>'


### PR DESCRIPTION
For better logging and easier debugging, this patch adds `str()` and `repr()` support to `Signature` type.