### PR TITLE
Pypy wheel macos - build on macOS 10.15

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - pypy-wheel-macos
     tags:
     - 'v*'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
           platforms: all
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==2.22.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
         - name: linux
           os: ubuntu-24.04
         - name: macos
-          os: macos-13
+          os: macos-15
 
     steps:
       - uses: actions/checkout@v4

--- a/build.sh
+++ b/build.sh
@@ -85,19 +85,6 @@ else
     cd ci
 fi
 
-# Install zlib
-# XXX Build libgit2 with USE_BUNDLED_ZLIB instead?
-if [ -n "$ZLIB_VERSION" ]; then
-    FILENAME=zlib-$ZLIB_VERSION
-    wget https://www.zlib.net/$FILENAME.tar.gz -N
-    tar xf $FILENAME.tar.gz
-    cd $FILENAME
-    ./configure --prefix=$PREFIX
-    make
-    make install
-    cd ..
-fi
-
 # Install openssl
 if [ -n "$OPENSSL_VERSION" ]; then
     FILENAME=openssl-$OPENSSL_VERSION
@@ -189,6 +176,7 @@ if [ -n "$LIBGIT2_VERSION" ]; then
                 -DOPENSSL_SSL_LIBRARY="../openssl-universal/$LIBSSL" \
                 -DOPENSSL_INCLUDE_DIR="../openssl-x86/include" \
                 -DCMAKE_INSTALL_PREFIX=$PREFIX \
+                -DUSE_BUNDLED_ZLIB=ON \
                 -DUSE_SSH=$USE_SSH
     else
         export CFLAGS=-I$PREFIX/include
@@ -197,6 +185,7 @@ if [ -n "$LIBGIT2_VERSION" ]; then
                 -DBUILD_TESTS=OFF \
                 -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
                 -DCMAKE_INSTALL_PREFIX=$PREFIX \
+                -DUSE_BUNDLED_ZLIB=ON \
                 -DUSE_SSH=$USE_SSH
     fi
     cmake --build . --target install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ LIBSSH2_VERSION = "1.11.1"
 OPENSSL_VERSION = "3.2.3"
 LIBGIT2 = "/Users/runner/work/pygit2/pygit2/ci"
 CFLAGS = "-I/usr/local/include"
-LDFLAGS = "-L/usr/local/lib"
-LDFLAGS_UNIVERSAL2 = "-lz" 
+LDFLAGS = "-L/usr/local/lib -lz"
 
 [tool.ruff]
 target-version = "py310"  # oldest supported Python version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ select = "*-musllinux*"
 repair-wheel-command = "LD_LIBRARY_PATH=/project/ci/lib auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
-archs = ["universal2"]
+archs = ["x86_64", "arm64"]
 environment = {LIBGIT2_VERSION="1.9.0", LIBSSH2_VERSION="1.11.1", OPENSSL_VERSION="3.2.3", LIBGIT2="/Users/runner/work/pygit2/pygit2/ci"}
 repair-wheel-command = "DYLD_LIBRARY_PATH=/Users/runner/work/pygit2/pygit2/ci/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,15 +21,8 @@ repair-wheel-command = "LD_LIBRARY_PATH=/project/ci/lib auditwheel repair -w {de
 
 [tool.cibuildwheel.macos]
 archs = ["universal2"]
+environment = {LIBGIT2_VERSION="1.9.0", LIBSSH2_VERSION="1.11.1", OPENSSL_VERSION="3.2.3", LIBGIT2="/Users/runner/work/pygit2/pygit2/ci"}
 repair-wheel-command = "DYLD_LIBRARY_PATH=/Users/runner/work/pygit2/pygit2/ci/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
-
-[tool.cibuildwheel.macos.environment]
-LIBGIT2_VERSION = "1.9.0"
-LIBSSH2_VERSION = "1.11.1"
-OPENSSL_VERSION = "3.2.3"
-LIBGIT2 = "/Users/runner/work/pygit2/pygit2/ci"
-CFLAGS = "-I/usr/local/include"
-LDFLAGS = "-L/usr/local/lib -lz"
 
 [tool.ruff]
 target-version = "py310"  # oldest supported Python version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ select = "*-musllinux*"
 repair-wheel-command = "LD_LIBRARY_PATH=/project/ci/lib auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
+archs = ["universal2"]
 environment = {LIBGIT2_VERSION="1.9.0", LIBSSH2_VERSION="1.11.1", OPENSSL_VERSION="3.2.3", LIBGIT2="/Users/runner/work/pygit2/pygit2/ci"}
 repair-wheel-command = "DYLD_LIBRARY_PATH=/Users/runner/work/pygit2/pygit2/ci/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,16 @@ repair-wheel-command = "LD_LIBRARY_PATH=/project/ci/lib auditwheel repair -w {de
 
 [tool.cibuildwheel.macos]
 archs = ["universal2"]
-environment = {LIBGIT2_VERSION="1.9.0", LIBSSH2_VERSION="1.11.1", OPENSSL_VERSION="3.2.3", LIBGIT2="/Users/runner/work/pygit2/pygit2/ci"}
 repair-wheel-command = "DYLD_LIBRARY_PATH=/Users/runner/work/pygit2/pygit2/ci/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.macos.environment]
+LIBGIT2_VERSION = "1.9.0"
+LIBSSH2_VERSION = "1.11.1"
+OPENSSL_VERSION = "3.2.3"
+LIBGIT2 = "/Users/runner/work/pygit2/pygit2/ci"
+CFLAGS = "-I/usr/local/include"
+LDFLAGS = "-L/usr/local/lib"
+LDFLAGS_UNIVERSAL2 = "-lz" 
 
 [tool.ruff]
 target-version = "py310"  # oldest supported Python version


### PR DESCRIPTION
Per cibuildwheel's documentation PyPy 3.9+ support is only available on macOS 10.15.

I don't know if this breaks compatibility with runtimes on 10.14, 10.15 though :slightly_frowning_face: 