### PR TITLE
ci: do not build unused openssl components

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -134,7 +134,7 @@ if [ -n "$OPENSSL_VERSION" ]; then
         # Linux
         tar xf $FILENAME.tar.gz
         cd $FILENAME
-        ./Configure shared --prefix=$PREFIX --libdir=$PREFIX/lib
+        ./Configure shared no-apps no-docs no-tests --prefix=$PREFIX --libdir=$PREFIX/lib
         make
         make install
         OPENSSL_PREFIX=$(pwd)


### PR DESCRIPTION
We build OpenSSL only for the library, so save some time and computing power by disabling unused apps, docs, and tests components for the CI OpenSSL build.