### PR TITLE
Add RemoteCallbacks.push_transfer_progress

### DIFF
--- a/pygit2/decl/callbacks.h
+++ b/pygit2/decl/callbacks.h
@@ -38,6 +38,12 @@ extern "Python" int _transfer_progress_cb(
     const git_indexer_progress *stats,
     void *payload);
 
+extern "Python" int _push_transfer_progress_cb(
+    unsigned int objects_pushed,
+    unsigned int total_objects,
+    size_t bytes_pushed,
+    void *payload);
+
 extern "Python" int _update_tips_cb(
 	const char *refname,
 	const git_oid *a,

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -252,8 +252,8 @@ def test_fetch_depth_one(testrepo):
 
 def test_transfer_progress(emptyrepo):
     class MyCallbacks(pygit2.RemoteCallbacks):
-        def transfer_progress(emptyrepo, stats):
-            emptyrepo.tp = stats
+        def transfer_progress(self, stats):
+            self.tp = stats
 
     callbacks = MyCallbacks()
     remote = emptyrepo.remotes[0]
@@ -360,6 +360,59 @@ def test_push_when_up_to_date_succeeds(origin, clone, remote):
     origin_tip = origin[origin.head.target].id
     clone_tip = clone[clone.head.target].id
     assert origin_tip == clone_tip
+
+
+def test_push_transfer_progress(origin, clone, remote):
+    tip = clone[clone.head.target]
+    new_tip_id = clone.create_commit(
+        'refs/heads/master',
+        tip.author,
+        tip.author,
+        'empty commit',
+        tip.tree.id,
+        [tip.id],
+    )
+
+    # NOTE: We're currently not testing bytes_pushed due to a bug in libgit2
+    # 1.9.0: it passes a junk value for bytes_pushed when pushing to a remote
+    # on the local filesystem, as is the case in this unit test. (When pushing
+    # to a remote over the network, the value is correct.)
+    class MyCallbacks(pygit2.RemoteCallbacks):
+        def push_transfer_progress(self, objects_pushed, total_objects, bytes_pushed):
+            self.objects_pushed = objects_pushed
+            self.total_objects = total_objects
+
+    assert origin.branches['master'].target == tip.id
+
+    callbacks = MyCallbacks()
+    remote.push(['refs/heads/master'], callbacks=callbacks)
+    assert callbacks.objects_pushed == 1
+    assert callbacks.total_objects == 1
+    assert origin.branches['master'].target == new_tip_id
+
+
+def test_push_interrupted_from_callbacks(origin, clone, remote):
+    tip = clone[clone.head.target]
+    clone.create_commit(
+        'refs/heads/master',
+        tip.author,
+        tip.author,
+        'empty commit',
+        tip.tree.id,
+        [tip.id],
+    )
+
+    class MyCallbacks(pygit2.RemoteCallbacks):
+        def push_transfer_progress(self, objects_pushed, total_objects, bytes_pushed):
+            raise InterruptedError('retreat! retreat!')
+
+    assert origin.branches['master'].target == tip.id
+
+    callbacks = MyCallbacks()
+    with pytest.raises(InterruptedError, match='retreat! retreat!'):
+        remote.push(['refs/heads/master'], callbacks=callbacks)
+
+    assert origin.branches['master'].target == tip.id
 
 
 def test_push_non_fast_forward_commits_to_remote_fails(origin, clone, remote):

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -99,6 +99,8 @@ def test_checkout_callbacks(testrepo):
             super().__init__()
             self.conflicting_paths = set()
             self.updated_paths = set()
+            self.completed_steps = -1
+            self.total_steps = -1
 
         def checkout_notify_flags(self) -> CheckoutNotify:
             return CheckoutNotify.CONFLICT | CheckoutNotify.UPDATED
@@ -109,12 +111,17 @@ def test_checkout_callbacks(testrepo):
             elif why == CheckoutNotify.UPDATED:
                 self.updated_paths.add(path)
 
+        def checkout_progress(self, path: str, completed_steps: int, total_steps: int):
+            self.completed_steps = completed_steps
+            self.total_steps = total_steps
+
     # checkout i18n with conflicts and default strategy should not be possible
     callbacks = MyCheckoutCallbacks()
     with pytest.raises(pygit2.GitError):
         testrepo.checkout(ref_i18n, callbacks=callbacks)
     # make sure the callbacks caught that
     assert {'bye.txt'} == callbacks.conflicting_paths
+    assert -1 == callbacks.completed_steps  # shouldn't have done anything
 
     # checkout i18n with GIT_CHECKOUT_FORCE
     head = testrepo.head
@@ -125,6 +132,8 @@ def test_checkout_callbacks(testrepo):
     # make sure the callbacks caught the files affected by the checkout
     assert set() == callbacks.conflicting_paths
     assert {'bye.txt', 'new'} == callbacks.updated_paths
+    assert callbacks.completed_steps > 0
+    assert callbacks.completed_steps == callbacks.total_steps
 
 
 def test_checkout_aborted_from_callbacks(testrepo):


### PR DESCRIPTION
The existing callback `RemoteCallbacks.transfer_progress` is only called during fetches, not pushes.
This PR exposes libgit2's `push_transfer_progress` callback, allowing users to:
- Report progress during a push;
- Abort a push by raising an exception in the callback.

Note: I had to rewrite test_push_options to use a real RemoteCallbacks object instead of a mock object (the mock wasn't complete enough to work with my additions to git_push_options)