### PR TITLE
remotes: support anonymous remotes

### DIFF
--- a/pygit2/decl/remote.h
+++ b/pygit2/decl/remote.h
@@ -105,6 +105,10 @@ int git_remote_create_with_fetchspec(
 		const char *name,
 		const char *url,
 		const char *fetch);
+int git_remote_create_anonymous(
+        git_remote **out,
+        git_repository *repo,
+        const char *url);
 int git_remote_delete(git_repository *repo, const char *name);
 const char * git_remote_name(const git_remote *remote);
 int git_remote_rename(

--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -344,6 +344,16 @@ class RemoteCollection:
 
         return Remote(self._repo, cremote[0])
 
+    def create_anonymous(self, url):
+        """Create a new anonymous (in-memory only) remote with the given URL.
+        Returns a <Remote> object.
+        """
+        cremote = ffi.new('git_remote **')
+        url = to_bytes(url)
+        err = C.git_remote_create_anonymous(cremote, self._repo._repo, url)
+        check_error(err)
+        return Remote(self._repo, cremote[0])
+
     def rename(self, name, new_name):
         """Rename a remote in the configuration. The refspecs in standard
         format will be renamed.

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -69,6 +69,16 @@ def test_remote_create_with_refspec(testrepo):
     assert [fetch] == remote.fetch_refspecs
     assert remote.push_url is None
 
+def test_remote_create_anonymous(testrepo):
+    url = 'https://github.com/libgit2/pygit2.git'
+
+    remote = testrepo.remotes.create_anonymous(url)
+    assert remote.name is None
+    assert url == remote.url
+    assert remote.push_url is None
+    assert [] == remote.fetch_refspecs
+    assert [] == remote.push_refspecs
+
 def test_remote_delete(testrepo):
     name = 'upstream'
     url = 'https://github.com/libgit2/pygit2.git'


### PR DESCRIPTION
Adds support for `git_remote_create_anonymous` for creating anonymous (in-memory) remotes when you have a URL but do not want to create a named remote and the associated config entries