### PR TITLE
Improve usability of `Remote.ls_remotes`'s result

### DIFF
--- a/pygit2/remotes.py
+++ b/pygit2/remotes.py
@@ -62,7 +62,7 @@ class RemoteHead:
 
     oid: Oid
 
-    loid: Oid | None
+    loid: Oid
 
     name: str | None
 
@@ -74,12 +74,8 @@ class RemoteHead:
 
     def __init__(self, c_struct: Any) -> None:
         self.local = bool(c_struct.local)
-        if self.local:
-            self.loid = Oid(raw=bytes(ffi.buffer(c_struct.loid.id)[:]))
-        else:
-            self.loid = None
-
         self.oid = Oid(raw=bytes(ffi.buffer(c_struct.oid.id)[:]))
+        self.loid = Oid(raw=bytes(ffi.buffer(c_struct.loid.id)[:]))
         self.name = maybe_string(c_struct.name)
         self.symref_target = maybe_string(c_struct.symref_target)
 

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -201,7 +201,21 @@ def test_ls_remotes(testrepo: Repository) -> None:
     assert refs
 
     # Check that a known ref is returned.
-    assert next(iter(r for r in refs if r['name'] == 'refs/tags/v0.28.2'))
+    assert next(iter(r for r in refs if r.name == 'refs/tags/v0.28.2'))
+
+
+@utils.requires_network
+def test_ls_remotes_backwards_compatibility(testrepo: Repository) -> None:
+    assert 1 == len(testrepo.remotes)
+    remote = testrepo.remotes[0]
+    refs = remote.ls_remotes()
+    ref = refs[0]
+
+    for field in ('name', 'oid', 'loid', 'local', 'symref_target'):
+        new_value = getattr(ref, field)
+        with pytest.warns(DeprecationWarning, match='no longer returns a dict'):
+            old_value = ref[field]
+        assert new_value == old_value
 
 
 @utils.requires_network
@@ -217,7 +231,7 @@ def test_ls_remotes_without_implicit_connect(testrepo: Repository) -> None:
     assert refs
 
     # Check that a known ref is returned.
-    assert next(iter(r for r in refs if r['name'] == 'refs/tags/v0.28.2'))
+    assert next(iter(r for r in refs if r.name == 'refs/tags/v0.28.2'))
 
 
 def test_remote_collection(testrepo: Repository) -> None:


### PR DESCRIPTION
`Remote.ls_remotes` used to return a dict with str keys, which is inconsistent with how pygit2 generally returns structured results. This PR introduces `RemoteHead`, a class with fields.

Backwards compatibility with the old-style dict was kept via `RemoteHead.__getitem__` which emits a `DeprecationWarning`.

Also, when the `local` flag is off, `RemoteHead.loid` now forwards oid zero (`0000000`) as returned by libgit2 instead of making it `None`.

--- 

Tangent: I think `ls_remotes` is a bit of a confusing name. Perhaps something like `list_heads` or `advertised_heads` would be more intuitive, but this could be for another PR. What do you think?