### PR TITLE
bump cibuildwheel to 2.9.0 to build Python 3.11 wheels, also test on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
         - os: ubuntu-20.04
           python-version: '3.10'
         - os: ubuntu-20.04
+          python-version: '3.11-dev'
+        - os: ubuntu-20.04
           python-version: pypy3
         - os: macos-latest
           python-version: 3.7

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,7 +28,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.4.0
+        uses: pypa/cibuildwheel@v2.9.0
         env:
           CIBW_BEFORE_ALL: sh build.sh
           CIBW_ENVIRONMENT: LIBGIT2_VERSION=1.5.0 LIBSSH2_VERSION=1.10.0 LIBGIT2=/project/ci


### PR DESCRIPTION
[Python 3.11.0rc1 is now released](https://pythoninsider.blogspot.com/2022/08/python-3110rc1-is-now-available.html), which is guaranteed to be ABI compatible with the final release.
And [the cibuildwheel v2.9.0 release](https://github.com/pypa/cibuildwheel/releases/tag/v2.9.0) includes Python 3.11 and builds wheels by default.

I also added a CI job to test with Python 3.11 in Linux so that any issues are caught. After final
release, we can remove the Python 3.10 version with 3.11 and reduce matrix that we are testing now.

Here's the GHA log for building wheels on my fork: https://github.com/skshetry/pygit2/actions/runs/2851936137.