### PR TITLE
Make merge API consistent with new enums

### DIFF
--- a/docs/merge.rst
+++ b/docs/merge.rst
@@ -19,10 +19,12 @@ branch reference in the case of a fastforward.
 
 Example::
 
+    >>> from pygit2.enums import MergeFavor, MergeFlag
     >>> other_branch_tip = '5ebeeebb320790caf276b9fc8b24546d63316533'
     >>> repo.merge(other_branch_tip)
-    >>> repo.merge(other_branch_tip, favor='ours')
-    >>> repo.merge(other_branch_tip, flags={'find_renames': False})
+    >>> repo.merge(other_branch_tip, favor=MergeFavor.OURS)
+    >>> repo.merge(other_branch_tip, flags=MergeFlag.FIND_RENAMES | MergeFlag.NO_RECURSIVE)
+    >>> repo.merge(other_branch_tip, flags=0)  # turn off FIND_RENAMES (on by default if flags omitted)
 
 You can now inspect the index file for conflicts and get back to the
 user to resolve if there are. Once there are no conflicts left, you

--- a/pygit2/decl/merge.h
+++ b/pygit2/decl/merge.h
@@ -5,6 +5,7 @@ typedef enum {
 	GIT_MERGE_FAIL_ON_CONFLICT = 2,
 	GIT_MERGE_SKIP_REUC = 4,
 	GIT_MERGE_NO_RECURSIVE = 8,
+	GIT_MERGE_VIRTUAL_BASE = (1 << 4),
 } git_merge_flag_t;
 
 typedef enum {
@@ -24,6 +25,8 @@ typedef enum {
 	GIT_MERGE_FILE_IGNORE_WHITESPACE_EOL = 32,
 	GIT_MERGE_FILE_DIFF_PATIENCE = 64,
 	GIT_MERGE_FILE_DIFF_MINIMAL = 128,
+	GIT_MERGE_FILE_STYLE_ZDIFF3 = (1 << 8),
+	GIT_MERGE_FILE_ACCEPT_CONFLICTS = (1 << 9),
 } git_merge_file_flag_t;
 
 typedef struct {


### PR DESCRIPTION
Merge functions now use new enums: MergeFavor, MergeFlag, MergeFileFlag.

These functions used to take a dict of strings to boolean flags (e.g. `flags={'no_recursive': True}`). Backward compatibility with this system was kept, and there are unit tests for that too.

As far as I'm aware, this system was only used in the merge functions and not anywhere else in pygit2. So, this PR aims to make these functions more consistent with the rest of the library, now that we use enums elsewhere.