### PR TITLE
add `depth` option to `clone_repository()`

### DIFF
--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -201,7 +201,7 @@ def init_repository(path, bare=False,
 
 def clone_repository(
         url, path, bare=False, repository=None, remote=None,
-        checkout_branch=None, callbacks=None):
+        checkout_branch=None, callbacks=None, depth=0):
     """
     Clones a new Git repository from *url* in the given *path*.
 
@@ -235,6 +235,12 @@ def clone_repository(
 
         The callbacks should be an object which inherits from
         `pyclass:RemoteCallbacks`.
+    depth : int
+        Number of commits to clone.
+
+        If greater than 0, creates a shallow clone with a history truncated to
+        the specified number of commits.
+        The default is 0 (full commit history).
     """
 
     if callbacks is None:
@@ -248,6 +254,7 @@ def clone_repository(
     with git_clone_options(payload):
         opts = payload.clone_options
         opts.bare = bare
+        opts.fetch_opts.depth = depth
 
         if checkout_branch:
             checkout_branch_ref = ffi.new('char []', to_bytes(checkout_branch))

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -578,6 +578,15 @@ def test_clone_bare_repository(barerepo, tmp_path):
     assert not repo.is_empty
     assert repo.is_bare
 
+@utils.requires_network
+def test_clone_shallow_repository(tmp_path):
+    # shallow cloning currently only works with remote repositories
+    url = 'https://github.com/libgit2/TestGitRepository'
+    repo = clone_repository(url, tmp_path / 'clone-shallow', depth=1)
+    assert not repo.is_empty
+    assert repo.is_shallow
+
+
 def test_clone_repository_and_remote_callbacks(barerepo, tmp_path):
     url = Path(barerepo.path).resolve().as_uri()
     repo_path = tmp_path / 'clone-into'


### PR DESCRIPTION
This adds a `depth` option to `clone_repository()` for shallow clones, which has been supported since libgit2 1.7.0: https://github.com/libgit2/libgit2/commit/190a4c55df72b32adf4d60f77cbc47276b74f84b

Note: The test for the shallow clone is currently online only due to libgit2 only supporting shallow clones of remote repositories. The git cli allows you to shallow clone a local repository if you use a file URI, but it seems that libgit2 doesn't support that.

fixes #1243 