### PR TITLE
docs: fix typo on `CRLFFilter` example

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -46,7 +46,7 @@ setting.
 
                 if eol == 'crlf':
                     self.linesep = b'\r\n'
-                elif eol = 'lf':
+                elif eol == 'lf':
                     self.linesep = b'\n'
             else:  # src.mode == GIT_FILTER_CLEAN
                 # always use LF line-endings when writing to the ODB


### PR DESCRIPTION
Iterative fixes. 😸 