### PR TITLE
add py.typed

### DIFF
--- a/pygit2/py.typed
+++ b/pygit2/py.typed
@@ -1,0 +1,1 @@
+# python type marker, see: https://peps.python.org/pep-0561/

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=['pygit2'],
-    package_data={'pygit2': ['decl/*.h', '*.pyi', "py.typed"]},
+    package_data={'pygit2': ['decl/*.h', '*.pyi', 'py.typed']},
     zip_safe=False,
     cmdclass=cmdclass,
     cffi_modules=['pygit2/_run.py:ffi'],

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ classifiers = [
     'Programming Language :: Python :: Implementation :: PyPy',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Software Development :: Version Control',
+    'Typing :: Typed',
 ]
 
 __dir__ = Path(__file__).parent
@@ -144,7 +145,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=['pygit2'],
-    package_data={'pygit2': ['decl/*.h', '*.pyi']},
+    package_data={'pygit2': ['decl/*.h', '*.pyi', "py.typed"]},
     zip_safe=False,
     cmdclass=cmdclass,
     cffi_modules=['pygit2/_run.py:ffi'],


### PR DESCRIPTION
This PR adds the `py.typed` marker file (see: https://peps.python.org/pep-0561/ for reference). Without this file, static type checkers such as MyPy do not consider the library as typed. Thus this PR will resolve errors such as this:

```text
error: Skipping analyzing "pygit2": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```