### PR TITLE
ci: change triggers to prevent dual runs on prs

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -4,7 +4,11 @@ name: Codespell
 
 on:
   pull_request:
+    branches:
+    - master
   push:
+    branches:
+    - master
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,11 @@ name: Lints
 
 on:
   pull_request:
+    branches:
+    - master
   push:
+    branches:
+    - master
     paths-ignore:
     - '**.rst'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,11 @@ name: Tests
 
 on:
   pull_request:
+    branches:
+    - master
   push:
+    branches:
+    - master
     paths-ignore:
     - '**.rst'
 


### PR DESCRIPTION
* runs on pushes to master or prs to master
* will prevent action from running for the push in pr and pull request into master