### PR TITLE
Update tests.yml - bump run-on-arch to v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Build & test
-      uses: uraimo/run-on-arch-action@v2
+      uses: uraimo/run-on-arch-action@v3
       with:
         arch: s390x
         distro: ubuntu22.04


### PR DESCRIPTION
Will fix segfault occurring in this workflow
From runs-on-arch 
Note: New major release addressing sporadic segmentation faults

The release 3.0.0 addresses sporadic segmentation faults noticed with recent kernel releases, please update your action to this new major release (e.g. @v3) if you start noticing random or systematic CI failures.

Currently project not blocking on this failure due to  https://github.com/libgit2/pygit2/issues/812

But I think this is fixed and should be enabled again