### PR TITLE
feat: revert future-compatible deployments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@
 # Import setuptools before distutils to avoid user warning
 import os
 import sys
-import sysconfig
 from distutils import log  # type: ignore[attr-defined]
 from distutils.command.build import build
 from distutils.command.sdist import sdist
@@ -153,16 +152,6 @@ setup(
     cmdclass=cmdclass,
     cffi_modules=['pygit2/_run.py:ffi'],
     ext_modules=ext_modules,
-    options={
-        'bdist_wheel': {
-            # for ABI3 (future-compatible) wheels.
-            # NOTE: free-threaded CPython builds do not support the limited API yet.
-            # See https://github.com/python/cpython/issues/111506
-            'py_limited_api': False
-            if sysconfig.get_config_var('Py_GIL_DISABLED')
-            else 'cp310'  # should correspond to `python_requires` below
-        }
-    },
     # Requirements
     python_requires='>=3.10',
     setup_requires=['cffi>=2.0'],


### PR DESCRIPTION
This reverts commit 5f655b7e6aa317494e5bb6d5aa823561bf1609d1.

There's much more needed in pygit2 C sources (`src/*`) to comply with CPython's Limited API. Unfortunately, this feature is not entirely dependent on `cffi` (which only handles libgit2 compilation).

This can be re-addressed at a later time, when more time is available.
ref https://github.com/libgit2/pygit2/issues/1418#issuecomment-3393952952
reopens #1046