### PR TITLE
Return Python enums from _pygit2

### DIFF
--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -59,6 +59,11 @@ features = enums.Feature(C.git_libgit2_features())
 # libgit version tuple
 LIBGIT2_VER = (LIBGIT2_VER_MAJOR, LIBGIT2_VER_MINOR, LIBGIT2_VER_REVISION)
 
+# Let _pygit2 cache references to Python enum types.
+# This is separate from PyInit__pygit2() to avoid a circular import.
+cache_enums()
+del cache_enums  # Don't expose this to user code
+
 
 def init_repository(
         path: typing.Union[str, bytes, PathLike, None],

--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -30,6 +30,7 @@ import typing
 
 # Low level API
 from ._pygit2 import *
+from ._pygit2 import _cache_enums
 
 # High level API
 from . import enums
@@ -61,8 +62,7 @@ LIBGIT2_VER = (LIBGIT2_VER_MAJOR, LIBGIT2_VER_MINOR, LIBGIT2_VER_REVISION)
 
 # Let _pygit2 cache references to Python enum types.
 # This is separate from PyInit__pygit2() to avoid a circular import.
-cache_enums()
-del cache_enums  # Don't expose this to user code
+_cache_enums()
 
 
 def init_repository(

--- a/pygit2/_pygit2.pyi
+++ b/pygit2/_pygit2.pyi
@@ -1,18 +1,23 @@
 from typing import Iterator, Literal, Optional, overload
 from io import IOBase
 from . import Index, Submodule
-from .enums import ApplyLocation
-from .enums import BranchType
-from .enums import DiffFind
-from .enums import DiffOption
-from .enums import DiffStatsFormat
-from .enums import MergeAnalysis
-from .enums import MergePreference
-from .enums import ObjectType
-from .enums import Option
-from .enums import ReferenceFilter
-from .enums import ResetMode
-from .enums import SortMode
+from .enums import (
+    ApplyLocation,
+    BranchType,
+    DiffFind,
+    DiffFlag,
+    DiffOption,
+    DiffStatsFormat,
+    FileMode,
+    FileStatus,
+    MergeAnalysis,
+    MergePreference,
+    ObjectType,
+    Option,
+    ReferenceFilter,
+    ResetMode,
+    SortMode,
+)
 
 GIT_OBJ_BLOB: Literal[3]
 GIT_OBJ_COMMIT: Literal[1]
@@ -139,19 +144,19 @@ class Diff:
     def __len__(self) -> int: ...
 
 class DiffDelta:
-    flags: int
+    flags: DiffFlag
     is_binary: bool
-    new_file: DiffFile
     nfiles: int
+    new_file: DiffFile
     old_file: DiffFile
     similarity: int
-    status: int
+    status: FileStatus
     def status_char(self) -> str: ...
 
 class DiffFile:
-    flags: int
+    flags: DiffFlag
     id: Oid
-    mode: int
+    mode: FileMode
     path: str
     raw_path: bytes
     size: int

--- a/src/diff.c
+++ b/src/diff.c
@@ -47,6 +47,10 @@ extern PyTypeObject DiffLineType;
 extern PyTypeObject DiffStatsType;
 extern PyTypeObject RepositoryType;
 
+extern PyObject *DeltaStatusEnum;
+extern PyObject *DiffFlagEnum;
+extern PyObject *FileModeEnum;
+
 PyObject *
 wrap_diff(git_diff *diff, Repository *repo)
 {
@@ -204,18 +208,42 @@ DiffFile_from_c(DiffFile *dummy, PyObject *py_diff_file_ptr)
     return wrap_diff_file(diff_file);
 }
 
+PyDoc_STRVAR(DiffFile_flags__doc__,
+    "A combination of enums.DiffFlag constants."
+);
+
+PyObject *
+DiffFile_flags__get__(DiffFile *self)
+{
+    return pygit2_enum(DiffFlagEnum, self->flags);
+}
+
+PyDoc_STRVAR(DiffFile_mode__doc__,
+    "Mode of the entry (an enums.FileMode constant)."
+);
+
+PyObject *
+DiffFile_mode__get__(DiffFile *self)
+{
+    return pygit2_enum(FileModeEnum, self->mode);
+}
+
 PyMemberDef DiffFile_members[] = {
     MEMBER(DiffFile, id, T_OBJECT, "Oid of the item."),
     MEMBER(DiffFile, path, T_STRING, "Path to the entry."),
     MEMBER(DiffFile, raw_path, T_OBJECT, "Path to the entry (bytes)."),
     MEMBER(DiffFile, size, T_LONG, "Size of the entry."),
-    MEMBER(DiffFile, flags, T_UINT, "Combination of GIT_DIFF_FLAG_* flags."),
-    MEMBER(DiffFile, mode, T_USHORT, "Mode of the entry."),
     {NULL}
 };
 
 PyMethodDef DiffFile_methods[] = {
     METHOD(DiffFile, from_c, METH_STATIC | METH_O),
+    {NULL},
+};
+
+PyGetSetDef DiffFile_getsetters[] = {
+    GETTER(DiffFile, flags),
+    GETTER(DiffFile, mode),
     {NULL},
 };
 
@@ -251,7 +279,7 @@ PyTypeObject DiffFileType = {
     0,                                         /* tp_iternext       */
     DiffFile_methods,                          /* tp_methods        */
     DiffFile_members,                          /* tp_members        */
-    0,                                         /* tp_getset         */
+    DiffFile_getsetters,                       /* tp_getset         */
     0,                                         /* tp_base           */
     0,                                         /* tp_dict           */
     0,                                         /* tp_descr_get      */
@@ -294,6 +322,26 @@ DiffDelta_is_binary__get__(DiffDelta *self)
     Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(DiffDelta_status__doc__,
+    "An enums.FileStatus constant."
+);
+
+PyObject *
+DiffDelta_status__get__(DiffDelta *self)
+{
+    return pygit2_enum(DeltaStatusEnum, self->status);
+}
+
+PyDoc_STRVAR(DiffDelta_flags__doc__,
+    "A combination of enums.DiffFlag constants."
+);
+
+PyObject *
+DiffDelta_flags__get__(DiffDelta *self)
+{
+    return pygit2_enum(DiffFlagEnum, self->flags);
+}
+
 static void
 DiffDelta_dealloc(DiffDelta *self)
 {
@@ -308,8 +356,6 @@ static PyMethodDef DiffDelta_methods[] = {
 };
 
 PyMemberDef DiffDelta_members[] = {
-    MEMBER(DiffDelta, status, T_UINT, "A GIT_DELTA_* constant."),
-    MEMBER(DiffDelta, flags, T_UINT, "Combination of GIT_DIFF_FLAG_* flags."),
     MEMBER(DiffDelta, similarity, T_USHORT, "For renamed and copied."),
     MEMBER(DiffDelta, nfiles, T_USHORT, "Number of files in the delta."),
     MEMBER(DiffDelta, old_file, T_OBJECT, "\"from\" side of the diff."),
@@ -319,6 +365,8 @@ PyMemberDef DiffDelta_members[] = {
 
 PyGetSetDef DiffDelta_getsetters[] = {
     GETTER(DiffDelta, is_binary),
+    GETTER(DiffDelta, status),
+    GETTER(DiffDelta, flags),
     {NULL}
 };
 

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -379,8 +379,8 @@ forget_enums(void)
     Py_CLEAR(MergePreferenceEnum);
 }
 
-PyDoc_STRVAR(cache_enums__doc__,
-    "cache_enums()\n"
+PyDoc_STRVAR(_cache_enums__doc__,
+    "_cache_enums()\n"
     "\n"
     "For internal use only. Do not call this from user code.\n"
     "\n"
@@ -388,7 +388,7 @@ PyDoc_STRVAR(cache_enums__doc__,
     "defined in pygit2.enums.\n");
 
 PyObject *
-cache_enums(PyObject *self, PyObject *args)
+_cache_enums(PyObject *self, PyObject *args)
 {
     (void) args;
 
@@ -439,7 +439,7 @@ PyMethodDef module_methods[] = {
     {"tree_entry_cmp", tree_entry_cmp, METH_VARARGS, tree_entry_cmp__doc__},
     {"filter_register", (PyCFunction)filter_register, METH_VARARGS | METH_KEYWORDS, filter_register__doc__},
     {"filter_unregister", filter_unregister, METH_VARARGS, filter_unregister__doc__},
-    {"cache_enums", cache_enums, METH_NOARGS, cache_enums__doc__},
+    {"_cache_enums", _cache_enums, METH_NOARGS, _cache_enums__doc__},
     {NULL}
 };
 

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -371,19 +371,12 @@ filter_unregister(PyObject *self, PyObject *args)
 static void
 forget_enums(void)
 {
-    Py_XDECREF(DeltaStatusEnum);
-    Py_XDECREF(DiffFlagEnum);
-    Py_XDECREF(FileModeEnum);
-    Py_XDECREF(FileStatusEnum);
-    Py_XDECREF(MergeAnalysisEnum);
-    Py_XDECREF(MergePreferenceEnum);
-
-    DeltaStatusEnum = NULL;
-    DiffFlagEnum = NULL;
-    FileModeEnum = NULL;
-    FileStatusEnum = NULL;
-    MergeAnalysisEnum = NULL;
-    MergePreferenceEnum = NULL;
+    Py_CLEAR(DeltaStatusEnum);
+    Py_CLEAR(DiffFlagEnum);
+    Py_CLEAR(FileModeEnum);
+    Py_CLEAR(FileStatusEnum);
+    Py_CLEAR(MergeAnalysisEnum);
+    Py_CLEAR(MergePreferenceEnum);
 }
 
 PyDoc_STRVAR(cache_enums__doc__,

--- a/src/utils.c
+++ b/src/utils.c
@@ -276,3 +276,18 @@ py_object_to_otype(PyObject *py_type)
     PyErr_SetString(PyExc_ValueError, "invalid target type");
     return GIT_OBJECT_INVALID; /* -1 */
 }
+
+
+/**
+ * Convert an integer to a reference to an IntEnum or IntFlag in pygit2.enums.
+ */
+PyObject *
+pygit2_enum(PyObject *enum_type, int value)
+{
+    if (!enum_type) {
+        PyErr_SetString(PyExc_TypeError, "an enum has not been cached in _pygit2.cache_enums()");
+        return NULL;
+    }
+    PyObject *enum_instance = PyObject_CallFunction(enum_type, "(i)", value);
+    return enum_instance;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -99,6 +99,11 @@ char* pgit_encode_fsdefault(PyObject *value);
 
 git_otype py_object_to_otype(PyObject *py_type);
 
+
+/* Enum utilities (pygit2.enums) */
+PyObject *pygit2_enum(PyObject *enum_type, int value);
+
+
 /* Helpers to make shorter PyMethodDef and PyGetSetDef blocks */
 #define METHOD(type, name, args)\
   {#name, (PyCFunction) type ## _ ## name, args, type ## _ ## name ## __doc__}


### PR DESCRIPTION
Following up on #1251: C functions in _pygit2 now return actual Python enums instead of ints.

For example, Repository.status() would previously return simple ints. Now it returns FileStatus which transparently demotes to ints for legacy code:
```pycon
>>> repo.status()
{'file1.txt': <FileStatus.CONFLICTED: 32768>,
 'file2.txt': <FileStatus.INDEX_MODIFIED|WT_MODIFIED: 258>}
```

Implementation details: References to the enums are cached via `cache_modules` so that lookups are faster. The references are decref'd in `free_module` (new module destructor function)

Affected functions:
- Repository.status
- Repository.status_file
- Repository.merge_analysis
- DiffFile.flags
- DiffFile.mode
- DiffDelta.flags
- DiffDelta.status