### PR TITLE
Fix Signature memory leak

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -81,13 +81,15 @@ Signature_init(Signature *self, PyObject *args, PyObject *kwds)
 void
 Signature_dealloc(Signature *self)
 {
-    /* self->obj is the owner of the git_signature, so we musn't free it */
+    /* self->obj is the owner of the git_signature C structure, so we musn't free it */
     if (self->obj) {
         Py_CLEAR(self->obj);
     } else {
         git_signature_free((git_signature *) self->signature);
-        free(self->encoding);
     }
+
+    /* we own self->encoding */
+    free(self->encoding);
 
     PyObject_Del(self);
 }


### PR DESCRIPTION
`encoding` is strdup'd in `build_signature` regardless of whether the Signature has an owner.

So, `Signature_dealloc` must always free `encoding`.