### PR TITLE
Fix git-cherry-pick.rst example.

### DIFF
--- a/docs/recipes/git-cherry-pick.rst
+++ b/docs/recipes/git-cherry-pick.rst
@@ -51,10 +51,9 @@ example `three-argument rebases`_.
     cherry = repo.revparse_single('9e044d03c')
     basket = repo.branches.get('basket')
 
-    base      = repo.merge_base(cherry.id, basket.target)
-    base_tree = cherry.parents[0].tree
+    base = repo.merge_base(cherry.id, basket.target)
 
-    index = repo.merge_trees(base_tree, basket, cherry)
+    index = repo.merge_trees(base, basket, cherry)
     tree_id = index.write_tree(repo)
 
     author    = cherry.author


### PR DESCRIPTION
Using the parent of the cherry-picked commit as ancestor is not correct sometimes. That looks to be an issue because `base` was not used at all in the example whereas it should be used as ancestor.