### PR TITLE
fix: set build-backend in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 enable = ["pypy"]


### PR DESCRIPTION
## Summary

Remove `wheel` from build requirements and add proper `build-backend = "setuptools.build_meta"` per PEP 517.

## Problem

Issue #1452 points out that the current `pyproject.toml` is missing the `build-backend` setting. Without it, pip uses legacy build behavior which causes issues.

## Fix

- Remove `wheel` from `[build-system].requires` (it's no longer needed as it's now part of setuptools)
- Add `build-backend = "setuptools.build_meta"` to enable proper PEP 517 build isolation

## Testing

This is a configuration-only change. The fix follows PEP 517 and setuptools documentation.

Closes #1452