### PR TITLE
Fix for TypeError in Repository.ident (plus typo fixes)

### DIFF
--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -1278,7 +1278,7 @@ class BaseRepository(_Repository):
         Example::
 
             >>> repo = pygit2.Repository('.')
-            >>> repo.stash(repo.default_signature(), 'WIP: stashing')
+            >>> repo.stash(repo.default_signature, 'WIP: stashing')
         """
 
         opts = ffi.new('git_stash_save_options *')
@@ -1347,7 +1347,7 @@ class BaseRepository(_Repository):
         Example::
 
             >>> repo = pygit2.Repository('.')
-            >>> repo.stash(repo.default_signature(), 'WIP: stashing')
+            >>> repo.stash(repo.default_signature, 'WIP: stashing')
             >>> repo.stash_apply(strategy=CheckoutStrategy.ALLOW_CONFLICTS)
         """
         with git_stash_apply_options(

--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -81,7 +81,7 @@ from .references import References
 from .remotes import RemoteCollection
 from .submodules import SubmoduleCollection
 from .transaction import ReferenceTransaction
-from .utils import StrArray, to_bytes
+from .utils import StrArray, maybe_string, to_bytes
 
 if TYPE_CHECKING:
     from pygit2._libgit2.ffi import (
@@ -1585,7 +1585,7 @@ class BaseRepository(_Repository):
         err = C.git_repository_ident(cname, cemail, self._repo)
         check_error(err)
 
-        return (ffi.string(cname).decode('utf-8'), ffi.string(cemail).decode('utf-8'))
+        return (maybe_string(cname[0]), maybe_string(cemail[0]))
 
     def set_ident(self, name: str, email: str) -> None:
         """Set the identity to be used for reference operations.

--- a/pygit2/repository.py
+++ b/pygit2/repository.py
@@ -1578,7 +1578,7 @@ class BaseRepository(_Repository):
     # Identity for reference operations
     #
     @property
-    def ident(self):
+    def ident(self) -> tuple[Optional[str], Optional[str]]:
         cname = ffi.new('char **')
         cemail = ffi.new('char **')
 
@@ -1587,7 +1587,7 @@ class BaseRepository(_Repository):
 
         return (maybe_string(cname[0]), maybe_string(cemail[0]))
 
-    def set_ident(self, name: str, email: str) -> None:
+    def set_ident(self, name: Optional[str], email: Optional[str]) -> None:
         """Set the identity to be used for reference operations.
 
         Updates to some references also append data to their

--- a/test/test_repository.py
+++ b/test/test_repository.py
@@ -641,6 +641,19 @@ def test_default_signature(testrepo: Repository) -> None:
     assert 'rjh@example.com' == sig.email
 
 
+def test_ident_get_set(testrepo: Repository) -> None:
+    # By default, reflog identity should be unset.
+    assert testrepo.ident == (None, None)
+
+    cname = 'C O Mitter'
+    cemail = 'committer@example.com'
+    testrepo.set_ident(cname, cemail)
+    assert testrepo.ident == (cname, cemail)
+
+    testrepo.set_ident(None, None)
+    assert testrepo.ident == (None, None)
+
+
 def test_new_repo(tmp_path: Path) -> None:
     repo = init_repository(tmp_path, False)
 


### PR DESCRIPTION
As of pygit2 1.19.2 (on my Python 3.14.4, Linux 6.19.14-artix1-1 x86_64), the `Repository.ident` property triggers TypeError:

```
Python 3.14.4 (main, Apr 15 2026, 07:34:47) [GCC 15.2.1 20260209] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pygit2; pygit2.__version__
'1.19.2'
>>> repo = pygit2.init_repository('/tmp/foo')
>>> repo.ident
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    repo.ident
  File "/usr/lib/python3.14/site-packages/pygit2/repository.py", line 1588, in ident
    return (ffi.string(cname).decode('utf-8'), ffi.string(cemail).decode('utf-8'))
            ~~~~~~~~~~^^^^^^^
TypeError: string(): unexpected cdata 'char * *' argument
```

`cname` and `cemail` are `char **` variables, which are pointers to C-strings, not the C-strings themselves. So they should be passed as `cname[0]` and `cemail[0]`.

In addition, `cname[0]` and `cemail[0]` appear to be NULL by default... so clearly we have to handle that separately.

Either way, I wrote up a patch (plus a typo I happened to catch when trying to skim the docs for other mentions of identity). Not sure if this is the right way to contribute here... any feedback\* is appreciated! :)

\*Specifically, (1) I'm not certain if `utils.maybe_string()` is the right tool for this, since the original UTF-8 decode mode was `"strict"`, but is now `"surrogateescape"` (but I don't want to introduce a separate function just for this, so...) Also (2) I used PEP 585 syntax for the tuple annotation, while keeping Optional since it has already been imported (pygit2 itself seems to use a mix of pre- and post-PEP 585 syntax, and ruff doesn't appear to complain either way, so I picked the ones I liked the best without importing more names...)