### PR TITLE
Relax transfer bytes check even more

### DIFF
--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -231,7 +231,7 @@ def test_fetch(emptyrepo):
     remote = emptyrepo.remotes[0]
     stats = remote.fetch()
     assert stats.received_bytes > 2700
-    assert stats.received_bytes < 2800
+    assert stats.received_bytes < 3100
     assert stats.indexed_objects == REMOTE_REPO_OBJECTS
     assert stats.received_objects == REMOTE_REPO_OBJECTS
 


### PR DESCRIPTION
On EPEL8 builds for s390x this transfers ~3040 bytes:

```
__________________________________ test_fetch __________________________________
emptyrepo = pygit2.Repository('/tmp/pytest-of-mockbuild/pytest-0/test_fetch0/emptyrepo/.git/')
    def test_fetch(emptyrepo):
        remote = emptyrepo.remotes[0]
        stats = remote.fetch()
        assert stats.received_bytes > 2700
>       assert stats.received_bytes < 2800
E       assert 3041 < 2800
E        +  where 3041 = <pygit2.remotes.TransferProgress object at 0x3ffa8668dd0>.received_bytes
test/test_remote.py:218: AssertionError
```

Would be too easy if this were deterministic.