### PR TITLE
Add ConflictCollection.__contains__

### DIFF
--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -427,6 +427,19 @@ class ConflictCollection:
     def __iter__(self):
         return ConflictIterator(self._index)
 
+    def __contains__(self, path):
+        cancestor = ffi.new('git_index_entry **')
+        cours = ffi.new('git_index_entry **')
+        ctheirs = ffi.new('git_index_entry **')
+
+        err = C.git_index_conflict_get(cancestor, cours, ctheirs,
+                                       self._index._index, to_bytes(path))
+        if err == C.GIT_ENOTFOUND:
+            return False
+
+        check_error(err)
+        return True
+
 
 class ConflictIterator:
 

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -100,6 +100,8 @@ def test_merge_no_fastforward_conflicts(mergerepo):
     assert mergerepo.index.conflicts is not None
     with pytest.raises(KeyError):
         mergerepo.index.conflicts.__getitem__('some-file')
+    assert 'some-file' not in mergerepo.index.conflicts
+    assert '.gitignore' in mergerepo.index.conflicts
 
     status = pygit2.GIT_STATUS_CONFLICTED
     # Asking twice to assure the reference counting is correct
@@ -126,12 +128,14 @@ def test_merge_remove_conflicts(mergerepo):
     idx = mergerepo.index
     conflicts = idx.conflicts
     assert conflicts is not None
+    assert '.gitignore' in conflicts
     try:
         conflicts['.gitignore']
     except KeyError:
         mergerepo.fail("conflicts['.gitignore'] raised KeyError unexpectedly")
     del idx.conflicts['.gitignore']
     with pytest.raises(KeyError): conflicts.__getitem__('.gitignore')
+    assert '.gitignore' not in conflicts
     assert idx.conflicts is None
 
 


### PR DESCRIPTION
This PR makes it possible to use the `in` operator with a ConflictCollection, e.g.:
```python
does_it_conflict = "some_path" in repo.index.conflicts
```