### PR TITLE
Build and release PyPy wheels to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools", "wheel"]
 
 [tool.cibuildwheel]
-skip = "pp3* *musllinux_aarch64 *musllinux_ppc64le"
+skip = "*musllinux_aarch64 *musllinux_ppc64le"
 
 archs = ["auto"]
 build-frontend = "default"


### PR DESCRIPTION
Associated with #1334. I noticed that while PyPy is officially supported no wheels for it are published to PyPI, setting up an env to build a wheel oneself is doable but unneeded as cibuildwheel handles this gracefully.

Link to successful Wheel build action: https://github.com/Spitfire1900/pygit2/actions/runs/12599295302/attempts/1