### PR TITLE
Re-Fix git-cherry-pick.rst

### DIFF
--- a/docs/recipes/git-cherry-pick.rst
+++ b/docs/recipes/git-cherry-pick.rst
@@ -51,9 +51,9 @@ example `three-argument rebases`_.
     cherry = repo.revparse_single('9e044d03c')
     basket = repo.branches.get('basket')
 
-    base = repo.merge_base(cherry.id, basket.target)
+    base_tree = cherry.parents[0].tree
 
-    index = repo.merge_trees(base, basket, cherry)
+    index = repo.merge_trees(base_tree, basket, cherry)
     tree_id = index.write_tree(repo)
 
     author    = cherry.author


### PR DESCRIPTION
The `base_tree` that must be used for a cherry pick is the cherry-picked commit parent.