### PR TITLE
Fix Submodule.head_id if submodule isn't in superproject HEAD tree

### DIFF
--- a/pygit2/submodules.py
+++ b/pygit2/submodules.py
@@ -148,10 +148,17 @@ class Submodule:
         return ffi.string(branch).decode('utf-8')
 
     @property
-    def head_id(self):
-        """Head of the submodule."""
+    def head_id(self) -> Union[Oid, None]:
+        """
+        The submodule's HEAD commit id (as recorded in the superproject's
+        current HEAD tree).
+        Returns None if the superproject's HEAD doesn't contain the submodule.
+        """
+
         head = C.git_submodule_head_id(self._subm)
-        return Oid(raw=bytes(ffi.buffer(head)[:]))
+        if head == ffi.NULL:
+            return None
+        return Oid(raw=bytes(ffi.buffer(head.id)[:]))
 
 
 class SubmoduleCollection:

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -211,6 +211,24 @@ def test_head_id(repo):
 
 
 @utils.requires_network
+def test_head_id_null(repo):
+    gitmodules_newlines = (
+        '\n'
+        '[submodule "uncommitted_submodule"]\n'
+        '    path = pygit2\n'
+        '    url = https://github.com/libgit2/pygit2\n'
+        '\n'
+    )
+    with open(Path(repo.workdir, '.gitmodules'), 'a') as f:
+        f.write(gitmodules_newlines)
+
+    subm = repo.submodules['uncommitted_submodule']
+
+    # The submodule isn't in the HEAD yet, so head_id should be None
+    assert subm.head_id is None
+
+
+@utils.requires_network
 @pytest.mark.parametrize('depth', [0, 1])
 def test_add_submodule(repo, depth):
     sm_repo_path = 'test/testrepo'


### PR DESCRIPTION
When a submodule isn't in HEAD, [git_submodule_head_id](https://libgit2.org/libgit2/#HEAD/group/submodule/git_submodule_head_id) returns NULL.

pygit2's Submodule.head_id didn't check for ffi.NULL and built an Oid from garbage data in this case.