### PR TITLE
workflows/tests: update macos job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,9 +78,9 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.13'
 
     - name: macOS
       run: |
-        export OPENSSL_PREFIX=`brew --prefix openssl@1.1`
+        export OPENSSL_PREFIX=`brew --prefix openssl@3`
         LIBSSH2_VERSION=1.11.1 LIBGIT2_VERSION=1.9.0 /bin/sh build.sh test


### PR DESCRIPTION
- [openssl@1.1 is disabled on the homebrew side](https://github.com/Homebrew/homebrew-core/blob/master/Formula/o/openssl%401.1.rb#L28-L29), bump to use openssl@3
- also update macos job to use py3.13

cc @jdavid 