### PR TITLE
Explicitly build PyPy wheels - cibuildwheel 2.21.3 -> 2.22.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
           platforms: all
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==2.22.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = ["setuptools", "wheel"]
 
 [tool.cibuildwheel]
+enable = ["pypy"]
 skip = "*musllinux_aarch64 *musllinux_ppc64le"
 
 archs = ["auto"]


### PR DESCRIPTION
In https://cibuildwheel.pypa.io/en/v2.22.0/options/#enable it's remarked that in cibuildwheel 2.x building PyPy wheels in implicitly enabled, but in cibuildwheel 3.x it must be explicitly enabled. The option to set this only is available beginning in cibuildwheel 2.22.0.

* Upgrade cibuildwheel to 2.22.0
* Explicitly enable PyPy builds in Wheel GitHub action 