### PR TITLE
Fix Signature repr()

### DIFF
--- a/pygit2/_pygit2.pyi
+++ b/pygit2/_pygit2.pyi
@@ -506,7 +506,7 @@ class RevSpec:
     to_object: Object
 
 class Signature:
-    _encoding: str
+    _encoding: str | None
     _pointer: bytes
     email: str
     name: str
@@ -514,7 +514,7 @@ class Signature:
     raw_email: bytes
     raw_name: bytes
     time: int
-    def __init__(self, name: str, email: str, time: int, offset: int, encoding: str) -> None: ...
+    def __init__(self, name: str, email: str, time: int, offset: int, encoding: str | None) -> None: ...
     def __eq__(self, other) -> bool: ...
     def __ge__(self, other) -> bool: ...
     def __gt__(self, other) -> bool: ...

--- a/src/utils.h
+++ b/src/utils.h
@@ -84,6 +84,8 @@ to_unicode_n(const char *value, size_t len, const char *encoding,
     return PyUnicode_Decode(value, len, encoding, errors);
 }
 
+#define value_or_default(x, _default) ((x) == NULL ? (_default) : (x))
+
 const char* pgit_borrow(PyObject *value);
 const char* pgit_borrow_encoding(PyObject *value, const char *encoding, const char *errors, PyObject **tvalue);
 char* pgit_encode(PyObject *value, const char *encoding);

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -142,8 +142,10 @@ def test_amend_commit_metadata(barerepo):
 
     encoding = 'iso-8859-1'
     amended_message = "Amended commit message.\n\nMessage with non-ascii chars: ééé.\n"
-    amended_author = Signature('Jane Author', 'jane@example.com', 12345, 0)
-    amended_committer = Signature('John Committer', 'john@example.com', 12346, 0)
+    amended_author = Signature(
+        'Jane Author', 'jane@example.com', 12345, 0, encoding=encoding)
+    amended_committer = Signature(
+        'John Committer', 'john@example.com', 12346, 0, encoding=encoding)
 
     amended_oid = repo.amend_commit(
         commit, 'HEAD', message=amended_message, author=amended_author,

--- a/test/test_signature.py
+++ b/test/test_signature.py
@@ -54,6 +54,14 @@ def test_latin1():
     assert signature.email == signature.raw_email.decode(encoding)
     assert signature.email.encode(encoding) == signature.raw_email
 
+def test_none():
+    signature = Signature('Foo Ibáñez', 'foo@example.com', encoding=None)
+    assert signature._encoding is None
+    assert signature.name == signature.raw_name.decode('utf-8')
+    assert signature.name.encode('utf-8') == signature.raw_name
+    assert signature.email == signature.raw_email.decode('utf-8')
+    assert signature.email.encode('utf-8') == signature.raw_email
+
 def test_now():
     encoding = 'utf-8'
     signature = Signature(
@@ -75,3 +83,15 @@ def test_repr():
     expected_signature = \
         "pygit2.Signature('Foo Ibáñez', 'foo@bar.com', 1322174594, 60, 'utf-8')"
     assert repr(signature) == expected_signature
+
+def test_repr_from_commit(barerepo):
+    repo = barerepo
+    signature = Signature('Foo Ibáñez', 'foo@example.com', encoding=None)
+    tree = '967fce8df97cc71722d3c2a5930ef3e6f1d27b12'
+    parents = ['5fe808e8953c12735680c257f56600cb0de44b10']
+    sha = repo.create_commit(
+        None, signature, signature, 'New commit.', tree, parents)
+    commit = repo[sha]
+
+    assert repr(signature) == repr(commit.author)
+    assert repr(signature) == repr(commit.committer)


### PR DESCRIPTION
`to_unicode()` expects a non-NULL `x` argument (due to `strlen(x)`);
however `self->encoding` _may_ be NULL, especially if built with
`build_signature()` (i.e. if called from the `commit.author` property).

As a result, any `repr()` on a `Signature` with a NULL `encoding` will
cause a segfault.

Other functions manually map NULL to "utf-8" (see
`Signature__encoding__get__()`), so we'll do the same thing here.