### PR TITLE
CI: Run Linux/aarch64 tests on a real ARM runner without virtualization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
     - '**.rst'
 
 jobs:
-  linux-x86_64:
+  linux:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -18,6 +18,8 @@ jobs:
           python-version: '3.13'
         - os: ubuntu-24.04
           python-version: 'pypy3.10'
+        - os: ubuntu-24.04-arm
+          python-version: '3.13'
 
     steps:
     - name: Checkout pygit2
@@ -32,23 +34,6 @@ jobs:
       run: |
         sudo apt install tinyproxy
         LIBSSH2_VERSION=1.11.1 LIBGIT2_VERSION=1.9.0 /bin/sh build.sh test
-
-  linux-arm64:
-    runs-on: ubuntu-24.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Build & test
-      uses: uraimo/run-on-arch-action@v2
-      with:
-        arch: aarch64
-        distro: ubuntu22.04
-        install: |
-          apt-get update -q -y
-          apt-get install -q -y cmake libssl-dev python3-dev python3-venv wget
-        run: |
-          LIBSSH2_VERSION=1.11.1 LIBGIT2_VERSION=1.9.0 /bin/sh build.sh test
 
   linux-s390x:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
GitHub Actions has recently made it possible to use [Linux/aarch64 runners](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) in public repos. The tests now complete much faster than with `run-on-arch-action`.