### PR TITLE
Add proxy option to clone_repository

### DIFF
--- a/docs/repository.rst
+++ b/docs/repository.rst
@@ -29,6 +29,7 @@ Functions
      >>> repo_path = '/path/to/create/repository'
      >>> repo = clone_repository(repo_url, repo_path) # Clones a non-bare repository
      >>> repo = clone_repository(repo_url, repo_path, bare=True) # Clones a bare repository
+     >>> repo = clone_repository(repo_url, repo_path, proxy=True) # Enable automatic proxy detection
 
 
 .. autofunction:: pygit2.discover_repository

--- a/pygit2/__init__.py
+++ b/pygit2/__init__.py
@@ -32,6 +32,7 @@ import typing
 
 # Low level API
 from ._pygit2 import *
+from ._pygit2 import _cache_enums
 
 # High level API
 from . import enums

--- a/pygit2/callbacks.py
+++ b/pygit2/callbacks.py
@@ -371,6 +371,29 @@ def git_fetch_options(payload, opts=None):
 
 
 @contextmanager
+def git_proxy_options(
+    payload: object,
+    opts: object | None = None,
+    proxy: None | bool | str = None,
+):
+    if opts is None:
+        opts = ffi.new('git_proxy_options *')
+        C.git_proxy_options_init(opts, C.GIT_PROXY_OPTIONS_VERSION)
+    if proxy is None:
+        opts.type = C.GIT_PROXY_NONE
+    elif proxy is True:
+        opts.type = C.GIT_PROXY_AUTO
+    elif type(proxy) is str:
+        opts.type = C.GIT_PROXY_SPECIFIED
+        # Keep url in memory, otherwise memory is freed and bad things happen
+        payload.__proxy_url = ffi.new('char[]', to_bytes(proxy))
+        opts.url = payload.__proxy_url
+    else:
+        raise TypeError('Proxy must be None, True, or a string')
+    yield opts
+
+
+@contextmanager
 def git_push_options(payload, opts=None):
     if payload is None:
         payload = RemoteCallbacks()

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -736,6 +736,18 @@ def test_clone_with_checkout_branch(barerepo, tmp_path):
     assert repo.lookup_reference('HEAD').target == 'refs/heads/test'
 
 
+@utils.requires_proxy
+@utils.requires_network
+def test_clone_with_proxy(tmp_path):
+    url = 'https://github.com/libgit2/TestGitRepository'
+    repo = clone_repository(
+        url,
+        tmp_path / 'testrepo-orig.git',
+        proxy=True,
+    )
+    assert not repo.is_empty
+
+
 # FIXME The tests below are commented because they are broken:
 #
 # - test_clone_push_url: Passes, but does nothing useful.


### PR DESCRIPTION
Fixes: #1328

```python
from pygit2 import clone_repository


url = "https://github.com/libgit2/TestGitRepository"
dest = "TestGitRepository"
main_branch = "master"

repo = clone_repository(url, dest, proxy=True)
```