### PR TITLE
Fix condition check for current remote name in rename method

### DIFF
--- a/pygit2/remotes.py
+++ b/pygit2/remotes.py
@@ -376,7 +376,7 @@ class RemoteCollection:
         the standard format and thus could not be remapped.
         """
 
-        if not new_name:
+        if not name:
             raise ValueError('Current remote name must be a non-empty string')
 
         if not new_name:

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -58,7 +58,7 @@ def test_read_commit(barerepo):
     assert 'c2792cfa289ae6321ecf2cd5806c2194b0fd070c' == parents[0].id
     assert commit.message_encoding is None
     assert commit.message == (
-        'Second test data commit.\n\n' 'This commit has some additional text.\n'
+        'Second test data commit.\n\nThis commit has some additional text.\n'
     )
     commit_time = 1288481576
     assert commit_time == commit.commit_time

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -318,9 +318,9 @@ def test_merge_mergeheads(mergerepo):
     assert mergerepo.listall_mergeheads() == [pygit2.Oid(hex=branch_head_hex)]
 
     mergerepo.state_cleanup()
-    assert (
-        mergerepo.listall_mergeheads() == []
-    ), 'state_cleanup() should wipe the mergeheads'
+    assert mergerepo.listall_mergeheads() == [], (
+        'state_cleanup() should wipe the mergeheads'
+    )
 
 
 def test_merge_message(mergerepo):

--- a/test/test_repository_bare.py
+++ b/test/test_repository_bare.py
@@ -135,7 +135,7 @@ def test_lookup_commit(barerepo):
     assert commit_sha == commit.id
     assert ObjectType.COMMIT == commit.type
     assert commit.message == (
-        'Second test data commit.\n\n' 'This commit has some additional text.\n'
+        'Second test data commit.\n\nThis commit has some additional text.\n'
     )
 
 


### PR DESCRIPTION
Fix incorrect condition in rename() method

Corrects a validation check in the remote renaming function where the first conditional was incorrectly checking new_name instead of name. 