### PR TITLE
Remove redundant to_bytes in remote fetch

### DIFF
--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -137,7 +137,6 @@ class Remote:
             * `True` to enable automatic proxy detection
             * an url to a proxy (`http://proxy.example.org:3128/`)
         """
-        message = to_bytes(message)
         with git_fetch_options(callbacks) as payload:
             opts = payload.fetch_options
             opts.prune = prune


### PR DESCRIPTION
Encoded again just below in
```
err = C.git_remote_fetch(self._remote, arr, opts, to_bytes(message))
```