### PR TITLE
Test with and build Python 3.12 wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         - os: ubuntu-20.04
           python-version: 3.8
         - os: ubuntu-20.04
-          python-version: '3.11'
+          python-version: '3.12-dev'
         - os: ubuntu-20.04
           python-version: 'pypy3.9'
         - os: macos-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
           platforms: all
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.12.1
+        run: python -m pip install cibuildwheel==2.13.1
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cffi>=1.9.1
+setuptools ; python_version >= "3.12"


### PR DESCRIPTION
Thanks for the great library :heart:!

Python 3.12.0 b3 is out, and the first RC will be out in July. Building a wheel now will allow other projects that depend on pygit2 to test with Python 3.12 without manually building libgit2.

This PR updates the version used for CI tests to 3.12-dev and updates cibuildwheel to get beta 3.12 support.