### PR TITLE
feat: add certificate_check callback to ls_remotes

### DIFF
--- a/pygit2/callbacks.py
+++ b/pygit2/callbacks.py
@@ -391,6 +391,7 @@ def git_remote_callbacks(payload):
     # Plug callbacks
     cdata.credentials = C._credentials_cb
     cdata.update_tips = C._update_tips_cb
+    cdata.certificate_check = C._certificate_check_cb
     # Payload
     handle = ffi.new_handle(payload)
     cdata.payload = handle


### PR DESCRIPTION
Fixes: https://github.com/libgit2/pygit2/issues/1262

I also added a test to ensure the callback is called on `ls_remotes`.