### PR TITLE
docs(repository.diff): fix docstring keyword 'flag' -> 'flags'

### DIFF
--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -614,7 +614,7 @@ class BaseRepository(_Repository):
             If 'b' is None, by default the working directory is compared to 'a'.
             If 'cached' is set to True, the index/staging area is used for comparing.
 
-        flag
+        flags
             A combination of enums.DiffOption constants.
 
         context_lines


### PR DESCRIPTION
## Summary

\`BaseRepository.diff\` signature takes \`flags: DiffOption = DiffOption.NORMAL\`, but its docstring's *Keyword arguments* block described the parameter as \`flag\` (singular). The overload stubs in \`pygit2/_pygit2.pyi\` also use \`flags\`. Fixed the docstring to match.

Closes #1138

## Testing

Docstring-only change.