### PR TITLE
Fixed RuntimeError when iterating git config entries with valueless keys.

### DIFF
--- a/pygit2/config.py
+++ b/pygit2/config.py
@@ -365,8 +365,8 @@ class ConfigEntry:
         return ffi.string(self._entry.name)
 
     @cached_property
-    def raw_value(self) -> bytes:
-        return ffi.string(self.c_value)
+    def raw_value(self) -> bytes | None:
+        return ffi.string(self.c_value) if self.c_value != ffi.NULL else None
 
     @cached_property
     def level(self) -> int:
@@ -379,6 +379,6 @@ class ConfigEntry:
         return self.raw_name.decode('utf-8')
 
     @property
-    def value(self) -> str:
+    def value(self) -> str | None:
         """The entry's value as a string."""
-        return self.raw_value.decode('utf-8')
+        return self.raw_value.decode('utf-8') if self.raw_value is not None else None

--- a/pygit2/config.py
+++ b/pygit2/config.py
@@ -73,7 +73,7 @@ class ConfigIterator:
 
 
 class ConfigMultivarIterator(ConfigIterator):
-    def __next__(self) -> str:  # type: ignore[override]
+    def __next__(self) -> str | None:  # type: ignore[override]
         entry = self._next_entry()
         return entry.value
 
@@ -137,7 +137,7 @@ class Config:
 
         return True
 
-    def __getitem__(self, key: str | bytes) -> str:
+    def __getitem__(self, key: str | bytes) -> str | None:
         """
         When using the mapping interface, the value is returned as a string. In
         order to apply the git-config parsing rules, you can use

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -185,6 +185,35 @@ def test_iterator(config: Config) -> None:
     assert lst['core.bare']
 
 
+def test_valueless_key_iteration() -> None:
+    # A valueless key (no `= value`) has a NULL value pointer in libgit2.
+    # Iterating over such entries must not raise a RuntimeError.
+    with open(CONFIG_FILENAME, 'w') as new_file:
+        new_file.write('[section]\n\tvaluelesskey\n\tnormalkey = somevalue\n')
+
+    config = Config()
+    config.add_file(CONFIG_FILENAME, 6)
+
+    entries = {entry.name: entry for entry in config}
+    assert 'section.valuelesskey' in entries
+    assert 'section.normalkey' in entries
+
+
+def test_valueless_key_value() -> None:
+    # A valueless key must expose value=None and raw_value=None.
+    with open(CONFIG_FILENAME, 'w') as new_file:
+        new_file.write('[section]\n\tvaluelesskey\n\tnormalkey = somevalue\n')
+
+    config = Config()
+    config.add_file(CONFIG_FILENAME, 6)
+
+    entries = {entry.name: entry for entry in config}
+    assert entries['section.valuelesskey'].raw_value is None
+    assert entries['section.valuelesskey'].value is None
+    assert entries['section.normalkey'].raw_value == b'somevalue'
+    assert entries['section.normalkey'].value == 'somevalue'
+
+
 def test_parsing() -> None:
     assert Config.parse_bool('on')
     assert Config.parse_bool('1')


### PR DESCRIPTION
Fixes #1456

## Description

Iterating over `repo.config` raises a `RuntimeError` if the configuration (including any `include.path`-sourced files) contains a valueless key — a boolean key written without `=`, e.g.:

```ini
[some-section "identifier"]
    booleanflag
```

## Traceback

```
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File ".../pygit2/config.py", line 65, in __next__
    return self._next_entry()
           ~~~~~~~~~~~~~~~~^^
  File ".../pygit2/config.py", line 72, in _next_entry
    return ConfigEntry._from_c(centry[0], self)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File ".../pygit2/config.py", line 349, in _from_c
    entry.raw_value = entry.raw_value
                      ^^^^^^^^^^^^^^^
  File ".../functools.py", line 1126, in __get__
    val = self.func(instance)
  File ".../pygit2/config.py", line 369, in raw_value
    return ffi.string(self.c_value)
           ~~~~~~~~~~^^^^^^^^^^^^^^
RuntimeError: cannot use string() on <cdata 'char *' NULL>
```

## Root Cause

libgit2 deliberately sets `git_config_entry.value = NULL` for valueless keys. The entry struct is zero-initialized via `git__calloc`, and the value field is only populated when a value is actually present (`src/libgit2/config_file.c`):

```c
entry = git__calloc(1, sizeof(git_config_list_entry));
/* ... */
if (var_value) {
    entry->base.entry.value = git__strdup(var_value);
    GIT_ERROR_CHECK_ALLOC(entry->base.entry.value);
}
```

libgit2's own code handles the NULL case explicitly (same file):

```c
else if ((!existing->base.entry.value && !value) ||
         (existing->base.entry.value && value &&
          !strcmp(existing->base.entry.value, value)))
```

So NULL in `git_config_entry.value` is intentional and documented behavior.

pygit2's `_from_c` eagerly caches `raw_value` during iteration (the workaround introduced for #970):

```python
if iterator is not None:
    entry.raw_name = entry.raw_name
    entry.raw_value = entry.raw_value   # ← crashes when c_value is NULL
    entry.level = entry.level
```

And `raw_value` has no NULL guard:

```python
@cached_property
def raw_value(self) -> bytes:
    return ffi.string(self.c_value)   # RuntimeError if c_value is NULL
```

## Expected Behavior

Valueless keys should be represented with `value = None` (or `raw_value = None`) rather than raising an exception.

## Reproduction

```shell-session
$ mkdir /tmp/testrepo && cd /tmp/testrepo && git init
Initialized empty Git repository in /tmp/testrepo/.git/

$ printf '[mysection]\n\tbooleanflag\n' >> .git/config

$ cat .git/config
[core]
        repositoryformatversion = 0
        filemode = true
        bare = false
        logallrefupdates = true
[mysection]
        booleanflag

$ uv run --with pygit2==1.19.1 python - <<EOF
import pygit2
repo = pygit2.Repository('/tmp/testrepo')
for entry in repo.config:
    print(entry.name, entry.value)
EOF
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File ".../pygit2/config.py", line 65, in __next__
    return self._next_entry()
           ~~~~~~~~~~~~~~~~^^
  File ".../pygit2/config.py", line 72, in _next_entry
    return ConfigEntry._from_c(centry[0], self)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File ".../pygit2/config.py", line 349, in _from_c
    entry.raw_value = entry.raw_value
                      ^^^^^^^^^^^^^^^
  File ".../functools.py", line 1126, in __get__
    val = self.func(instance)
  File ".../pygit2/config.py", line 369, in raw_value
    return ffi.string(self.c_value)
           ~~~~~~~~~~^^^^^^^^^^^^^^
RuntimeError: cannot use string() on <cdata 'char *' NULL>
```
