### PR TITLE
Release GIL in Walker.__next__

### DIFF
--- a/src/walker.c
+++ b/src/walker.c
@@ -149,7 +149,10 @@ Walker_iternext(Walker *self)
     git_commit *commit;
     git_oid oid;
 
+    Py_BEGIN_ALLOW_THREADS
     err = git_revwalk_next(&oid, self->walk);
+    Py_END_ALLOW_THREADS
+
     if (err < 0)
         return Error_set(err);
 


### PR DESCRIPTION
The first call to `git_revwalk_next` may take a while to complete in large repositories – sometimes a couple of seconds.

This PR releases the Global Interpreter Lock (GIL) during `git_revwalk_next` to avoid locking up multithreaded applications. (Note: cffi wraps C function calls in a similar fashion.)

A possible use case for this is to keep a GUI application responsive while a background thread is iterating on a Walker. Before this change, pygit2 would hold onto the GIL while calling into git_revwalk_next, causing the UI thread to freeze.