### PR TITLE
build(dev): enable dependabot for automatic updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(CI):"
+    groups:
+      actions:
+        patterns:
+          - "*"
+  # - package-ecosystem: pip
+  #   directory: .github/
+  #   schedule:
+  #     interval: "monthly"
+  #   groups:
+  #     pip:
+  #       patterns:
+  #         - "*"


### PR DESCRIPTION
Only for GitHub Actions in CI workflows.

Managing Python dependencies in this project seems to be manual driven. It can be enabled (un-commented) later, if desired. I just didn't want to cause PR spam.

To reduce perceivable spam, I set the "auto-check for updates" schedule to monthly. Note, dependabot will automatically close or update any outdated PRs that it opened.