### PR TITLE
stub - fix issues with literal types

### DIFF
--- a/pygit2/_pygit2.pyi
+++ b/pygit2/_pygit2.pyi
@@ -20,10 +20,10 @@ from .enums import (
     SortMode,
 )
 
-GIT_OBJ_BLOB: Literal[3]
-GIT_OBJ_COMMIT: Literal[1]
-GIT_OBJ_TAG: Literal[4]
-GIT_OBJ_TREE: Literal[2]
+GIT_OBJ_BLOB = Literal[3]
+GIT_OBJ_COMMIT = Literal[1]
+GIT_OBJ_TAG = Literal[4]
+GIT_OBJ_TREE = Literal[2]
 GIT_OID_HEXSZ: int
 GIT_OID_HEX_ZERO: str
 GIT_OID_MINPREFIXLEN: int


### PR DESCRIPTION
See example snippet - because of the issue with literal types `commit.type` type is detected as 'Unknown'. 
![image](https://github.com/user-attachments/assets/22e47282-50c8-491f-8e7e-c4d0c1c0eb1e)

```python
import pygit2
repo = pygit2.Repository(r"L:\test")
for commit in repo.walk(repo.head.target, pygit2.GIT_SORT_TIME):
    print(commit.type) # type detected by type checker is 'Unknown'.
    print(commit.message)
    break
```

After this fix the type becomes `Literal[1, 2, 4, 3]`.
![image](https://github.com/user-attachments/assets/3eb26a08-9687-4261-9ca3-fa009fca245a)

It also resolves the issue with a couple overloads that use those types. E.g. running pyright on `_pygit2.pyi` before this fix:
```
pyright L:\Projects\Github\pygit2\pygit2\_pygit2.pyi
l:\Projects\Github\pygit2\pygit2\_pygit2.pyi
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:45:20 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:45:20 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:45:46 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:45:46 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:45:70 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:45:70 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:45:93 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:45:93 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:48:9 - error: Overload 1 for "peel" overlaps overload 2 and returns an incompatible type (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:48:9 - error: Overload 1 for "peel" overlaps overload 3 and returns an incompatible type (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:48:9 - error: Overload 1 for "peel" overlaps overload 4 and returns an incompatible type (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:48:42 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:48:42 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:50:9 - error: Overload 2 for "peel" will never be used because its parameters overlap overload 1 (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:50:42 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:50:42 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:52:9 - error: Overload 3 for "peel" will never be used because its parameters overlap overload 1 (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:52:42 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:52:42 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:54:9 - error: Overload 4 for "peel" will never be used because its parameters overlap overload 1 (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:54:42 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:54:42 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:56:9 - error: Overload 5 for "peel" will never be used because its parameters overlap overload 1 (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:78:9 - error: Overload 1 for "peel" overlaps overload 2 and returns an incompatible type (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:78:9 - error: Overload 1 for "peel" overlaps overload 3 and returns an incompatible type (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:78:9 - error: Overload 1 for "peel" overlaps overload 4 and returns an incompatible type (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:78:35 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:78:35 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:80:9 - error: Overload 2 for "peel" will never be used because its parameters overlap overload 1 (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:80:35 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:80:35 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:82:9 - error: Overload 3 for "peel" will never be used because its parameters overlap overload 1 (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:82:35 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:82:35 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:84:9 - error: Overload 4 for "peel" will never be used because its parameters overlap overload 1 (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:84:35 - error: Variable not allowed in type expression (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:84:35 - error: Type arguments for "Literal" must be None, a literal value (int, bool, str, or bytes), or an enum value (reportInvalidTypeForm)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:86:9 - error: Overload 5 for "peel" will never be used because its parameters overlap overload 1 (reportOverlappingOverload)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:127:9 - error: Method "rename" overrides class "Reference" in an incompatible manner
    Parameter 2 name mismatch: base parameter is named "new_name", override parameter is named "name" (reportIncompatibleMethodOverride)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:500:5 - error: "name" overrides symbol of same name in class "Object"
    Variable is mutable so its type is invariant
      Override type "str" is not the same as base type "str | None" (reportIncompatibleVariableOverride)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:502:5 - error: "raw_name" overrides symbol of same name in class "Object"
    Variable is mutable so its type is invariant
      Override type "bytes" is not the same as base type "bytes | None" (reportIncompatibleVariableOverride)
41 errors, 0 warnings, 0 informations
```

After the fix:
```python
pyright L:\Projects\Github\pygit2\pygit2\_pygit2.pyi
l:\Projects\Github\pygit2\pygit2\_pygit2.pyi
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:127:9 - error: Method "rename" overrides class "Reference" in an incompatible manner
    Parameter 2 name mismatch: base parameter is named "new_name", override parameter is named "name" (reportIncompatibleMethodOverride)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:500:5 - error: "name" overrides symbol of same name in class "Object"
    Variable is mutable so its type is invariant
      Override type "str" is not the same as base type "str | None" (reportIncompatibleVariableOverride)
  l:\Projects\Github\pygit2\pygit2\_pygit2.pyi:502:5 - error: "raw_name" overrides symbol of same name in class "Object"
    Variable is mutable so its type is invariant
      Override type "bytes" is not the same as base type "bytes | None" (reportIncompatibleVariableOverride)
3 errors, 0 warnings, 0 informations
```