### PR TITLE
feat: build windows distributions with cibuildwheel in GitHub CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,9 +21,19 @@ jobs:
           os: ubuntu-24.04-arm
         - name: macos
           os: macos-13
+        - name: windows-x64
+          os: windows-latest
+        - name: windows-x86
+          os: windows-latest
+        - name: windows-arm64
+          # https://github.com/actions/partner-runner-images#available-images
+          os: windows-11-arm
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          # avoid leaking credentials in uploaded artifacts
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:
@@ -33,6 +43,8 @@ jobs:
         run: python -m pip install cibuildwheel~=3.1.1
 
       - name: Build wheels
+        env:
+          CIBW_ARCHS_WINDOWS: ${{ matrix.name == 'windows-x86' && 'auto32' || 'native' }}
         run: python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v4
@@ -46,6 +58,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          # avoid leaking credentials in uploaded artifacts
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:
@@ -68,6 +83,43 @@ jobs:
         with:
           name: wheels-linux-ppc
           path: ./wheelhouse/*.whl
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # avoid leaking credentials in uploaded artifacts
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Build sdist
+        run: pipx run build --sdist --outdir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist/*
+
+  twine-check:
+    name: Twine check
+    # It is good to do this check on non-tagged commits.
+    # Note, pypa/gh-action-pypi-publish (see job below) does this automatically.
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    needs: [build_wheels, build_wheels_ppc, sdist]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          path: dist
+          pattern: wheels-*
+          merge-multiple: true
+      - name: check distribution files
+        run: pipx run twine check dist/*
 
   pypi:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/README.md
+++ b/README.md
@@ -3,18 +3,22 @@
 Bindings to the libgit2 shared library, implements Git plumbing.
 Supports Python 3.10 to 3.13 and PyPy3 7.3+
 
-[![image](https://github.com/libgit2/pygit2/actions/workflows/tests.yml/badge.svg)](https://github.com/libgit2/pygit2/actions/workflows/tests.yml)
+[![test-ci-badge][test-ci-badge]][test-ci-link]
+[![deploy-ci-badge][deploy-ci-badge]][deploy-ci-link]
 
-[![image](https://ci.appveyor.com/api/projects/status/edmwc0dctk5nacx0/branch/master?svg=true)](https://ci.appveyor.com/project/jdavid/pygit2/branch/master)
+[deploy-ci-badge]: https://github.com/libgit2/pygit2/actions/workflows/wheels.yml/badge.svg
+[deploy-ci-link]: https://github.com/libgit2/pygit2/actions/workflows/wheels.yml
+[test-ci-badge]: https://github.com/libgit2/pygit2/actions/workflows/tests.yml/badge.svg
+[test-ci-link]: https://github.com/libgit2/pygit2/actions/workflows/tests.yml
 
 ## Links
 
--   Documentation - <https://www.pygit2.org/>
--   Install - <https://www.pygit2.org/install.html>
--   Download - <https://pypi.org/project/pygit2/>
--   Source code and issue tracker - <https://github.com/libgit2/pygit2>
--   Changelog - <https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md>
--   Authors - <https://github.com/libgit2/pygit2/blob/master/AUTHORS.md>
+- Documentation - <https://www.pygit2.org/>
+- Install - <https://www.pygit2.org/install.html>
+- Download - <https://pypi.org/project/pygit2/>
+- Source code and issue tracker - <https://github.com/libgit2/pygit2>
+- Changelog - <https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md>
+- Authors - <https://github.com/libgit2/pygit2/blob/master/AUTHORS.md>
 
 ## Sponsors
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,21 @@
+if (!(Test-Path -Path "build")) {
+    # in case the pygit2 package build/ workspace has not been created by cibuildwheel yet
+    mkdir build
+}
+if (Test-Path -Path "$env:LIBGIT2_SRC") {
+    Set-Location "$env:LIBGIT2_SRC"
+    # for local runs, reuse build/libgit_src if it exists
+    if (Test-Path -Path build) {
+        # purge previous build env (likely for a different arch type)
+        Remove-Item -Recurse -Force build
+    }
+    # ensure we are checked out to the right version
+    git fetch --depth=1 --tags
+    git checkout "v$env:LIBGIT2_VERSION"
+} else {
+    # from a fresh run (like in CI)
+    git clone --depth=1 -b "v$env:LIBGIT2_VERSION" https://github.com/libgit2/libgit2.git $env:LIBGIT2_SRC
+    Set-Location "$env:LIBGIT2_SRC"
+}
+cmake -B build -S . -DBUILD_TESTS=OFF
+cmake --build build/ --config=Release --target install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,35 @@ archs = ["universal2"]
 environment = {LIBGIT2_VERSION="1.9.1", LIBSSH2_VERSION="1.11.1", OPENSSL_VERSION="3.3.3", LIBGIT2="/Users/runner/work/pygit2/pygit2/ci"}
 repair-wheel-command = "DYLD_LIBRARY_PATH=/Users/runner/work/pygit2/pygit2/ci/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
 
+[tool.cibuildwheel.windows]
+environment.LIBGIT2_SRC = "build/libgit2_src"
+environment.LIBGIT2_VERSION = "1.9.1"
+before-all = "powershell -File build.ps1"
+
+[[tool.cibuildwheel.overrides]]
+select="*-win_amd64"
+inherit.environment="append"
+environment.CMAKE_GENERATOR = "Visual Studio 17 2022"
+environment.CMAKE_GENERATOR_PLATFORM = "x64"
+environment.CMAKE_INSTALL_PREFIX = "C:/libgit2_install_x86_64"
+environment.LIBGIT2 = "C:/libgit2_install_x86_64"
+
+[[tool.cibuildwheel.overrides]]
+select="*-win32"
+inherit.environment="append"
+environment.CMAKE_GENERATOR = "Visual Studio 17 2022"
+environment.CMAKE_GENERATOR_PLATFORM = "Win32"
+environment.CMAKE_INSTALL_PREFIX = "C:/libgit2_install_x86"
+environment.LIBGIT2 = "C:/libgit2_install_x86"
+
+[[tool.cibuildwheel.overrides]]
+select="*-win_arm64"
+inherit.environment="append"
+environment.CMAKE_GENERATOR = "Visual Studio 17 2022"
+environment.CMAKE_GENERATOR_PLATFORM = "ARM64"
+environment.CMAKE_INSTALL_PREFIX = "C:/libgit2_install_arm64"
+environment.LIBGIT2 = "C:/libgit2_install_arm64"
+
 [tool.ruff]
 extend-exclude = [ ".cache", ".coverage", "build", "site-packages", "venv*"]
 target-version = "py310"  # oldest supported Python version


### PR DESCRIPTION
- resolves #1341 
- resolves #1171 
- resolves #1222 

This should avoid maintaining appveyor workflow (and free up appveyor account limitations 😉).

This also introduces windows aarch64 distributions 🎉

Lastly, I updated other spots in the GH actions workflow:

- upgrade `actions/checkout` to v5 (only breaking changes are internal like upgrade node version used for building their dist)
- turn off credential persistence in `actions/checkout` action (only useful if the workflow uses `git push` or similar)
- upgrade `actions/download-artifact` to v5 (only breaking changes are internal because this already uses `merge-multiple: true`)
- add job to check built distributions for non-tagged commits to default branch. This is meant to highlight any problems with dists' metadata before tagging a release.
- add job to build sdist (for sake of completeness)
- replace badge in README

### Further Ideas
Ideas that are related to this.

These can be added to this PR with ease:
- [x] remove the appveyor workflow (requires @jdavid to make necessary changes in appveyor first)
- [ ] use trusted publishing on PyPI (requires @jdavid to [enable trusted publishing on PyPI](https://pypi.org/manage/project/pygit2/settings/publishing/) first)
- [ ] automatically create a [GitHub Release](https://github.com/libgit2/pygit2/releases) for each (new) tag pushed (using [gh-cli](https://cli.github.com/manual/gh_release_create))

These should be done in a separate PR:
- [ ] run [tests with cibuildwheel](https://cibuildwheel.pypa.io/en/stable/options/#testing)
- [ ] satify #994 