### PR TITLE
fix: disable GIL for free-threaded builds

### DIFF
--- a/src/pygit2.c
+++ b/src/pygit2.c
@@ -465,6 +465,10 @@ PyInit__pygit2(void)
     if (m == NULL)
         return NULL;
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     /* libgit2 version info */
     ADD_CONSTANT_INT(m, LIBGIT2_VER_MAJOR)
     ADD_CONSTANT_INT(m, LIBGIT2_VER_MINOR)


### PR DESCRIPTION
This properly disables the GIL for free threaded python builds. Thanks to advice from @ngoldbaum

This patch simply gets pygit2 ready for use with Python 3.14t without warnings/errors.
All tests pass with Python v3.14t and `python -c "import pygit2"` completes without warnings.

I haven't done a through code review for spots (in `src/*`) where thread safety might be a concern.
My impression is that `_pygit2` (when appropriate) invokes `_libgit2` (which is compiled with `cffi`). So, I'm guessing most thread safety concerns are delegated to `cffi`.
