### PR TITLE
maybe_string dealing with non-unicode strings

### DIFF
--- a/pygit2/errors.py
+++ b/pygit2/errors.py
@@ -42,7 +42,7 @@ def check_error(err, io=False):
     # Error message
     giterr = C.git_error_last()
     if giterr != ffi.NULL:
-        message = ffi.string(giterr.message).decode('utf8',errors='surrogateescape')
+        message = ffi.string(giterr.message).decode('utf8', errors='surrogateescape')
     else:
         message = f'err {err} (no message provided)'
 

--- a/pygit2/errors.py
+++ b/pygit2/errors.py
@@ -42,7 +42,7 @@ def check_error(err, io=False):
     # Error message
     giterr = C.git_error_last()
     if giterr != ffi.NULL:
-        message = ffi.string(giterr.message).decode('utf8')
+        message = ffi.string(giterr.message).decode('utf8',errors='surrogateescape')
     else:
         message = f'err {err} (no message provided)'
 

--- a/pygit2/utils.py
+++ b/pygit2/utils.py
@@ -34,16 +34,14 @@ def maybe_string(ptr):
     if not ptr:
         return None
 
-    try:
-        return ffi.string(ptr).decode('utf8')
-    except UnicodeDecodeError:
-        return ffi.string(ptr)
+    return ffi.string(ptr).decode("utf8", errors="surrogateescape")
 
-def to_bytes(s, encoding='utf-8', errors='strict'):
+
+def to_bytes(s, encoding="utf-8", errors="strict"):
     if s == ffi.NULL or s is None:
         return ffi.NULL
 
-    if hasattr(s, '__fspath__'):
+    if hasattr(s, "__fspath__"):
         s = os.fspath(s)
 
     if isinstance(s, bytes):
@@ -53,7 +51,7 @@ def to_bytes(s, encoding='utf-8', errors='strict'):
 
 
 def to_str(s):
-    if hasattr(s, '__fspath__'):
+    if hasattr(s, "__fspath__"):
         s = os.fspath(s)
 
     if type(s) is str:
@@ -71,13 +69,13 @@ def ptr_to_bytes(ptr_cdata):
     to a byte buffer containing the address that the pointer refers to.
     """
 
-    pp = ffi.new('void **', ptr_cdata)
+    pp = ffi.new("void **", ptr_cdata)
     return bytes(ffi.buffer(pp)[:])
 
 
 @contextlib.contextmanager
 def new_git_strarray():
-    strarray = ffi.new('git_strarray *')
+    strarray = ffi.new("git_strarray *")
     yield strarray
     C.git_strarray_dispose(strarray)
 
@@ -90,7 +88,7 @@ def strarray_to_strings(arr):
     calling this function.
     """
     try:
-        return [ffi.string(arr.strings[i]).decode('utf-8') for i in range(arr.count)]
+        return [ffi.string(arr.strings[i]).decode("utf-8") for i in range(arr.count)]
     finally:
         C.git_strarray_dispose(arr)
 
@@ -122,19 +120,19 @@ class StrArray:
             return
 
         if not isinstance(l, (list, tuple)):
-            raise TypeError('Value must be a list')
+            raise TypeError("Value must be a list")
 
         strings = [None] * len(l)
         for i in range(len(l)):
             li = l[i]
-            if not isinstance(li, str) and not hasattr(li, '__fspath__'):
-                raise TypeError('Value must be a string or PathLike object')
+            if not isinstance(li, str) and not hasattr(li, "__fspath__"):
+                raise TypeError("Value must be a string or PathLike object")
 
-            strings[i] = ffi.new('char []', to_bytes(li))
+            strings[i] = ffi.new("char []", to_bytes(li))
 
-        self.__arr = ffi.new('char *[]', strings)
+        self.__arr = ffi.new("char *[]", strings)
         self.__strings = strings
-        self.__array = ffi.new('git_strarray *', [self.__arr, len(strings)])
+        self.__array = ffi.new("git_strarray *", [self.__arr, len(strings)])
 
     def __enter__(self):
         return self

--- a/pygit2/utils.py
+++ b/pygit2/utils.py
@@ -34,8 +34,10 @@ def maybe_string(ptr):
     if not ptr:
         return None
 
-    return ffi.string(ptr).decode('utf8')
-
+    try:
+        return ffi.string(ptr).decode('utf8')
+    except UnicodeDecodeError:
+        return ffi.string(ptr)
 
 def to_bytes(s, encoding='utf-8', errors='strict'):
     if s == ffi.NULL or s is None:

--- a/pygit2/utils.py
+++ b/pygit2/utils.py
@@ -34,14 +34,14 @@ def maybe_string(ptr):
     if not ptr:
         return None
 
-    return ffi.string(ptr).decode("utf8", errors="surrogateescape")
+    return ffi.string(ptr).decode('utf8', errors='surrogateescape')
 
 
-def to_bytes(s, encoding="utf-8", errors="strict"):
+def to_bytes(s, encoding='utf-8', errors='strict'):
     if s == ffi.NULL or s is None:
         return ffi.NULL
 
-    if hasattr(s, "__fspath__"):
+    if hasattr(s, '__fspath__'):
         s = os.fspath(s)
 
     if isinstance(s, bytes):
@@ -51,7 +51,7 @@ def to_bytes(s, encoding="utf-8", errors="strict"):
 
 
 def to_str(s):
-    if hasattr(s, "__fspath__"):
+    if hasattr(s, '__fspath__'):
         s = os.fspath(s)
 
     if type(s) is str:
@@ -69,13 +69,13 @@ def ptr_to_bytes(ptr_cdata):
     to a byte buffer containing the address that the pointer refers to.
     """
 
-    pp = ffi.new("void **", ptr_cdata)
+    pp = ffi.new('void **', ptr_cdata)
     return bytes(ffi.buffer(pp)[:])
 
 
 @contextlib.contextmanager
 def new_git_strarray():
-    strarray = ffi.new("git_strarray *")
+    strarray = ffi.new('git_strarray *')
     yield strarray
     C.git_strarray_dispose(strarray)
 
@@ -88,7 +88,7 @@ def strarray_to_strings(arr):
     calling this function.
     """
     try:
-        return [ffi.string(arr.strings[i]).decode("utf-8") for i in range(arr.count)]
+        return [ffi.string(arr.strings[i]).decode('utf-8') for i in range(arr.count)]
     finally:
         C.git_strarray_dispose(arr)
 
@@ -120,19 +120,19 @@ class StrArray:
             return
 
         if not isinstance(l, (list, tuple)):
-            raise TypeError("Value must be a list")
+            raise TypeError('Value must be a list')
 
         strings = [None] * len(l)
         for i in range(len(l)):
             li = l[i]
-            if not isinstance(li, str) and not hasattr(li, "__fspath__"):
-                raise TypeError("Value must be a string or PathLike object")
+            if not isinstance(li, str) and not hasattr(li, '__fspath__'):
+                raise TypeError('Value must be a string or PathLike object')
 
-            strings[i] = ffi.new("char []", to_bytes(li))
+            strings[i] = ffi.new('char []', to_bytes(li))
 
-        self.__arr = ffi.new("char *[]", strings)
+        self.__arr = ffi.new('char *[]', strings)
         self.__strings = strings
-        self.__array = ffi.new("git_strarray *", [self.__arr, len(strings)])
+        self.__array = ffi.new('git_strarray *', [self.__arr, len(strings)])
 
     def __enter__(self):
         return self

--- a/test/test_nonunicode.py
+++ b/test/test_nonunicode.py
@@ -41,7 +41,8 @@ def bstring(request):
 
 
 def test_nonunicode_branchname(testrepo, bstring):
-    testrepo.branches.local.create(bstring.decode("utf8", errors="surrogateescape"),commit=testrepo.head.target)
+    cmd = b"git checkout -b " + bstring
+    subprocess.check_output(cmd.decode('utf8',errors='surrogateescape').split(" "), cwd=testrepo.workdir)
     newrepo = pygit2.clone_repository(
         testrepo.workdir,
         os.path.join(os.path.dirname(testrepo.workdir), "test_nonunicode_repo"),

--- a/test/test_nonunicode.py
+++ b/test/test_nonunicode.py
@@ -1,0 +1,53 @@
+# Copyright 2010-2024 The pygit2 contributors
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2,
+# as published by the Free Software Foundation.
+#
+# In addition to the permissions in the GNU General Public License,
+# the authors give you unlimited permission to link the compiled
+# version of this file into combinations with other programs,
+# and to distribute those combinations without any restriction
+# coming from the use of this file.  (The General Public License
+# restrictions do apply in other respects; for example, they cover
+# modification of the file, and distribution when not linked into
+# a combined executable.)
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+
+"""Tests for reference objects."""
+
+from pathlib import Path
+
+import pygit2
+import pytest
+import subprocess
+import os
+
+bstring_list = [b"\xc3master"]
+
+
+@pytest.fixture(params=bstring_list)
+def bstring(request):
+    return request.param
+
+
+def test_nonunicode_branchname(testrepo, bstring):
+    cmd = b"git checkout -b " + bstring
+    subprocess.check_output(cmd.split(b" "), cwd=testrepo.workdir)
+    newrepo = pygit2.clone_repository(
+        testrepo.workdir,
+        os.path.join(os.path.dirname(testrepo.workdir), "test_nonunicode_repo"),
+    )
+    assert bstring in [
+        branch.encode("utf8", "surrogateescape")
+        for branch in newrepo.listall_branches()
+    ]

--- a/test/test_nonunicode.py
+++ b/test/test_nonunicode.py
@@ -23,31 +23,24 @@
 # the Free Software Foundation, 51 Franklin Street, Fifth Floor,
 # Boston, MA 02110-1301, USA.
 
-"""Tests for reference objects."""
-
-from pathlib import Path
+"""Tests for non unicode byte strings"""
 
 import pygit2
-import pytest
-import subprocess
 import os
-
-bstring_list = [b"\xc3master"]
-
-
-@pytest.fixture(params=bstring_list)
-def bstring(request):
-    return request.param
+import shutil
 
 
-def test_nonunicode_branchname(testrepo, bstring):
-    cmd = b"git checkout -b " + bstring
-    subprocess.check_output(cmd.decode('utf8',errors='surrogateescape').split(" "), cwd=testrepo.workdir)
+bstring = b'\xc3master'
+
+def test_nonunicode_branchname(testrepo):
+    folderpath = 'temp_repo_nonutf'
+    if os.path.exists(folderpath):
+        shutil.rmdir(folderpath)
     newrepo = pygit2.clone_repository(
-        testrepo.workdir,
-        os.path.join(os.path.dirname(testrepo.workdir), "test_nonunicode_repo"),
-    )
+        path=folderpath, 
+        url='https://github.com/pygit2/test_branch_notutf.git'
+        )
     assert bstring in [
-        branch.encode("utf8", "surrogateescape")
-        for branch in newrepo.listall_branches()
-    ]
+        (ref.split('/')[-1]).encode('utf8', 'surrogateescape')
+        for ref in newrepo.listall_references()
+    ] # Remote branch among references: 'refs/remotes/origin/\udcc3master'

--- a/test/test_nonunicode.py
+++ b/test/test_nonunicode.py
@@ -37,10 +37,9 @@ def test_nonunicode_branchname(testrepo):
     if os.path.exists(folderpath):
         shutil.rmtree(folderpath)
     newrepo = pygit2.clone_repository(
-        path=folderpath, 
-        url='https://github.com/pygit2/test_branch_notutf.git'
-        )
+        path=folderpath, url='https://github.com/pygit2/test_branch_notutf.git'
+    )
     assert bstring in [
         (ref.split('/')[-1]).encode('utf8', 'surrogateescape')
         for ref in newrepo.listall_references()
-    ] # Remote branch among references: 'refs/remotes/origin/\udcc3master'
+    ]  # Remote branch among references: 'refs/remotes/origin/\udcc3master'

--- a/test/test_nonunicode.py
+++ b/test/test_nonunicode.py
@@ -41,8 +41,7 @@ def bstring(request):
 
 
 def test_nonunicode_branchname(testrepo, bstring):
-    cmd = b"git checkout -b " + bstring
-    subprocess.check_output(cmd.split(b" "), cwd=testrepo.workdir)
+    testrepo.branches.local.create(bstring.decode("utf8", errors="surrogateescape"),commit=testrepo.head.target)
     newrepo = pygit2.clone_repository(
         testrepo.workdir,
         os.path.join(os.path.dirname(testrepo.workdir), "test_nonunicode_repo"),

--- a/test/test_nonunicode.py
+++ b/test/test_nonunicode.py
@@ -35,7 +35,7 @@ bstring = b'\xc3master'
 def test_nonunicode_branchname(testrepo):
     folderpath = 'temp_repo_nonutf'
     if os.path.exists(folderpath):
-        shutil.rmdir(folderpath)
+        shutil.rmtree(folderpath)
     newrepo = pygit2.clone_repository(
         path=folderpath, 
         url='https://github.com/pygit2/test_branch_notutf.git'


### PR DESCRIPTION
Hi,

I am cloning and analyzing a big bunch of repositories, and therefore stumble on rare edge cases.
In this repo: https://github.com/LSSTDESC/DeblenderVAE
One of the refs turned out to be non-unicode (a branch name, '0xc3master' ), and that causes even clone to fail.

```
python3 -c "import pygit2; pygit2.clone_repository(path='temp_repo',url='https://github.com/LSSTDESC/DeblenderVAE')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "pygit2/__init__.py", line 217, in clone_repository
    payload.check_error(err)
  File "pygit2/callbacks.py", line 97, in check_error
    raise self._stored_exception
  File "pygit2/callbacks.py", line 424, in wrapper
    return f(*args)
           ^^^^^^^^
  File "pygit2/callbacks.py", line 565, in _update_tips_cb
    s = maybe_string(refname)
        ^^^^^^^^^^^^^^^^^^^^^
  File "pygit2/utils.py", line 37, in maybe_string
    return ffi.string(ptr).decode('utf8')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 20: invalid continuation byte
```
I tracked the function being wrapped: `<function _update_tips_cb at 0x75b8ebb17420>`

I found this, about refs names not being necessarily unicode:
https://stackoverflow.com/questions/69174955/what-character-encoding-is-used-in-git-symbolic-refs-especially-on-windows

No error if in .utils, I catch the error like this:
```
def maybe_string(ptr):
    if not ptr:
        return None

    try:
        return ffi.string(ptr).decode("utf8")
    except BaseException as e:
        return ffi.string(ptr).decode("latin1")
```

But of course there are other encodings than utf8 and latin1. What could be a generic solution? Does the output of `maybe_string` need to be a text string and not byte string?

If not, I suggest:
```
def maybe_string(ptr):
    if not ptr:
        return None

    try:
        return ffi.string(ptr).decode("utf8")
    except UnicodeDecodeError:
        return ffi.string(ptr)
```
which also clones without error. But it creates a case where the output is only in rare cases a byte string...