### PR TITLE
Enable multi-threaded pack file creation

### DIFF
--- a/pygit2/remotes.py
+++ b/pygit2/remotes.py
@@ -237,7 +237,7 @@ class Remote:
         check_error(err)
         return strarray_to_strings(specs)
 
-    def push(self, specs, callbacks=None, proxy=None, push_options=None):
+    def push(self, specs, callbacks=None, proxy=None, push_options=None, threads=1):
         """
         Push the given refspec to the remote. Raises ``GitError`` on protocol
         error or unpack failure.
@@ -263,9 +263,19 @@ class Remote:
         push_options : [str]
             Push options to send to the server, which passes them to the
             pre-receive as well as the post-receive hook.
+
+        threads : int
+            If the transport being used to push to the remote requires the
+            creation of a pack file, this controls the number of worker threads
+            used by the packbuilder when creating that pack file to be sent to
+            the remote.
+
+            If set to 0, the packbuilder will auto-detect the number of threads
+            to create. The default value is 1.
         """
         with git_push_options(callbacks) as payload:
             opts = payload.push_options
+            opts.pb_parallelism = threads
             self.__set_proxy(opts.proxy_opts, proxy)
             with StrArray(specs) as refspecs, StrArray(push_options) as pushopts:
                 pushopts.assign_to(opts.remote_push_options)

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -466,3 +466,19 @@ def test_push_options(origin, clone, remote):
     remote_push_options = callbacks.push_options.remote_push_options
     assert remote_push_options.count == 2
     # strings pointed to by remote_push_options.strings[] are already freed
+
+
+def test_push_threads(origin, clone, remote):
+    from pygit2 import RemoteCallbacks
+
+    callbacks = RemoteCallbacks()
+    remote.push(['refs/heads/master'], callbacks)
+    assert callbacks.push_options.pb_parallelism == 1
+
+    callbacks = RemoteCallbacks()
+    remote.push(['refs/heads/master'], callbacks, threads=0)
+    assert callbacks.push_options.pb_parallelism == 0
+
+    callbacks = RemoteCallbacks()
+    remote.push(['refs/heads/master'], callbacks, threads=1)
+    assert callbacks.push_options.pb_parallelism == 1


### PR DESCRIPTION
libgit2 supports creating pack files using multiple threads, which can significantly speed up a push operation.  Enable Remote.push() to take advantage of that capability by adding a relevant keyword argument whose value gets passed to git_remote_push().

The documentation for the new argument was ~~stolen from~~ inspired by [upstream docs](https://github.com/libgit2/libgit2/blob/b042e574064859c01cb902a3f4f418a3706eb78d/include/git2/remote.h#L863-L871).