### PR TITLE
Return Python enums from Object.filemode and Reference.type

### DIFF
--- a/pygit2/_pygit2.pyi
+++ b/pygit2/_pygit2.pyi
@@ -15,6 +15,7 @@ from .enums import (
     ObjectType,
     Option,
     ReferenceFilter,
+    ReferenceType,
     ResetMode,
     SortMode,
 )
@@ -69,7 +70,7 @@ class Reference:
     raw_target: Oid | bytes
     shorthand: str
     target: Oid | str
-    type: int
+    type: ReferenceType
     def __init__(self, *args) -> None: ...
     def delete(self) -> None: ...
     def log(self) -> Iterator[RefLogEntry]: ...

--- a/pygit2/_pygit2.pyi
+++ b/pygit2/_pygit2.pyi
@@ -34,7 +34,7 @@ LIBGIT2_VER_REVISION: int
 
 class Object:
     _pointer: bytes
-    filemode: int
+    filemode: FileMode
     hex: str
     id: Oid
     name: str | None

--- a/pygit2/enums.py
+++ b/pygit2/enums.py
@@ -1004,10 +1004,23 @@ class ReferenceFilter(IntEnum):
 class ReferenceType(IntFlag):
     """ Basic type of any Git reference. """
 
-    INVALID = _pygit2.GIT_REF_INVALID
-    OID = _pygit2.GIT_REF_OID
-    SYMBOLIC = _pygit2.GIT_REF_SYMBOLIC
-    LISTALL = _pygit2.GIT_REF_LISTALL
+    INVALID = C.GIT_REFERENCE_INVALID
+    "Invalid reference"
+
+    DIRECT = C.GIT_REFERENCE_DIRECT
+    "A reference that points at an object id"
+
+    SYMBOLIC = C.GIT_REFERENCE_SYMBOLIC
+    "A reference that points at another reference"
+
+    ALL = C.GIT_REFERENCE_ALL
+    "Bitwise OR of (DIRECT | SYMBOLIC)"
+
+    # Deprecated entries
+    OID = DIRECT
+    "Deprecated, use DIRECT instead"
+    LISTALL = ALL
+    "Deprecated, use ALL instead"
 
 
 class RepositoryInitFlag(IntFlag):

--- a/src/object.c
+++ b/src/object.c
@@ -40,6 +40,7 @@ extern PyTypeObject TreeType;
 extern PyTypeObject CommitType;
 extern PyTypeObject BlobType;
 extern PyTypeObject TagType;
+extern PyObject *FileModeEnum;
 
 PyTypeObject ObjectType;
 
@@ -159,7 +160,7 @@ Object__pointer__get__(Object *self)
 }
 
 PyDoc_STRVAR(Object_name__doc__,
-             "Name (will be None if the object was not reached trough a tree)");
+             "Name (or None if the object was not reached through a tree)");
 PyObject *
 Object_name__get__(Object *self)
 {
@@ -181,14 +182,14 @@ Object_raw_name__get__(Object *self)
 }
 
 PyDoc_STRVAR(Object_filemode__doc__,
-             "Filemode (will be None if the object was not reached trough a tree)");
+             "An enums.FileMode constant (or None if the object was not reached through a tree)");
 PyObject *
 Object_filemode__get__(Object *self)
 {
     if (self->entry == NULL)
         Py_RETURN_NONE;
 
-    return PyLong_FromLong(git_tree_entry_filemode(self->entry));
+    return pygit2_enum(FileModeEnum, git_tree_entry_filemode(self->entry));
 }
 
 

--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -48,6 +48,7 @@ PyObject *FileModeEnum;
 PyObject *FileStatusEnum;
 PyObject *MergeAnalysisEnum;
 PyObject *MergePreferenceEnum;
+PyObject *ReferenceTypeEnum;
 
 extern PyTypeObject RepositoryType;
 extern PyTypeObject OdbType;
@@ -377,6 +378,7 @@ forget_enums(void)
     Py_CLEAR(FileStatusEnum);
     Py_CLEAR(MergeAnalysisEnum);
     Py_CLEAR(MergePreferenceEnum);
+    Py_CLEAR(ReferenceTypeEnum);
 }
 
 PyDoc_STRVAR(_cache_enums__doc__,
@@ -411,6 +413,7 @@ _cache_enums(PyObject *self, PyObject *args)
     CACHE_PYGIT2_ENUM(FileStatus);
     CACHE_PYGIT2_ENUM(MergeAnalysis);
     CACHE_PYGIT2_ENUM(MergePreference);
+    CACHE_PYGIT2_ENUM(ReferenceType);
 
 #undef CACHE_PYGIT2_ENUM
 
@@ -606,13 +609,14 @@ PyInit__pygit2(void)
     ADD_TYPE(m, Reference)
     ADD_TYPE(m, RefLogEntry)
     ADD_TYPE(m, Note)
+    ADD_CONSTANT_INT(m, GIT_REFERENCES_ALL)
+    ADD_CONSTANT_INT(m, GIT_REFERENCES_BRANCHES)
+    ADD_CONSTANT_INT(m, GIT_REFERENCES_TAGS)
+    /* libgit2 deprecated enums */
     ADD_CONSTANT_INT(m, GIT_REF_INVALID)
     ADD_CONSTANT_INT(m, GIT_REF_OID)
     ADD_CONSTANT_INT(m, GIT_REF_SYMBOLIC)
     ADD_CONSTANT_INT(m, GIT_REF_LISTALL)
-    ADD_CONSTANT_INT(m, GIT_REFERENCES_ALL)
-    ADD_CONSTANT_INT(m, GIT_REFERENCES_BRANCHES)
-    ADD_CONSTANT_INT(m, GIT_REFERENCES_TAGS)
 
     /*
      * RevSpec
@@ -622,7 +626,7 @@ PyInit__pygit2(void)
     ADD_CONSTANT_INT(m, GIT_REVSPEC_SINGLE)
     ADD_CONSTANT_INT(m, GIT_REVSPEC_RANGE)
     ADD_CONSTANT_INT(m, GIT_REVSPEC_MERGE_BASE)
-    /* Deprecated enums */
+    /* libgit2 deprecated enums */
     ADD_CONSTANT_INT(m, GIT_REVPARSE_SINGLE)
     ADD_CONSTANT_INT(m, GIT_REVPARSE_RANGE)
     ADD_CONSTANT_INT(m, GIT_REVPARSE_MERGE_BASE)

--- a/src/reference.c
+++ b/src/reference.c
@@ -43,6 +43,7 @@ extern PyObject *GitError;
 extern PyTypeObject RefLogEntryType;
 extern PyTypeObject RepositoryType;
 extern PyTypeObject SignatureType;
+extern PyObject *ReferenceTypeEnum;
 
 PyTypeObject ReferenceType;
 
@@ -424,7 +425,7 @@ Reference_raw_shorthand__get__(Reference *self)
 }
 
 PyDoc_STRVAR(Reference_type__doc__,
-    "Type, either GIT_REF_OID or GIT_REF_SYMBOLIC.");
+    "An enums.ReferenceType constant (either OID or SYMBOLIC).");
 
 PyObject *
 Reference_type__get__(Reference *self)
@@ -433,7 +434,8 @@ Reference_type__get__(Reference *self)
 
     CHECK_REFERENCE(self);
     c_type = git_reference_type(self->reference);
-    return PyLong_FromLong(c_type);
+
+    return pygit2_enum(ReferenceTypeEnum, c_type);
 }
 
 

--- a/test/test_refs.py
+++ b/test/test_refs.py
@@ -88,7 +88,8 @@ def test_refs_set_sha_prefix(testrepo):
 
 def test_refs_get_type(testrepo):
     reference = testrepo.references.get('refs/heads/master')
-    assert reference.type == ReferenceType.OID
+    assert reference.type == ReferenceType.DIRECT
+    assert reference.type == ReferenceType.OID  # deprecated
 
 def test_refs_get_target(testrepo):
     reference = testrepo.references.get('HEAD')
@@ -167,7 +168,8 @@ def test_refs_resolve(testrepo):
     reference = testrepo.references.get('HEAD')
     assert reference.type == ReferenceType.SYMBOLIC
     reference = reference.resolve()
-    assert reference.type == ReferenceType.OID
+    assert reference.type == ReferenceType.DIRECT
+    assert reference.type == ReferenceType.OID  # deprecated
     assert reference.target.hex == LAST_COMMIT
 
 def test_refs_resolve_identity(testrepo):
@@ -468,7 +470,8 @@ def test_reference_set_sha_prefix(testrepo):
 
 def test_reference_get_type(testrepo):
     reference = testrepo.lookup_reference('refs/heads/master')
-    assert reference.type == ReferenceType.OID
+    assert reference.type == ReferenceType.DIRECT
+    assert reference.type == ReferenceType.OID  # deprecated
 
 def test_get_target(testrepo):
     reference = testrepo.lookup_reference('HEAD')
@@ -548,7 +551,8 @@ def test_reference_resolve(testrepo):
     reference = testrepo.lookup_reference('HEAD')
     assert reference.type == ReferenceType.SYMBOLIC
     reference = reference.resolve()
-    assert reference.type == ReferenceType.OID
+    assert reference.type == ReferenceType.DIRECT
+    assert reference.type == ReferenceType.OID  # deprecated
     assert reference.target.hex == LAST_COMMIT
 
 def test_reference_resolve_identity(testrepo):


### PR DESCRIPTION
I missed those two properties in #1263.

`ReferenceType` was also updated to keep the names in sync with libgit2's enum deprecation (OID became DIRECT, LISTALL became ALL).