### PR TITLE
feat: enable future-compatible deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /build/
 /ci/
 /dist/
+/wheelhouse/
 /docs/_build/
 /MANIFEST
 /venv*

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@
 # Import setuptools before distutils to avoid user warning
 import os
 import sys
+import sysconfig
 from distutils import log  # type: ignore[attr-defined]
 from distutils.command.build import build
 from distutils.command.sdist import sdist
@@ -152,6 +153,16 @@ setup(
     cmdclass=cmdclass,
     cffi_modules=['pygit2/_run.py:ffi'],
     ext_modules=ext_modules,
+    options={
+        'bdist_wheel': {
+            # for ABI3 (future-compatible) wheels.
+            # NOTE: free-threaded CPython builds do not support the limited API yet.
+            # See https://github.com/python/cpython/issues/111506
+            'py_limited_api': False
+            if sysconfig.get_config_var('Py_GIL_DISABLED')
+            else 'cp310'  # should correspond to `python_requires` below
+        }
+    },
     # Requirements
     python_requires='>=3.10',
     setup_requires=['cffi>=2.0'],


### PR DESCRIPTION
Free-threaded builds are exempt from abi3 builds.

- ref #1418
- resolves #1046 

## Why?
1. Reduces CI build time by only building 1 binary wheel for each architecture (and Linux-specific libc variants). This way, wheels are not built separately for each version of python, just the minimum supported python version.
2. Allows consumers of pygit2 to test their software with pre-releases of Python (excluding free-threaded variants).

> [!NOTE]
> Until free-threaded variants supports [CPytyhon's Limited API](https://docs.python.org/3/c-api/stable.html#limited-c-api) (AKA "abi3" wheels), each new release of python still mandates new release assets of pygit2 for free-threaded python versions (which can be retro-actively uploaded to PyPI if desired).
