### PR TITLE
Return None from submodules.get() for a nested plain repository

### DIFF
--- a/pygit2/submodules.py
+++ b/pygit2/submodules.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Optional
 from ._pygit2 import Oid
 from .callbacks import RemoteCallbacks, git_fetch_options
 from .enums import SubmoduleIgnore, SubmoduleStatus
-from .errors import check_error
+from .errors import AlreadyExistsError, check_error
 from .ffi import C, ffi
 from .utils import decode_fs_path, decode_string, encode_string
 
@@ -210,7 +210,11 @@ class SubmoduleCollection:
         """
         try:
             return self[name]
-        except KeyError:
+        except (KeyError, AlreadyExistsError):
+            # libgit2 reports GIT_EEXISTS, which check_error turns into
+            # AlreadyExistsError, when a repository exists at the path but was
+            # never registered as a submodule. There is still no submodule by
+            # that name, so report it the same way as a missing one.
             return None
 
     def add(

--- a/test/test_submodule.py
+++ b/test/test_submodule.py
@@ -68,6 +68,25 @@ def test_lookup_missing_submodule(repo: Repository) -> None:
     assert repo.submodules.get('does-not-exist') is None
 
 
+def test_lookup_nested_repo_that_is_not_a_submodule(tmp_path: Path) -> None:
+    """A plain repository inside another is not a submodule.
+
+    libgit2 reports GIT_EEXISTS for this case rather than GIT_ENOTFOUND, which
+    reaches Python as AlreadyExistsError. get() and __contains__ must still
+    describe it as absent, per their documented contracts.
+    """
+    outer = pygit2.init_repository(tmp_path / 'outer')
+    pygit2.init_repository(tmp_path / 'outer' / 'nested')
+
+    assert outer.submodules.get('nested') is None
+    assert 'nested' not in outer.submodules
+
+    # __getitem__ keeps reporting the distinction, so callers that care can
+    # still tell "there is a repository there" from "there is nothing there".
+    with pytest.raises(pygit2.AlreadyExistsError):
+        outer.submodules['nested']
+
+
 def test_listall_submodules(repo: Repository) -> None:
     submodules = repo.listall_submodules()
     assert len(submodules) == 1


### PR DESCRIPTION
Fixes #1405

## The bug, and one symptom the issue does not mention

`SubmoduleCollection.get()` promises:

> Unlike `__getitem__`, this returns None if the submodule is not found.

It only catches `KeyError`. But `git_submodule_lookup` reports **`GIT_EEXISTS`**, not `GIT_ENOTFOUND`, when a repository exists at the path yet was never registered as a submodule — libgit2's message is `submodule 'x' has not been added yet`. `check_error` turns that into `AlreadyExistsError`, which escapes `get()`.

Because `__contains__` is implemented as `self.get(name) is not None`, the same input makes a containment test raise:

```python
outer = pygit2.init_repository(outer)
pygit2.init_repository(outer/nested)

outer.submodules.get(nested)      # ValueError: submodule nested has not been added yet
nested in outer.submodules        # same ValueError
outer.submodules.get(absent)      # None  (correct)
```

Reproduced on 1.20.0 from PyPI and on this branch's parent built against libgit2 1.9.7.

The reporter later wondered whether their confusion about nested repositories was the real issue. It was not the whole of it: whatever one thinks libgit2 *should* report for a nested repository, `get()` and `in` are documented to answer "absent" rather than raise, and today they raise.

## The change

`get()` also catches `AlreadyExistsError`. `__getitem__` is untouched, so callers who need to distinguish "a repository is there but unregistered" from "nothing is there" still can — the new test pins that too.

I considered instead translating `GIT_EEXISTS` to `KeyError` inside `__getitem__`, which would arguably make its own docstring more accurate. I did not, because it changes an exception type users may already catch, and it is your call rather than mine. Happy to switch if you prefer it.

## Verification

- `pytest test/test_submodule.py` — **28 passed**
- Full suite minus network/ssh — **595 passed, 7 skipped, 2 xfailed, 1 xpassed, 1 failed**
- That one failure is **pre-existing**: `test_status_file_unicode_normalization[café.txt]` fails identically with my changes stashed on a clean checkout, which is the usual macOS filesystem normalisation issue
- Mutation check: reverting only `pygit2/submodules.py` fails exactly the new test, `test_lookup_nested_repo_that_is_not_a_submodule`
- `ruff check` and `ruff format --check` clean on both files
- Built locally with `LIBGIT2=$(brew --prefix libgit2) pip install -e .`

Per `CONTRIBUTING.md`, the commit carries `Assisted-by: Claude Code (Claude Opus 5)`. I can explain the change and stand behind it.