### PR TITLE
Remove setuptools runtime dependency on Python 3.12+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,9 +132,6 @@ src = __dir__ / 'src'
 pygit2_exts = [str(path) for path in sorted(src.iterdir()) if path.suffix == '.c']
 ext_modules = [Extension('pygit2._pygit2', pygit2_exts, **libgit2_kw)]
 
-with open('requirements.txt') as f:
-    install_requires = f.read().splitlines()
-
 setup(
     name='pygit2',
     description='Python bindings for libgit2.',
@@ -155,7 +152,7 @@ setup(
     # Requirements
     python_requires='>=3.9',
     setup_requires=['cffi>=1.16.0'],
-    install_requires=install_requires,
+    install_requires=['cffi>=1.16.0'],
     # URLs
     url='https://github.com/libgit2/pygit2',
     project_urls={


### PR DESCRIPTION
The change from https://github.com/libgit2/pygit2/commit/aab211a842b17c8b699b2753301abb3a9ba7f1ad has incorrectly made setuptools a dependency of pygit2. It is not a runtime dependency, it is only a build dependency - `pkg_resources` / `setuptools` are not used outside of the installer script i.e. `setup.py`.

This change removes the setuptools dependency from package metadata, and makes it possible to use pygit2 without needing setuptools installed at all.