### PR TITLE
RemoteCallbacks.push_update_reference: pass refname as a string

### DIFF
--- a/pygit2/callbacks.py
+++ b/pygit2/callbacks.py
@@ -481,7 +481,7 @@ def _push_update_reference_cb(ref, msg, data):
     if not push_update_reference:
         return 0
 
-    refname = ffi.string(ref)
+    refname = maybe_string(ref)
     message = maybe_string(msg)
     push_update_reference(refname, message)
     return 0


### PR DESCRIPTION
refname was passed to push_update_reference as bytes.
However, the docstring for push_update_reference says refname is a string.
Also, refname is already passed as a string to another callback (update_tips).