### PR TITLE
Fix docstring/type annotation for DiffDelta.status

### DIFF
--- a/pygit2/_pygit2.pyi
+++ b/pygit2/_pygit2.pyi
@@ -4,12 +4,12 @@ from . import Index, Submodule
 from .enums import (
     ApplyLocation,
     BranchType,
+    DeltaStatus,
     DiffFind,
     DiffFlag,
     DiffOption,
     DiffStatsFormat,
     FileMode,
-    FileStatus,
     MergeAnalysis,
     MergePreference,
     ObjectType,
@@ -171,7 +171,7 @@ class DiffDelta:
     new_file: DiffFile
     old_file: DiffFile
     similarity: int
-    status: FileStatus
+    status: DeltaStatus
     def status_char(self) -> str: ...
 
 class DiffFile:

--- a/src/diff.c
+++ b/src/diff.c
@@ -323,7 +323,7 @@ DiffDelta_is_binary__get__(DiffDelta *self)
 }
 
 PyDoc_STRVAR(DiffDelta_status__doc__,
-    "An enums.FileStatus constant."
+    "An enums.DeltaStatus constant."
 );
 
 PyObject *

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -339,6 +339,8 @@ def test_deltas(barerepo):
     assert len(deltas) == len(patches)
     for i, delta in enumerate(deltas):
         patch_delta = patches[i].delta
+        assert isinstance(delta.status, DeltaStatus)
+        assert isinstance(patch_delta.status, DeltaStatus)
         assert delta.status == patch_delta.status
         assert delta.similarity == patch_delta.similarity
         assert delta.nfiles == patch_delta.nfiles


### PR DESCRIPTION
The docstring and type hints incorrectly state that `DiffDelta.status` returns a value of type `FileStatus` instead of `DeltaStatus`.