### PR TITLE
Improve write_archive performance

### DIFF
--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -1208,7 +1208,7 @@ class BaseRepository(_Repository):
                 info.size = 0
                 archive.addfile(info)
             else:
-                info.mode = tree[entry.path].filemode
+                info.mode = entry.mode
                 archive.addfile(info, BytesIO(content))
 
     #


### PR DESCRIPTION
Accessing each item in the tree during this loop slows down the `write_archive` method significantly when dealing with repositories with a large nr of files.

On a repository of ~5000 files the archiving time went from `13s` to `0.5s`.  
From what I can tell when testing `tree[entry.path].filemode` and `entry.mode` are the same.