### PR TITLE
Add Repository.revert()

### DIFF
--- a/pygit2/decl/revert.h
+++ b/pygit2/decl/revert.h
@@ -1,3 +1,17 @@
+#define GIT_REVERT_OPTIONS_VERSION ...
+
+typedef struct {
+	unsigned int version;
+	unsigned int mainline;
+	git_merge_options merge_opts;
+	git_checkout_options checkout_opts;
+} git_revert_options;
+
+int git_revert(
+	git_repository *repo,
+	git_commit *commit,
+	const git_revert_options *given_opts);
+
 int git_revert_commit(
 	git_index **out,
 	git_repository *repo,

--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -1343,6 +1343,19 @@ class BaseRepository(_Repository):
         err = C.git_repository_set_ident(self._repo, to_bytes(name), to_bytes(email))
         check_error(err)
 
+    def revert(self, commit: Commit):
+        """
+        Revert the given commit, producing changes in the index and working
+        directory.
+
+        This operation updates the repository's state and prepared message
+        (MERGE_MSG).
+        """
+        commit_ptr = ffi.new('git_commit **')
+        ffi.buffer(commit_ptr)[:] = commit._pointer[:]
+        err = C.git_revert(self._repo, commit_ptr[0], ffi.NULL)
+        check_error(err)
+
     def revert_commit(self, revert_commit, our_commit, mainline=0):
         """
         Revert the given Commit against the given "our" Commit, producing an


### PR DESCRIPTION
This exposes libgit2's [git_revert()](https://libgit2.org/libgit2/#HEAD/group/revert/git_revert), which produces changes in the index and working directory. It also affects the repository's state (via .git/REVERT_HEAD) and prepared message (via .git/MERGE_MSG).

Rationale for adding this even though Repository.revert_commit() already exists: revert_commit() is a binding for  [git_revert_commit()](https://libgit2.org/libgit2/#HEAD/group/revert/git_revert_commit), which is less powerful -- it doesn't check out the resulting index, and it doesn't modify the state and prepared message.

---

Note: git_revert() accepts [additional checkout/revert settings](https://libgit2.org/libgit2/#HEAD/type/git_revert_options). We could implement support for these as extra arguments to Repository.revert() in the future.