### PR TITLE
Push negotiation callback

### DIFF
--- a/pygit2/decl/callbacks.h
+++ b/pygit2/decl/callbacks.h
@@ -16,6 +16,11 @@ extern "Python" int _push_update_reference_cb(
     const char *status,
     void *data);
 
+extern "Python" int _push_negotiation_cb(
+    const git_push_update **updates,
+    size_t len,
+    void *data);
+
 extern "Python" int _remote_create_cb(
 	git_remote **out,
 	git_repository *repo,

--- a/pygit2/remotes.py
+++ b/pygit2/remotes.py
@@ -224,7 +224,10 @@ class Remote:
         return TransferProgress(C.git_remote_stats(self._remote))
 
     def ls_remotes(
-        self, callbacks: RemoteCallbacks | None = None, proxy: str | None | bool = None
+        self,
+        callbacks: RemoteCallbacks | None = None,
+        proxy: str | None | bool = None,
+        connect: bool = True,
     ) -> list[LsRemotesDict]:
         """
         Return a list of dicts that maps to `git_remote_head` from a
@@ -235,9 +238,14 @@ class Remote:
         callbacks : Passed to connect()
 
         proxy : Passed to connect()
+
+        connect : Whether to connect to the remote first. You can pass False
+        if the remote has already connected. The list remains available after
+        disconnecting as long as a new connection is not initiated.
         """
 
-        self.connect(callbacks=callbacks, proxy=proxy)
+        if connect:
+            self.connect(callbacks=callbacks, proxy=proxy)
 
         refs = ffi.new('git_remote_head ***')
         refs_len = ffi.new('size_t *')

--- a/pygit2/remotes.py
+++ b/pygit2/remotes.py
@@ -58,6 +58,34 @@ class LsRemotesDict(TypedDict):
     oid: Oid
 
 
+class PushUpdate:
+    """
+    Represents an update which will be performed on the remote during push.
+    """
+
+    src_refname: str
+    """The source name of the reference"""
+
+    dst_refname: str
+    """The name of the reference to update on the server"""
+
+    src: Oid
+    """The current target of the reference"""
+
+    dst: Oid
+    """The new target for the reference"""
+
+    def __init__(self, c_struct: Any) -> None:
+        src_refname = maybe_string(c_struct.src_refname)
+        dst_refname = maybe_string(c_struct.dst_refname)
+        assert src_refname is not None, 'libgit2 returned null src_refname'
+        assert dst_refname is not None, 'libgit2 returned null dst_refname'
+        self.src_refname = src_refname
+        self.dst_refname = dst_refname
+        self.src = Oid(raw=bytes(ffi.buffer(c_struct.src.id)[:]))
+        self.dst = Oid(raw=bytes(ffi.buffer(c_struct.dst.id)[:]))
+
+
 class TransferProgress:
     """Progress downloading and indexing data during a fetch."""
 

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -204,6 +204,22 @@ def test_ls_remotes(testrepo: Repository) -> None:
     assert next(iter(r for r in refs if r['name'] == 'refs/tags/v0.28.2'))
 
 
+@utils.requires_network
+def test_ls_remotes_without_implicit_connect(testrepo: Repository) -> None:
+    assert 1 == len(testrepo.remotes)
+    remote = testrepo.remotes[0]
+
+    with pytest.raises(pygit2.GitError, match='this remote has never connected'):
+        remote.ls_remotes(connect=False)
+
+    remote.connect()
+    refs = remote.ls_remotes(connect=False)
+    assert refs
+
+    # Check that a known ref is returned.
+    assert next(iter(r for r in refs if r['name'] == 'refs/tags/v0.28.2'))
+
+
 def test_remote_collection(testrepo: Repository) -> None:
     remote = testrepo.remotes['origin']
     assert REMOTE_NAME == remote.name


### PR DESCRIPTION
This PR does two things:
- Expose libgit2's `git_remote_callbacks.push_negotiation` to Python code (via `RemoteCallbacks`).
- Add a new `connect` argument to `Remote.ls_remotes()`. This lets you tell `ls_remote` to skip its default connection step, which is harmful if calling `ls_remotes` from `RemoteCallbacks.push_negotiation`.

Some background info:

My use case is to implement an equivalent of `git push --force-with-lease`. To achieve this, I need `push_negotiation` which is called right before the transfer actually begins.

My negotiation callback uses `Remote.ls_remotes` to determine whether the repo has stale information about the remote branch to force-push to, in which case the push should be rejected.

However, `Remote.ls_remotes` currently forces a new connection to the remote. This invalidates the existing connection that was set up by the push - causing the push fail. So, this PR also lets you tell `ls_remotes` to not override the current connection (by passing `connect=False`).
