### PR TITLE
Relax transfer bytes check in test_remote.test_fetch

### DIFF
--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -39,7 +39,6 @@ REMOTE_URL = 'https://github.com/libgit2/pygit2.git'
 REMOTE_FETCHSPEC_SRC = 'refs/heads/*'
 REMOTE_FETCHSPEC_DST = 'refs/remotes/origin/*'
 REMOTE_REPO_OBJECTS = 30
-REMOTE_REPO_BYTES = 2758
 REMOTE_FETCHTEST_FETCHSPECS = ["refs/tags/v1.13.2"]
 REMOTE_REPO_FETCH_ALL_OBJECTS = 13276
 REMOTE_REPO_FETCH_HEAD_COMMIT_OBJECTS = 238
@@ -215,7 +214,8 @@ def test_remote_refcount(testrepo):
 def test_fetch(emptyrepo):
     remote = emptyrepo.remotes[0]
     stats = remote.fetch()
-    assert stats.received_bytes == REMOTE_REPO_BYTES
+    assert stats.received_bytes > 2700
+    assert stats.received_bytes < 2800
     assert stats.indexed_objects == REMOTE_REPO_OBJECTS
     assert stats.received_objects == REMOTE_REPO_OBJECTS
 


### PR DESCRIPTION
On Fedora 40, this test fails with:

```
__________________________________ test_fetch __________________________________
emptyrepo = pygit2.Repository('/tmp/pytest-of-mockbuild/pytest-0/test_fetch0/emp tyrepo/.git/')
    def test_fetch(emptyrepo):
        remote = emptyrepo.remotes[0]
        stats = remote.fetch()
>       assert stats.received_bytes == REMOTE_REPO_BYTES
E       assert 2760 == 2758
E        +  where 2760 = <pygit2.remote.TransferProgress object at 0xf60a7db0>.received_bytes
test/test_remote.py:218: AssertionError
```

Probably due to zlib-ng/zlib differences.