### PR TITLE
Remove outdated log_append example

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -62,23 +62,6 @@ The Reference type
 
    .. automethod:: log
 
-      Example::
-
-         >>> branch = repository.references["refs/heads/master"]
-         >>> branch.target = another_commit.id
-         >>> committer = Signature('Cecil Committer', 'cecil@committers.tld')
-         >>> branch.log_append(another_commit.id, committer,
-                               "changed branch target using pygit2")
-
-      This creates a reflog entry in ``git reflog master`` which looks like::
-
-         7296b92 master@{10}: changed branch target using pygit2
-
-      In order to make an entry in ``git reflog``, ie. the reflog for ``HEAD``, you
-      have to get the Reference object for ``HEAD`` and call ``log_append`` on
-      that.
-
-
 The HEAD
 ====================
 


### PR DESCRIPTION
The `Reference.log_append` method was removed 9 years ago in f35f58ca455c869263c97b28f77435fe626526ae. This removes an outdated reference to it in the documentation.

I think what happened here is that when the documentation was updated in 70410349ff6baf0714b671a6811e67770e672c89 to remove `log_append`, the example didn't get removed and instead was accidentally left under `log`.