### PR TITLE
ci/appveyor: build Python3.11 wheel for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,10 @@ environment:
     PYTHON: 'C:\Python310\python.exe'
   - GENERATOR: 'Visual Studio 14 Win64'
     PYTHON: 'C:\Python310-x64\python.exe'
+  - GENERATOR: 'Visual Studio 14'
+    PYTHON: 'C:\Python311\python.exe'
+  - GENERATOR: 'Visual Studio 14 Win64'
+    PYTHON: 'C:\Python311-x64\python.exe'
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Appveyor now has support for Python 3.11.
See https://github.com/appveyor/ci/issues/3844 and https://www.appveyor.com/updates/2022/11/07.

Related: https://github.com/libgit2/pygit2/pull/1154.