### PR TITLE
[RFC] Index: add wrapper for `git_index_remove_directory`

### DIFF
--- a/docs/index_file.rst
+++ b/docs/index_file.rst
@@ -18,9 +18,10 @@ Iterate over all entries of the index::
 
 Index write::
 
-    >>> index.add('path/to/file')          # git add
-    >>> index.remove('path/to/file')       # git rm
-    >>> index.write()                      # don't forget to save the changes
+    >>> index.add('path/to/file')                    # git add
+    >>> index.remove('path/to/file')                 # git rm
+    >>> index.remove_directory('path/to/directory/') # git rm -r
+    >>> index.write()                                # don't forget to save the changes
 
 Custom entries::
    >>> entry = pygit2.IndexEntry('README.md', blob_id, blob_filemode)

--- a/pygit2/decl/index.h
+++ b/pygit2/decl/index.h
@@ -34,6 +34,7 @@ int git_index_find(size_t *at_pos, git_index *index, const char *path);
 int git_index_add_bypath(git_index *index, const char *path);
 int git_index_add(git_index *index, const git_index_entry *source_entry);
 int git_index_remove(git_index *index, const char *path, int stage);
+int git_index_remove_directory(git_index *index, const char *path, int stage);
 int git_index_read_tree(git_index *index, const git_tree *tree);
 int git_index_clear(git_index *index);
 int git_index_write_tree(git_oid *out, git_index *index);

--- a/pygit2/index.py
+++ b/pygit2/index.py
@@ -177,6 +177,11 @@ class Index:
         err = C.git_index_remove(self._index, to_bytes(path), level)
         check_error(err, io=True)
 
+    def remove_directory(self, path, level=0):
+        """Remove a directory from the Index."""
+        err = C.git_index_remove_directory(self._index, to_bytes(path), level)
+        check_error(err, io=True)
+
     def remove_all(self, pathspecs):
         """Remove all index entries matching pathspecs."""
         with StrArray(pathspecs) as arr:

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -192,6 +192,13 @@ def test_remove(testrepo):
     assert 'hello.txt' not in index
 
 
+def test_remove_directory(dirtyrepo):
+    index = dirtyrepo.index
+    assert 'subdir/current_file' in index
+    index.remove_directory('subdir')
+    assert 'subdir/current_file' not in index
+
+
 def test_remove_all(testrepo):
     index = testrepo.index
     assert 'hello.txt' in index
@@ -206,6 +213,13 @@ def test_remove_aspath(testrepo):
     assert 'hello.txt' in index
     index.remove(Path('hello.txt'))
     assert 'hello.txt' not in index
+
+
+def test_remove_directory_aspath(dirtyrepo):
+    index = dirtyrepo.index
+    assert 'subdir/current_file' in index
+    index.remove_directory(Path('subdir'))
+    assert 'subdir/current_file' not in index
 
 
 def test_remove_all_aspath(testrepo):


### PR DESCRIPTION
Hello pygit2 maintainers,

While using pygit2 I needed a way to remove a directory in one fell swoop. I noticed that such a function exists in libgit2, `git_index_remove_directory`, but that it was not exported to the python binding yet.

This PR exports it. Let me know what you think.
