### PR TITLE
filter: fix FilterSource bugs

### DIFF
--- a/pygit2/filter.py
+++ b/pygit2/filter.py
@@ -23,7 +23,7 @@
 # the Free Software Foundation, 51 Franklin Street, Fifth Floor,
 # Boston, MA 02110-1301, USA.
 
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 from ._pygit2 import FilterSource
 
@@ -58,7 +58,7 @@ class Filter:
     def nattrs(cls) -> int:
         return len(cls.attributes.split())
 
-    def check(self, src: FilterSource, attr_values: List[str]):
+    def check(self, src: FilterSource, attr_values: List[Optional[str]]):
         """
         Check whether this filter should be applied to the given source.
 

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -36,6 +36,8 @@ class _BufferedFilter(pygit2.Filter):
 class _PassthroughFilter(_Rot13Filter):
 
     def check(self, src, attr_values):
+        assert attr_values == [None]
+        assert src.repo
         raise Passthrough
 
 


### PR DESCRIPTION
Follow up for https://github.com/libgit2/pygit2/pull/1237

- Exposes `FilterSource.mode` which was documented but missing a getter
- Fixes potential NULL `FilterSource.repo` handling and `FilterSource.repo` refcounting
- Fixes `Filter.check(..., attr_values)` list being shifted off by one (with an extra null/none value at index 0)