### PR TITLE
Add support for push options

### DIFF
--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -179,7 +179,7 @@ class Index:
     def remove_all(self, pathspecs):
         """Remove all index entries matching pathspecs."""
         with StrArray(pathspecs) as arr:
-            err = C.git_index_remove_all(self._index, arr, ffi.NULL, ffi.NULL)
+            err = C.git_index_remove_all(self._index, arr.ptr, ffi.NULL, ffi.NULL)
             check_error(err, io=True)
 
     def add_all(self, pathspecs=None):
@@ -190,7 +190,7 @@ class Index:
         """
         pathspecs = pathspecs or []
         with StrArray(pathspecs) as arr:
-            err = C.git_index_add_all(self._index, arr, 0, ffi.NULL, ffi.NULL)
+            err = C.git_index_add_all(self._index, arr.ptr, 0, ffi.NULL, ffi.NULL)
             check_error(err, io=True)
 
     def add(self, path_or_entry):

--- a/pygit2/remotes.py
+++ b/pygit2/remotes.py
@@ -236,7 +236,7 @@ class Remote:
         check_error(err)
         return strarray_to_strings(specs)
 
-    def push(self, specs, callbacks=None, proxy=None):
+    def push(self, specs, callbacks=None, proxy=None, push_options=None):
         """
         Push the given refspec to the remote. Raises ``GitError`` on protocol
         error or unpack failure.
@@ -258,11 +258,16 @@ class Remote:
             * `None` (the default) to disable proxy usage
             * `True` to enable automatic proxy detection
             * an url to a proxy (`http://proxy.example.org:3128/`)
+
+        push_options : [str]
+            Push options to send to the server, which passes them to the
+            pre-receive as well as the post-receive hook.
         """
         with git_push_options(callbacks) as payload:
             opts = payload.push_options
             self.__set_proxy(opts.proxy_opts, proxy)
-            with StrArray(specs) as refspecs:
+            with StrArray(specs) as refspecs, StrArray(push_options) as pushopts:
+                pushopts.assign_to(opts.remote_push_options)
                 err = C.git_remote_push(self._remote, refspecs.ptr, opts)
                 payload.check_error(err)
 

--- a/pygit2/remotes.py
+++ b/pygit2/remotes.py
@@ -155,7 +155,7 @@ class Remote:
             opts.depth = depth
             self.__set_proxy(opts.proxy_opts, proxy)
             with StrArray(refspecs) as arr:
-                err = C.git_remote_fetch(self._remote, arr, opts, to_bytes(message))
+                err = C.git_remote_fetch(self._remote, arr.ptr, opts, to_bytes(message))
                 payload.check_error(err)
 
         return TransferProgress(C.git_remote_stats(self._remote))
@@ -263,7 +263,7 @@ class Remote:
             opts = payload.push_options
             self.__set_proxy(opts.proxy_opts, proxy)
             with StrArray(specs) as refspecs:
-                err = C.git_remote_push(self._remote, refspecs, opts)
+                err = C.git_remote_push(self._remote, refspecs.ptr, opts)
                 payload.check_error(err)
 
     def __set_proxy(self, proxy_opts, proxy):

--- a/pygit2/utils.py
+++ b/pygit2/utils.py
@@ -93,6 +93,16 @@ class StrArray:
 
         with StrArray(list_of_strings) as arr:
             C.git_function_that_takes_strarray(arr.ptr)
+
+    To make a pre-existing git_strarray point to the provided list of strings,
+    use the context manager's assign_to() method:
+
+        struct = ffi.new('git_strarray *', [ffi.NULL, 0])
+        with StrArray(list_of_strings) as arr:
+            arr.assign_to(struct)
+
+    The above construct is still subject to FFI scoping rules, i.e. the
+    contents of 'struct' only remain valid within the StrArray context.
     """
 
     def __init__(self, l):
@@ -125,6 +135,14 @@ class StrArray:
     @property
     def ptr(self):
         return self.array
+
+    def assign_to(self, git_strarray):
+        if self.array == ffi.NULL:
+            git_strarray.strings = ffi.NULL
+            git_strarray.count = 0
+        else:
+            git_strarray.strings = self._arr
+            git_strarray.count = len(self._strings)
 
 
 class GenericIterator:

--- a/pygit2/utils.py
+++ b/pygit2/utils.py
@@ -92,7 +92,7 @@ class StrArray:
     list of strings. This has a context manager, which you should use, e.g.
 
         with StrArray(list_of_strings) as arr:
-            C.git_function_that_takes_strarray(arr)
+            C.git_function_that_takes_strarray(arr.ptr)
     """
 
     def __init__(self, l):
@@ -117,10 +117,14 @@ class StrArray:
         self.array = ffi.new('git_strarray *', [self._arr, len(strings)])
 
     def __enter__(self):
-        return self.array
+        return self
 
     def __exit__(self, type, value, traceback):
         pass
+
+    @property
+    def ptr(self):
+        return self.array
 
 
 class GenericIterator:


### PR DESCRIPTION
With libgit2/libgit2#6439 having been recently merged, this PR attempts adding support for push options to pygit2.

While the basic code change (d387941a309804ac7bc198be4d34e4086204258f) is fairly trivial, I had to jump through some other hoops to get it to work.  Here is a summary of how this PR reached its current form:

 1. First, I need a libgit2 version that supports push options.  Let's build it!
 2. Oh no, push options only work in libgit2's `master` branch, not in libgit 1.7.2, which is the latest version that pygit2 currently works with.
 3. Okay, let's hack around the current requirement for libgit2 1.7.x in pygit2's `master` branch.  (These changes are not included in this PR.)
 4. This should be easy now, just turn a list of strings into a `git_strarray` and voilà.
 5. Oh no, `StrArray` is only able to allocate a new `git_strarray` structure, how do I assign a list of strings to an existing `git_strarray` that is a member of another structure (`git_push_options`)?
 6. Okay, let's add something reusable that can be used for this purpose.
 7. Done, now we can finally add support for push options :rocket:

So here we are:

  - ed3a6b22797214d60e5e2a5f82f49aa257ce6c5c proposes a slight change in the way `StrArray` is used, to make the cases where a pointer to an allocated `git_strarray` structure is passed to a libgit2 function slightly more readable (IMHO, of course),
  - 2c8fc47a377f62ced340372eb6f03e9e48386b94 adds a new method to `StrArray` that enables assigning a list of strings to an existing `git_strarray` structure (I deliberately avoided naming the method `copy_to()` because FFI scoping rules still need to be adhered to),
  - d387941a309804ac7bc198be4d34e4086204258f actually adds support for push options, using the `StrArray.assign_to()` method added by the previous commit.

There is one more pitfall: I don't have any bright ideas for testing push options using the test infrastructure currently existing in the pygit2 repository.  Hook support for libgit2 has been in the making for a few years now (libgit2/libgit2#4620) and server-side hooks cannot be defined for a GitHub repository (and even if this was possible, the test would need to examine some sort of an artifact created by the server-side hook, as it is done in the [relevant libgit2 tests][1]), so the only option I can think of is firing up a local Git daemon for this purpose during pygit2 tests.  It's all doable, of course, but I thought it is prudent to wait for initial feedback on this proposal before going any further.

I would be happy to rework any part of this PR - it just felt that the additions proposed here might be useful in other similar cases in the future and it is always easier to discuss specific proposals than high-level ideas.

Thank you in advance for taking a look!

Fixes #1126 

[1]: https://github.com/libgit2/libgit2/blob/a035aa4b9735a9e6aa478831e7113eb46f03a541/tests/resources/pushoptions.git/hooks/pre-receive