### PR TITLE
remote: add `depth` option to `fetch()`

### DIFF
--- a/pygit2/remote.py
+++ b/pygit2/remote.py
@@ -111,7 +111,7 @@ class Remote:
                                        ffi.NULL)
             payload.check_error(err)
 
-    def fetch(self, refspecs=None, message=None, callbacks=None, prune=C.GIT_FETCH_PRUNE_UNSPECIFIED, proxy=None):
+    def fetch(self, refspecs=None, message=None, callbacks=None, prune=C.GIT_FETCH_PRUNE_UNSPECIFIED, proxy=None, depth=0):
         """Perform a fetch against this remote. Returns a <TransferProgress>
         object.
 
@@ -130,10 +130,18 @@ class Remote:
             * `None` (the default) to disable proxy usage
             * `True` to enable automatic proxy detection
             * an url to a proxy (`http://proxy.example.org:3128/`)
+        
+        depth : int
+            Number of commits from the tip of each remote branch history to fetch.
+        
+            If non-zero, the number of commits from the tip of each remote
+            branch history to fetch. If zero, all history is fetched.
+            The default is 0 (all history is fetched).
         """
         with git_fetch_options(callbacks) as payload:
             opts = payload.fetch_options
             opts.prune = prune
+            opts.depth = depth
             self.__set_proxy(opts.proxy_opts, proxy)
             with StrArray(refspecs) as arr:
                 err = C.git_remote_fetch(self._remote, arr, opts, to_bytes(message))

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -40,6 +40,9 @@ REMOTE_FETCHSPEC_SRC = 'refs/heads/*'
 REMOTE_FETCHSPEC_DST = 'refs/remotes/origin/*'
 REMOTE_REPO_OBJECTS = 30
 REMOTE_REPO_BYTES = 2758
+REMOTE_FETCHTEST_FETCHSPECS = ["refs/tags/v1.13.2"]
+REMOTE_REPO_FETCH_ALL_OBJECTS = 13276
+REMOTE_REPO_FETCH_HEAD_COMMIT_OBJECTS = 238
 
 ORIGIN_REFSPEC = '+refs/heads/*:refs/remotes/origin/*'
 
@@ -215,6 +218,18 @@ def test_fetch(emptyrepo):
     assert stats.received_bytes == REMOTE_REPO_BYTES
     assert stats.indexed_objects == REMOTE_REPO_OBJECTS
     assert stats.received_objects == REMOTE_REPO_OBJECTS
+
+def test_fetch_depth_zero(testrepo):
+    remote = testrepo.remotes[0]
+    stats = remote.fetch(REMOTE_FETCHTEST_FETCHSPECS, depth=0)
+    assert stats.indexed_objects == REMOTE_REPO_FETCH_ALL_OBJECTS
+    assert stats.received_objects == REMOTE_REPO_FETCH_ALL_OBJECTS
+
+def test_fetch_depth_one(testrepo):
+    remote = testrepo.remotes[0]
+    stats = remote.fetch(REMOTE_FETCHTEST_FETCHSPECS, depth=1)
+    assert stats.indexed_objects == REMOTE_REPO_FETCH_HEAD_COMMIT_OBJECTS
+    assert stats.received_objects == REMOTE_REPO_FETCH_HEAD_COMMIT_OBJECTS
 
 def test_transfer_progress(emptyrepo):
     class MyCallbacks(pygit2.RemoteCallbacks):


### PR DESCRIPTION
Adds `depth` option to `fetch()`.