### PR TITLE
Add Repository.hashfile()

### DIFF
--- a/pygit2/decl/repository.h
+++ b/pygit2/decl/repository.h
@@ -83,6 +83,7 @@ int git_repository_set_head_detached(
 	git_repository* repo,
 	const git_oid* commitish);
 
+int git_repository_hashfile(git_oid *out, git_repository *repo, const char *path, git_object_t type, const char *as_path);
 int git_repository_ident(const char **name, const char **email, const git_repository *repo);
 int git_repository_set_ident(git_repository *repo, const char *name, const char *email);
 int git_repository_index(git_index **out, git_repository *repo);

--- a/pygit2/decl/types.h
+++ b/pygit2/decl/types.h
@@ -57,3 +57,14 @@ typedef enum {
 	GIT_SUBMODULE_IGNORE_DIRTY     = 3,
 	GIT_SUBMODULE_IGNORE_ALL       = 4,
 } git_submodule_ignore_t;
+
+typedef enum {
+	GIT_OBJECT_ANY       = ...,
+	GIT_OBJECT_INVALID   = ...,
+	GIT_OBJECT_COMMIT    = ...,
+	GIT_OBJECT_TREE      = ...,
+	GIT_OBJECT_BLOB      = ...,
+	GIT_OBJECT_TAG       = ...,
+	GIT_OBJECT_OFS_DELTA = ...,
+	GIT_OBJECT_REF_DELTA = ...,
+} git_object_t;

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -908,7 +908,10 @@ def test_repository_hashfile(testrepo):
     assert h == original_hash
 
     # Test absolute path
-    h = testrepo.hashfile(str(Path(testrepo.workdir, 'hello.txt')))
+    # For best results on Windows, pass a pure POSIX path. (See https://github.com/libgit2/libgit2/issues/6825)
+    absolute_path = Path(testrepo.workdir, 'hello.txt')
+    absolute_path = absolute_path.as_posix()  # Windows compatibility
+    h = testrepo.hashfile(str(absolute_path))
     assert h == original_hash
 
     # Test missing path
@@ -944,8 +947,11 @@ def test_repository_hashfile_filter(testrepo):
     h = testrepo.hashfile('hellocrlf.txt')
     assert h == original_hash
 
-    # Treat absolute path with filters
-    h = testrepo.hashfile(str(Path(testrepo.workdir, 'hellocrlf.txt')))
+    # Treat absolute path with filters.
+    # For best results on Windows, pass a pure POSIX path. (See https://github.com/libgit2/libgit2/issues/6825)
+    absolute_path = Path(testrepo.workdir, 'hellocrlf.txt')
+    absolute_path = absolute_path.as_posix()  # Windows compatibility
+    h = testrepo.hashfile(str(absolute_path))
     assert h == original_hash
 
     # Bypass filters


### PR DESCRIPTION
This exposes libgit2's [`git_repository_hashfile()`](https://libgit2.org/libgit2/#HEAD/group/repository/git_repository_hashfile).

`pygit2.hashfile()` already exists, but this lets you hash files using the repository's filters.