### PR TITLE
Fix Submodule.open() if parent repo is instance of Repository subclass

### DIFF
--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -1548,6 +1548,6 @@ class Repository(BaseRepository):
         cptr = ffi.new('git_repository **')
         cptr[0] = ptr
         repo = cls.__new__(cls)
-        super(cls, repo)._from_c(bytes(ffi.buffer(cptr)[:]), owned)
+        BaseRepository._from_c(repo, bytes(ffi.buffer(cptr)[:]), owned)
         repo._common_init()
         return repo

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -91,6 +91,20 @@ def test_submodule_open(repo):
     assert r.head.target == SUBM_HEAD_SHA
 
 
+@utils.requires_network
+def test_submodule_open_from_repository_subclass(repo):
+    class CustomRepoClass(pygit2.Repository):
+        pass
+
+    custom_repo = CustomRepoClass(repo.workdir)
+    s = custom_repo.submodules[SUBM_PATH]
+    custom_repo.submodules.init()
+    custom_repo.submodules.update()
+    r = s.open()
+    assert isinstance(r, CustomRepoClass)
+    assert r.head.target == SUBM_HEAD_SHA
+
+
 def test_name(repo):
     s = repo.submodules[SUBM_PATH]
     assert SUBM_NAME == s.name


### PR DESCRIPTION
`Submodule.open()` fails if the submodule was created from a subclass of Repository.

For example:

```python
class CustomRepoClass(pygit2.Repository):
    pass
r = CustomRepoClass("some-repo")
s = r.submodules["submodule-name"].open()

# Traceback (most recent call last):
#   (...snip...)
#   File "pygit2/submodules.py", line 60, in open
#     return self._repo._from_c(crepo[0], True)
#   File "pygit2/repository.py", line 1551, in _from_c
#     super(cls, repo)._from_c(bytes(ffi.buffer(cptr)[:]), owned)
#   File "pygit2/repository.py", line 1549, in _from_c
#     cptr[0] = ptr
# TypeError: initializer for ctype 'struct git_repository *' must be a cdata pointer, not bytes
```
This PR fixes this issue.