### PR TITLE
Deprecate Remote.ls_remotes in favor of Remote.list_heads

### DIFF
--- a/pygit2/remotes.py
+++ b/pygit2/remotes.py
@@ -298,7 +298,7 @@ class Remote:
             {
                 'local': h.local,
                 'oid': h.oid,
-                'loid': h.loid,
+                'loid': h.loid if h.local else None,
                 'name': h.name,
                 'symref_target': h.symref_target,
             }

--- a/test/test_remote.py
+++ b/test/test_remote.py
@@ -220,9 +220,13 @@ def test_ls_remotes_deprecated(testrepo: Repository) -> None:
     for new, old in zip(new_refs, old_refs, strict=True):
         assert new.name == old['name']
         assert new.oid == old['oid']
-        assert new.loid == old['loid']
         assert new.local == old['local']
         assert new.symref_target == old['symref_target']
+        if new.local:
+            assert new.loid == old['loid']
+        else:
+            assert new.loid == pygit2.Oid(b'')
+            assert old['loid'] is None
 
 
 @utils.requires_network


### PR DESCRIPTION
This PR implements changes discussed in https://github.com/libgit2/pygit2/pull/1397#issuecomment-3182758075