### PR TITLE
Remove decrement of reference when using Py_None #1161

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -202,3 +202,4 @@ Authors::
   chengyuhang
   earl
   odidev
+  siscia

--- a/src/signature.c
+++ b/src/signature.c
@@ -246,6 +246,7 @@ Signature__repr__(Signature *self)
         encoding = to_unicode(self->encoding, self->encoding, NULL);
     } else {
         encoding = Py_None;
+        Py_INCREF(Py_None);
     }
 
     str = PyUnicode_FromFormat(


### PR DESCRIPTION
Addressing #1161 

If the representation of a signature requires the use of `Py_None` we should not decrement the reference count of the special `Py_None` object.

I tried adding a unit test to verify this new behavior, unfortunately, all the unit test I could come up with were not triggering the bug.

This was tested against the reproduce example in the issue setting the env var PYTHONPATH.